### PR TITLE
add custom_ort_backend

### DIFF
--- a/onnxsim/__main__.py
+++ b/onnxsim/__main__.py
@@ -3,6 +3,7 @@ import sys
 
 import onnx     # type: ignore
 import onnxsim
+import numpy as np
 
 
 def main():
@@ -13,18 +14,21 @@ def main():
                         nargs='?', type=int, default=3)
     parser.add_argument('--enable-fuse-bn', help='This option is deprecated. Fusing bn into conv is enabled by default.',
                         action='store_true')
-    parser.add_argument('--skip-fuse-bn', help='Skip fusing batchnorm into conv.',
-                        action='store_true')
+    parser.add_argument('--skip-fuse-bn', help='Skip fusing batchnorm into conv.', action='store_true')
     parser.add_argument('--skip-optimization', help='Skip optimization of ONNX optimizers.',
                         action='store_true')
     parser.add_argument(
-        '--input-shape', help='The manually-set static input shape, useful when the input shape is dynamic. The value should be "input_name:dim0,dim1,...,dimN" or simply "dim0,dim1,...,dimN" when there is only one input, for example, "data:1,3,224,224" or "1,3,224,224". Note: you might want to use some visualization tools like netron to make sure what the input name and dimension ordering (NCHW or NHWC) is.', type=str, nargs='+')
+        '--input-shape', help='The manually-set static input shape, useful when the input shape is dynamic. The value should be "input_name1:dim0,dim1,...,dimN input_name2:dim0,dim1...dimN", for example, "data1:1,3,224,224 data2:1,3,224,224". Note: you might want to use some visualization tools like netron to make sure what the input name and dimension ordering (NCHW or NHWC) is.', type=str, nargs='+')
     parser.add_argument(
         '--skip-optimizer', help='Skip a certain ONNX optimizer', type=str, nargs='+')
     parser.add_argument('--skip-shape-inference',
                         help='Skip shape inference. Shape inference causes segfault on some large models', action='store_true')
     parser.add_argument('--dynamic-input-shape', help='This option enables dynamic input shape support. "Shape" ops will not be eliminated in this case. Note that "--input-shape" is also needed for generating random inputs and checking equality. If "dynamic_input_shape" is False, the input shape in simplified model will be overwritten by the value of "input_shapes" param.', action='store_true')
             
+    parser.add_argument(
+        '--input-data', help='input data, The value should be "input_name1:xxx1.bin  input_name2:xxx2.bin ...", input data should be a binary data file.', type=str, nargs='+')
+    parser.add_argument(
+        '--custom-lib', help="custom lib, if you have custom onnxruntime backend you should use this to register you custom op", type=str)
     args = parser.parse_args()
 
     print("Simplifying...")
@@ -33,21 +37,38 @@ def main():
         raise RuntimeError('Please pass "--input-shape" argument for generating random input and checking equality. Run "python3 -m onnxsim -h" for details.')
     if args.input_shape is not None and not args.dynamic_input_shape:
         print("Note: The input shape of the simplified model will be overwritten by the value of '--input--shape' argument. Pass '--dynamic-input-shape' if it is not what you want. Run 'python3 -m onnxsim -h' for details.")
-    input_shapes = {}
+    input_shapes = dict()
     if args.input_shape is not None:
         for x in args.input_shape:
-            if ':' not in x:
-                input_shapes[None] = list(map(int, x.split(',')))
-            else:
-                pieces = x.split(':')
-                # for the input name like input:0
-                name, shape = ':'.join(
-                    pieces[:-1]), list(map(int, pieces[-1].split(',')))
-                input_shapes[name] = shape
+            pieces = x.split(':')
+            # for the input name like input:0
+            name, shape = ':'.join(
+                pieces[:-1]), list(map(int, pieces[-1].split(',')))
+            input_shapes.update({name: shape})
+
+    input_datas = dict()
+    if args.input_data is not None:
+        for x in args.input_data:
+            pieces = x.split(':')
+            name, data = pieces[0], pieces[-1]
+            input_datas.update({name: data})
+
+    input_tensors = dict()
+    for name in input_shapes.keys():
+        input_data = np.fromfile(input_datas[name], dtype=np.float32)
+        input_data = input_data.reshape(input_shapes[name])
+        input_tensors.update({name: input_data})
+
     model_opt, check_ok = onnxsim.simplify(
-        args.input_model, check_n=args.check_n, perform_optimization=not args.skip_optimization, 
-        skip_fuse_bn=args.skip_fuse_bn, input_shapes=input_shapes, 
-        skipped_optimizers=args.skip_optimizer, skip_shape_inference=args.skip_shape_inference, 
+        args.input_model,
+        check_n=args.check_n,
+        perform_optimization=not args.skip_optimization,
+        skip_fuse_bn=args.skip_fuse_bn,
+        input_shapes=input_shapes,
+        input_tensors=input_tensors,
+        custom_lib=args.custom_lib,
+        skipped_optimizers=args.skip_optimizer,
+        skip_shape_inference=args.skip_shape_inference,
         dynamic_input_shape=args.dynamic_input_shape)
 
     onnx.save(model_opt, args.output_model)

--- a/onnxsim/__main__.py
+++ b/onnxsim/__main__.py
@@ -14,8 +14,8 @@ def main():
                         nargs='?', type=int, default=3)
     parser.add_argument('--enable-fuse-bn', help='This option is deprecated. Fusing bn into conv is enabled by default.',
                         action='store_true')
-    parser.add_argument('--skip-fuse-bn', help='Skip fusing batchnorm into conv.',
-                        action='store_true')
+    parser.add_argument(
+        '--skip-fuse-bn', help='Skip fusing batchnorm into conv.', action='store_true')
     parser.add_argument('--skip-optimization', help='Skip optimization of ONNX optimizers.',
                         action='store_true')
     parser.add_argument(
@@ -35,7 +35,8 @@ def main():
     print("Simplifying...")
 
     if args.dynamic_input_shape and args.input_shape is None:
-        raise RuntimeError('Please pass "--input-shape" argument for generating random input and checking equality. Run "python3 -m onnxsim -h" for details.')
+        raise RuntimeError(
+            'Please pass "--input-shape" argument for generating random input and checking equality. Run "python3 -m onnxsim -h" for details.')
     if args.input_shape is not None and not args.dynamic_input_shape:
         print("Note: The input shape of the simplified model will be overwritten by the value of '--input--shape' argument. Pass '--dynamic-input-shape' if it is not what you want. Run 'python3 -m onnxsim -h' for details.")
     input_shapes = dict()

--- a/onnxsim/__main__.py
+++ b/onnxsim/__main__.py
@@ -14,7 +14,8 @@ def main():
                         nargs='?', type=int, default=3)
     parser.add_argument('--enable-fuse-bn', help='This option is deprecated. Fusing bn into conv is enabled by default.',
                         action='store_true')
-    parser.add_argument('--skip-fuse-bn', help='Skip fusing batchnorm into conv.', action='store_true')
+    parser.add_argument('--skip-fuse-bn', help='Skip fusing batchnorm into conv.',
+                        action='store_true')
     parser.add_argument('--skip-optimization', help='Skip optimization of ONNX optimizers.',
                         action='store_true')
     parser.add_argument(

--- a/onnxsim/__main__.py
+++ b/onnxsim/__main__.py
@@ -14,8 +14,8 @@ def main():
                         nargs='?', type=int, default=3)
     parser.add_argument('--enable-fuse-bn', help='This option is deprecated. Fusing bn into conv is enabled by default.',
                         action='store_true')
-    parser.add_argument(
-        '--skip-fuse-bn', help='Skip fusing batchnorm into conv.', action='store_true')
+    parser.add_argument('--skip-fuse-bn', help='Skip fusing batchnorm into conv.',
+                        action='store_true')
     parser.add_argument('--skip-optimization', help='Skip optimization of ONNX optimizers.',
                         action='store_true')
     parser.add_argument(

--- a/onnxsim/__main__.py
+++ b/onnxsim/__main__.py
@@ -67,7 +67,7 @@ def main():
         perform_optimization=not args.skip_optimization,
         skip_fuse_bn=args.skip_fuse_bn,
         input_shapes=input_shapes,
-        input_tensors=input_tensors,
+        input_data=input_tensors,
         custom_lib=args.custom_lib,
         skipped_optimizers=args.skip_optimizer,
         skip_shape_inference=args.skip_shape_inference,

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -160,7 +160,6 @@ def forward(model, input_data: Dict[str, np.ndarray] = None,
     if input_shapes is None:
         input_shapes = {}
     sess_options = rt.SessionOptions()
-    print("custom_lib: ",custom_lib)
     if os.path.exists(custom_lib):
         sess_options.register_custom_ops_library(custom_lib)
     sess_options.graph_optimization_level = rt.GraphOptimizationLevel(0)

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -94,7 +94,9 @@ def generate_specific_rand_input(model, input_shapes: TensorShapes):
         if not np.all(np.array(shape) > 0):
             raise RuntimeError(
                 'The shape of input "{}" has dynamic size "{}", '
-                'please determine the input size manually by --input-shape xxx'.format(key, shape))
+                'please determine the input size manually by '
+                '"--dynamic-input-shape --input-shape xxx" or "--input-shape xxx". '
+                'Run "python3 -m onnxsim -h" for details'.format(key, shape))
 
     inputs = {ipt: np.array(np.random.rand(*input_shapes[ipt]),
                             dtype=get_np_type_from_elem_type(get_elem_type(model, ipt))) for ipt in

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -14,7 +14,7 @@ import onnxoptimizer  # type: ignore
 import numpy as np  # type: ignore
 import os.path
 
-Tensors = Dict[Optional[str], np.array]
+Tensors = Dict[str, np.array]
 TensorShape = List[int]
 TensorShapes = Dict[str, TensorShape]
 TensorShapesWithOptionalKey = Dict[Optional[str], TensorShape]
@@ -156,7 +156,7 @@ def get_constant_nodes(m: onnx.ModelProto, dynamic_input_shape: bool = False) ->
 
 
 def forward(model,
-            input_data: Dict[Tensors] = None,
+            input_data: Optional[Tensors] = None,
             input_shapes: Optional[TensorShapes] = None,
             custom_lib: Optional[str] = None) -> Dict[str, np.ndarray]:
     if input_shapes is None:
@@ -192,7 +192,7 @@ def forward(model,
 def forward_for_node_outputs(model: onnx.ModelProto,
                              nodes: List[onnx.NodeProto],
                              input_shapes: Optional[TensorShapes] = None,
-                             input_data: Dict[Tensors] = None,
+                             input_data: Optional[Tensors] = None,
                              custom_lib: Optional[str] = None) -> Dict[str, np.ndarray]:
     if input_shapes is None:
         input_shapes = {}
@@ -374,10 +374,10 @@ def simplify(model: Union[str, onnx.ModelProto],
              perform_optimization: bool = True,
              skip_fuse_bn: bool = False,
              input_shapes: Optional[TensorShapesWithOptionalKey] = None,
-             skipped_optimizers: Optional[Sequence[str]] = None,
-             skip_shape_inference: bool = False,
              input_data: Optional[Tensors] = None,
              custom_lib: Optional[str] = None,
+             skipped_optimizers: Optional[Sequence[str]] = None,
+             skip_shape_inference: bool = False,
              dynamic_input_shape: bool = False) \
         -> Tuple[onnx.ModelProto, bool]:
     """

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         'onnx',
         'onnxoptimizer >= 0.2.0',
-        'onnxruntime >= 1.6.0',
+        'onnxruntime-noopenmp >= 1.6.0',
         'protobuf >= 3.7.0'
     ],
     classifiers=[


### PR DESCRIPTION
1. add onnxruntime custom op lib
2. add custom input data, because in some detection model such as: retinanet/faster-rcnn ..., if we use random input there will no anchor output, then we will encounter this error:
    2021-01-26 14:55:45.747470604 [E:onnxruntime:, sequential_executor.cc:333 Execute] Non-zero status code returned while running ReduceMax node. Name:'ReduceMax_1004' Status Message: /onnxruntime_src/onnxruntime/core/providers/cpu/reduction/reduction_ops.cc:487 void onnxruntime::CommonReduce(onnxruntime::OpKernelContext*, std::vector<long int>, int64_t, onnxruntime::ResultsNoTransposePrepareForReduce&, bool) [with T = float; AGG = onnxruntime::ReduceAggregatorMax<float, float>; int64_t = long int] keepdims_ was false. Can't reduce on dim with value of 0 if 'keepdims' is false. Invalid output shape would be produced. input_shape:{0,4}
