### PR TITLE
[FixBug] when the input of command line is NOT illegal, onnxsim crash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ else()
   target_link_libraries(onnxsim ${ORT_NAME} onnx_optimizer onnx)
 endif()
 
-add_executable(onnxsim_bin onnxsim/bin/onnxsim_bin.cpp)
+add_executable(onnxsim_bin onnxsim/bin/onnxsim_bin.cpp onnxsim/bin/onnxsim_option.cpp)
 target_link_libraries(onnxsim_bin onnxsim)
 set_target_properties(onnxsim_bin PROPERTIES OUTPUT_NAME onnxsim)
 if (EMSCRIPTEN)

--- a/onnxsim/bin/onnxsim_option.cpp
+++ b/onnxsim/bin/onnxsim_option.cpp
@@ -4,7 +4,7 @@
 void OnnxsimOption::Parse(int argc, char** argv) {
   cxxopts::Options cxx_options("onnxsim", "Simplify your ONNX model");
 
-  // Do NOT format the following lines.
+  // clang-format off
   cxx_options.add_options()
   ("h,help",              "Print help")
   ("i,input-model",       "Input onnx model filename, MUST have this option",   cxxopts::value<std::string>())
@@ -12,6 +12,7 @@ void OnnxsimOption::Parse(int argc, char** argv) {
   ("no-opt",              "No optimization",             cxxopts::value<bool>()->default_value("false"))
   ("no-sim",              "No simplification",           cxxopts::value<bool>()->default_value("false"))
   ;
+  // clang-format on
 
   try {
     options_ = cxx_options.parse(argc, argv);

--- a/onnxsim/bin/onnxsim_option.cpp
+++ b/onnxsim/bin/onnxsim_option.cpp
@@ -7,8 +7,8 @@ void OnnxsimOption::Parse(int argc, char** argv) {
   // clang-format off
   cxx_options.add_options()
   ("h,help",              "Print help")
-  ("i,input-model",       "Input onnx model filename, MUST have this option",   cxxopts::value<std::string>())
-  ("o,output-model",      "Output onnx model filename, MUST have this option",  cxxopts::value<std::string>())
+  ("i,input-model",       "Input onnx model filename. This argument is required.",   cxxopts::value<std::string>())
+  ("o,output-model",      "Output onnx model filename. This argument is required.",  cxxopts::value<std::string>())
   ("no-opt",              "No optimization",             cxxopts::value<bool>()->default_value("false"))
   ("no-sim",              "No simplification",           cxxopts::value<bool>()->default_value("false"))
   ;

--- a/onnxsim/bin/onnxsim_option.cpp
+++ b/onnxsim/bin/onnxsim_option.cpp
@@ -1,0 +1,34 @@
+#include "onnxsim_option.h"
+#include <iostream>
+
+void OnnxsimOption::Parse(int argc, char** argv) {
+  cxxopts::Options cxx_options("onnxsim", "Simplify your ONNX model");
+
+  // Do NOT format the following lines.
+  cxx_options.add_options()
+  ("h,help",              "Print help")
+  ("i,input-model",       "Input onnx model filename, MUST have this option",   cxxopts::value<std::string>())
+  ("o,output-model",      "Output onnx model filename, MUST have this option",  cxxopts::value<std::string>())
+  ("no-opt",              "No optimization",             cxxopts::value<bool>()->default_value("false"))
+  ("no-sim",              "No simplification",           cxxopts::value<bool>()->default_value("false"))
+  ;
+
+  try {
+    options_ = cxx_options.parse(argc, argv);
+  } catch (cxxopts::OptionParseException cxxopts_exception) {
+    std::cout << "[Error] Can not parse your options" << std::endl;
+    std::cout << cxx_options.help() << std::endl;
+    exit(1);
+  }
+
+  if (options_.count("help")) {
+    std::cout << cxx_options.help() << std::endl;
+    exit(0);
+  }
+  if (!options_.count("input-model") || !options_.count("output-model")) {
+    std::cout << cxx_options.help() << std::endl;
+    exit(1);
+  }
+
+  return;
+}

--- a/onnxsim/bin/onnxsim_option.h
+++ b/onnxsim/bin/onnxsim_option.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "cxxopts.hpp"
+
+class OnnxsimOption {
+ public:
+  OnnxsimOption() = default;
+  OnnxsimOption(int argc, char** argv) { Parse(argc, argv); }
+  ~OnnxsimOption() = default;
+
+  void Parse(int argc, char** argv);
+
+  template <typename T>
+  T Get(const std::string& key) const {
+    T value = options_[key].as<T>();
+    return value;
+  }
+
+ private:
+  cxxopts::ParseResult options_;
+};


### PR DESCRIPTION
when command line input is like:
`./onnxsim --no-opt ./input.onnx ./output.onnx`
or without output filename
`./onnxsim ./input.onnx`

the onnxsim will **crash**