### PR TITLE
Fix pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We have published ONNX Simplifier on [convertmodel.com](https://www.convertmodel
 
 
 ```
-pip3 install -U pip && pip3 install onnxsim
+pip3 install -U pip && pip3 install onnx-simplifier
 ```
 
 Then


### PR DESCRIPTION
```pip install onnxsim``` get wrong onnxsim. 
Error message is:
![image](https://user-images.githubusercontent.com/92794867/179346720-f7de3717-bf37-4a02-8174-fa667b706f45.png)
If use ```pip install onnx-simplifier``` will get right version.
![image](https://user-images.githubusercontent.com/92794867/179346833-74a74ed5-97c5-45e8-ad12-1b7a63ca04af.png)
Besides, we should remove onnxsim first, such as:
``` shell
pip uninstall onnx-simplifier
pip uninstall onnxsim # not sure
pip uninstall onnxsim-no-ort #  not sure
```