### PR TITLE
Fix bug when sess.run returns list of empty list

### DIFF
--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -245,6 +245,7 @@ class PyModelExecutor(C.ModelExecutor):
         run_options = rt.RunOptions()
         run_options.log_severity_level = 3
         output_arrs = sess.run(output_names, inputs, run_options=run_options)
+        output_arrs = [x if isinstance(x, np.ndarray) else np.array([]) for x in output_arrs]
         return [
             onnx.numpy_helper.from_array(x).SerializeToString() for x in output_arrs
         ]


### PR DESCRIPTION
I have this error when run onnxsim.

```
Traceback (most recent call last):
  File "F:\github.com\MatchaChoco010\streaming-vc-test\streaming_asr\extract_onnx.py", line 59, in <module>
    enc, check = simplify(enc)
  File "F:\github.com\MatchaChoco010\streaming-vc-test\.venv\lib\site-packages\onnxsim\onnx_simplifier.py", line 186, in simplify
    model_opt_bytes = C.simplify(
  File "F:\github.com\MatchaChoco010\streaming-vc-test\.venv\lib\site-packages\onnxsim\onnx_simplifier.py", line 248, in Run
    return [
  File "F:\github.com\MatchaChoco010\streaming-vc-test\.venv\lib\site-packages\onnxsim\onnx_simplifier.py", line 249, in <listcomp>
    onnx.numpy_helper.from_array(x).SerializeToString() for x in output_arrs
  File "F:\github.com\MatchaChoco010\streaming-vc-test\.venv\lib\site-packages\onnx\numpy_helper.py", line 114, in from_array
    tensor.dims.extend(arr.shape)
AttributeError: 'list' object has no attribute 'shape'
```

This error seems to occur when sess.run returns a list of an empty list instead of a list of numpy arrays.
When sess.run returns a list, I replaced it with an empty numpy array and the error disappeared.