### PR TITLE
fix: Preserve empty initializer inputs

### DIFF
--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -243,6 +243,7 @@ std::vector<onnx::TensorProto> RunOp(onnx::ModelProto& model,
                                      const onnx::NodeProto& op) {
   std::vector<std::string> input_names;
   std::vector<onnx::TensorProto> input_tps;
+  std::set<std::string> initializer_names;
 
   onnx::ModelProto op_model;
   op_model.set_ir_version(model.ir_version());
@@ -260,9 +261,12 @@ std::vector<onnx::TensorProto> RunOp(onnx::ModelProto& model,
     if (input.empty()) {
       continue;
     }
-
+    if (initializer_names.find(input) != initializer_names.end()) {
+      continue;
+    }
     auto in_tp = FindInitializerByName(model, input);
     if (in_tp.dims().size() == 1 && in_tp.dims()[0] == 0) {
+      initializer_names.insert(input);
       *op_model.mutable_graph()->add_initializer() = in_tp;
       continue;
     }


### PR DESCRIPTION
For some Operators, there may be an empty input initializer. During the constant folding phase, it will be treated as a normal input node. This may break the constraints of some Operators, such as Resize.

![Origin ONNX](https://github.com/daquexian/onnx-simplifier/assets/23482405/53ea643b-3050-47d4-b7ef-1d8fa85410de)

The `scales` and `sizes` of the Resize node only allow one to be set, and the original version may generate such a structure,and the onnxruntime cannot use this model.

![onnxsim-old](https://github.com/daquexian/onnx-simplifier/assets/23482405/ca0366a9-0ff3-4b4e-ae20-539eaf1e0321)

```python
In [3]: sess = onnxruntime.InferenceSession('onnxsim_bug_fix/resize_561_old.onnx', providers=['CPUExecutionProvider'])
---------------------------------------------------------------------------
Fail                                      Traceback (most recent call last)
Cell In[3], line 1
----> 1 onnxruntime.InferenceSession('onnxsim_bug_fix/resize_561_old.onnx', providers=['CPUExecutionProvider'])

File ~/Environments/miniconda3/envs/default/lib/python3.11/site-packages/onnxruntime/capi/onnxruntime_inference_collection.py:383, in InferenceSession.__init__(self, path_or_bytes, sess_options, providers, provider_options, **kwargs)
    380 disabled_optimizers = kwargs["disabled_optimizers"] if "disabled_optimizers" in kwargs else None
    382 try:
--> 383     self._create_inference_session(providers, provider_options, disabled_optimizers)
    384 except (ValueError, RuntimeError) as e:
    385     if self._enable_fallback:

File ~/Environments/miniconda3/envs/default/lib/python3.11/site-packages/onnxruntime/capi/onnxruntime_inference_collection.py:424, in InferenceSession._create_inference_session(self, providers, provider_options, disabled_optimizers)
    422 session_options = self._sess_options if self._sess_options else C.get_default_session_options()
    423 if self._model_path:
--> 424     sess = C.InferenceSession(session_options, self._model_path, True, self._read_config_from_model)
    425 else:
    426     sess = C.InferenceSession(session_options, self._model_bytes, False, self._read_config_from_model)

Fail: [ONNXRuntimeError] : 1 : FAIL : Load model from onnxsim_bug_fix/resize_561_old.onnx failed:Node (Resize_561) Op (Resize) [ShapeInferenceError] Either `sizes` or `scales` must be provided, but not both of them

In [4]: 
```


Special judgment on empty initializer can solve this problem.

![onnxsim-new](https://github.com/daquexian/onnx-simplifier/assets/23482405/08b06a34-377e-494e-9ee9-6f4727bbffca)

```python
In [7]: ses = onnxruntime.InferenceSession('onnxsim_bug_fix/resize_561_fix.onnx', providers=['CPUExecutionProvider'])

In [8]: 
```
