### PR TITLE
Adding support for pre-built aarch64

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,13 +10,14 @@ jobs:
       # Only build universal2 package
       # Related issue: https://github.com/pypa/cibuildwheel/issues/1190
       CIBW_ARCHS_MACOS: universal2
+      CIBW_ARCHS_LINUX: "auto aarch64"
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       CIBW_ENVIRONMENT_PASS_LINUX: ONNXSIM_CI
       CIBW_BEFORE_ALL_LINUX: WD=`pwd` && /opt/python/cp38-cp38/bin/python -m pip install --target tmp_cmake cmake && cp tmp_cmake/bin/cmake /usr/local/bin/cmake && rm -rf tmp_cmake && /opt/python/cp38-cp38/bin/python -m pip install cmake && cmake --version && whereis cmake
       CIBW_BEFORE_ALL_MACOS: WD=`pwd` && python3 -m pip install cmake
-      CIBW_TEST_REQUIRES_LINUX: pytest flake8 onnxruntime 
-      CIBW_TEST_REQUIRES_MACOS: pytest onnxruntime 
-      CIBW_TEST_REQUIRES_WINDOWS: pytest onnxruntime 
+      CIBW_TEST_REQUIRES_LINUX: pytest flake8 onnxruntime
+      CIBW_TEST_REQUIRES_MACOS: pytest onnxruntime
+      CIBW_TEST_REQUIRES_WINDOWS: pytest onnxruntime
       CIBW_BEFORE_TEST_LINUX: pip install torch==1.13.1+cpu torchvision==0.14.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
       CIBW_BEFORE_TEST_MACOS: pip install torch torchvision
       CIBW_BEFORE_TEST_WINDOWS: pip install torch torchvision
@@ -37,6 +38,8 @@ jobs:
       with:
         submodules: recursive
         fetch-depth: 0
+    - name: install qemu
+      uses: docker/setup-qemu-action@v2
     - name: Build onnxsim wheels
       uses: pypa/cibuildwheel@v2.16.5
       env:
@@ -148,7 +151,7 @@ jobs:
         echo "endpoint=oss-cn-beijing.aliyuncs.com" >> ~/.ossutilconfig
         echo "accessKeyID=${{ secrets.OSS_ACCESS_KEY }}" >> ~/.ossutilconfig
         echo "accessKeySecret=${{ secrets.OSS_SECRET_KEY }}" >> ~/.ossutilconfig
-        
+
         gzip -c -9 build-wasm-node-OFF/onnxsim.wasm > onnxsim_gz.wasm
         ./ossutil64 --config-file ~/.ossutilconfig cp -u onnxsim_gz.wasm oss://converter-web/onnxsim.wasm --meta=Content-Type:application/wasm#Content-Encoding:gzip
         ./ossutil64 --config-file ~/.ossutilconfig cp -u build-wasm-node-OFF/onnxsim.js oss://converter-web/

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,7 +40,7 @@ jobs:
         fetch-depth: 0
     - name: install qemu
       if: runner.os == 'Linux'
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     - name: Build onnxsim wheels
       uses: pypa/cibuildwheel@v2.16.5
       env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,6 +39,7 @@ jobs:
         submodules: recursive
         fetch-depth: 0
     - name: install qemu
+      if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@v2
     - name: Build onnxsim wheels
       uses: pypa/cibuildwheel@v2.16.5


### PR DESCRIPTION
Thank you so much for this project!  

I went to pip install on a baremetal `aarch64` box, and found that I required cmake in order to install. As such, I wanted to contribute this PR, which if accepted would pre-build `aarch64` wheels accordingly.

There are two changes here, both to the workflow:

1. The [default cibuildwheel](https://cibuildwheel.pypa.io/en/stable/options/#archs) on Linux only builds for amd64. Adding `aarch64` to the `CIBW_ARCHS_LINUX` flag, will enable arm builds, assuming qemu is installed. I used this in a past project [here](https://github.com/redis/hiredis-py/blob/64e3394548fe670e7853a2407799e13daa4bf2cb/.github/workflows/REUSABLE-wheeler.yaml#L44), in case you wanted to see something else using it.
2. As a result, we need to install `qemu`. That too, is installed using the qemu-action

I'm hoping this might be accepted, so that `aarch64` builds start to appear in a future release. Thanks again!