### PR TITLE
fallback C.simplify ir_version error to C.simplify_path

### DIFF
--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -209,7 +209,7 @@ def simplify(
         check_ok = model_checking.compare(
             model_opt, model, check_n, test_input_shapes, input_data, custom_lib
         )
-    except ValueError:
+    except (ValueError, onnx.onnx_cpp2py_export.checker.ValidationError):
         print("[bold magenta]Simplified model larger than 2GB. Trying to save as external data...[/bold magenta]")
         # large models try to convert through a temporary file
         with tempfile.TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
Fix onnxsim about simplifying larger than 2G onnx model.
It will raise an error in `C.simplify`: `onnx.onnx_cpp2py_export.checker.ValidationError: The model does not have an ir_version set properly.` 
And it cannot be solved by downgrading the version of onnx/onnxsim/protobuf.
But we can catch this exception and treat it as equivalent to a value error about exceeding 2GB.
Then `C.simplify_path` works well now.