### PR TITLE
Use https instead of ssh when pulling submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "onnxsim/third_party/onnxruntime"]
 	path = third_party/onnxruntime
-	url = git@github.com:microsoft/onnxruntime.git
+	url = https://github.com/microsoft/onnxruntime.git
 [submodule "onnxsim/third_party/onnx-optimizer"]
 	path = third_party/onnx-optimizer
-	url = git@github.com:onnx/optimizer.git
+	url = https://github.com/onnx/optimizer.git
 [submodule "third_party/pybind11"]
 	path = third_party/pybind11
-	url = git@github.com:pybind/pybind11.git
+	url = https://github.com/pybind/pybind11.git


### PR DESCRIPTION
This enables building this package in systems that dont have ssh without resorting to workarounds. Also makes it possible to building this python package in nixpkgs as is.