### PR TITLE
Enable Python 3.12 wheel building

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,10 +22,10 @@ jobs:
       CIBW_BEFORE_TEST_WINDOWS: pip install torch torchvision
       # Skip arm test on x86. Skip python 3.11 test because of the absense of torchvision binary wheel
       # Skip python3.7 because of onnxruntime has deprecated it
-      CIBW_TEST_SKIP: "cp37-* cp311-* *_arm64 *_universal2:arm64"
+      CIBW_TEST_SKIP: "cp37-* cp311-* cp312-* *_arm64 *_universal2:arm64"
       CIBW_TEST_COMMAND: pytest -v {project}/tests/test_python_api.py
       # Only build on Python 3 and skip 32-bit or musl builds
-      CIBW_BUILD: "cp3?-* cp310-* cp311-*"
+      CIBW_BUILD: "cp3?-* cp310-* cp311-* cp312-*"
       CIBW_SKIP: "cp36-* *-win32 *-manylinux_i686 *-musllinux_*"
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Pre-built wheels are only available till 3.11. Adding 3.12 support so we can install pre-built wheels instead of having to build from sdist which requires cmake.