### PR TITLE
Fix protobuf symbol clashes by hiding library symbols in Python extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,4 +76,6 @@ if (ONNXSIM_PYTHON)
   if(NOT "${PY_EXT_SUFFIX}" STREQUAL "")
     set_target_properties(onnxsim_cpp2py_export PROPERTIES SUFFIX ${PY_EXT_SUFFIX})
   endif()
+  set_target_properties(onnxsim_cpp2py_export
+                        PROPERTIES LINK_FLAGS "-Wl,--exclude-libs,ALL")
 endif()


### PR DESCRIPTION
**Problem**
When using `onnx-simplifier` alongside TensorFlow or other libraries that export `protobuf` symbols, symbol clashes can occur which may result in a segfault.

This happens because the `onnx-simplifier` Python extension (`onnxsim_cpp2py_export`) was exposing all symbols from its linked static libraries, including `protobuf` symbols. These public symbols can conflict with `protobuf` symbols exported by TensorFlow and other ML frameworks, leading to runtime issues and potential crashes.

**Solution**
This PR adds the linker flag `-Wl,--exclude-libs,ALL` to the Python extension target, which hides all symbols from statically linked libraries. This ensures that `protobuf` and other internal symbols are not exposed publicly from the extension module.

Note that this change only applies to the Python extension build (`ONNXSIM_PYTHON` flag)

**Precedent**
This approach follows the exact same solution used by the ONNX project itself in their Python bindings ([see ONNX CMakeLists.txt](https://github.com/onnx/onnx/blob/v1.18.0/CMakeLists.txt#L588-L589), demonstrating this is an established best practice for avoiding protobuf symbol conflicts in Python extensions.

**Testing**
The change only affects symbol visibility and doesn't change functionality. Existing tests continue to pass.

We have successfully tested this to fix symbol clashes we saw with tensorflow 2.20 