### PR TITLE
Add atexit handler to release C++ model executor reference

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -10,6 +10,6 @@ del x  # C++ shared_ptr now owns the instance; no need to keep Python reference
 
 # Ensure the C++ static reference is released before nanobind's module teardown
 # to prevent "leaked instances/types" warnings at interpreter shutdown
-atexit.register(onnxsim.onnxsim_cpp2py_export._clear_model_executor)
+atexit.register(lambda: onnxsim.onnxsim_cpp2py_export._set_model_executor(None))
 
 from .version import version as __version__  # noqa

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -100,13 +100,7 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       .def("_set_model_executor",
            [](std::shared_ptr<PyModelExecutor> executor) {
              ModelExecutor::set_instance(std::move(executor));
-           });
-
-  // Release the C++ static reference to the Python model executor
-  // This is called via atexit to prevent nanobind's "leaked instances" warning
-  m.def("_clear_model_executor", []() {
-    ModelExecutor::set_instance(nullptr);
-  });
+           }, "executor"_a.none());
 
   py::class_<PyModelExecutor, PyModelExecutorTrampoline>(m, "ModelExecutor")
       .def(py::init<>())


### PR DESCRIPTION
To avoid warnings from nanobind
Ref: https://github.com/onnxsim/onnxsim/pull/378/changes/2902feff4fceaf320ca4d8fbca448e16c23d5ecf