### PR TITLE
Migrate from `setup.py`-only to `pyproject.toml` hybrid

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools", "wheel"]
-build-backend = "setuptools.backends.legacy:build"
+build-backend = "setuptools.build_meta:__legacy__"
 
 [project]
 name = "onnxsim"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.backends.legacy:build"
+
+[project]
+name = "onnxsim"
+dynamic = ["version"]
+description = "Simplify your ONNX model"
+readme = "README.md"
+license = {text = "MIT AND (Apache-2.0 OR BSD-2-Clause)"}
+requires-python = ">=3.10"
+dependencies = [
+    "onnx",
+    "rich",
+]
+authors = [
+    {name = "ONNX Simplifier Authors", email = "daquexian566@gmail.com"},
+]
+keywords = ["deep-learning", "ONNX"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Software Development",
+]
+
+[project.urls]
+Homepage = "https://github.com/daquexian/onnx-simplifier"
+
+[project.scripts]
+onnxsim = "onnxsim:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/daquexian/onnx-simplifier"
+Homepage = "https://github.com/onnxsim/onnxsim"
 
 [project.scripts]
 onnxsim = "onnxsim:main"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils import sysconfig, log
+import sysconfig
 import setuptools
 import setuptools.command.build_py
 import setuptools.command.develop
@@ -6,13 +6,11 @@ import setuptools.command.build_ext
 
 from collections import namedtuple
 from contextlib import contextmanager
-import glob
 import os
 import shlex
 import subprocess
 import shutil
 import sys
-import platform
 from textwrap import dedent
 import multiprocessing
 import re
@@ -26,9 +24,6 @@ WINDOWS = (os.name == 'nt')
 MACOS = sys.platform.startswith("darwin")
 
 CMAKE = shutil.which('cmake')
-
-install_requires = []
-setup_requires = []
 
 USE_MSVC_STATIC_RUNTIME = bool(os.getenv('USE_MSVC_STATIC_RUNTIME', '0') == '1')
 ONNX_ML = not bool(os.getenv('ONNX_ML') == '0')
@@ -144,7 +139,7 @@ class cmake_build(setuptools.Command):
             # configure
             cmake_args = [
                 CMAKE,
-                '-DPython_INCLUDE_DIR={}'.format(sysconfig.get_python_inc()),
+                '-DPython_INCLUDE_DIR={}'.format(sysconfig.get_path('include')),
                 '-DPython_EXECUTABLE={}'.format(sys.executable),
                 '-DONNX_BUILD_PYTHON=ON',
                 '-DONNXSIM_PYTHON=ON',
@@ -187,7 +182,7 @@ class cmake_build(setuptools.Command):
                 extra_cmake_args = shlex.split(os.environ['CMAKE_ARGS'])
                 # prevent crossfire with downstream scripts
                 del os.environ['CMAKE_ARGS']
-                log.info('Extra cmake args: {}'.format(extra_cmake_args))
+                print('Extra cmake args: {}'.format(extra_cmake_args))
                 cmake_args.extend(extra_cmake_args)
             cmake_args.append(TOP_DIR)
             print(f"Run command {cmake_args}")
@@ -261,26 +256,7 @@ ext_modules = [
         py_limited_api=py_limited_api)
 ]
 
-# no need to do fancy stuff so far
 packages = setuptools.find_packages()
-
-# Though we depend on onnxruntime, it has three different packages:
-# onnxruntime, onnxruntime-gpu and onnxruntime-noopenmp.
-# The solution is, we publish two packages, a wheel named onnxsim-no-ort
-# and a sdist package named onnxsim, onnxsim depends on onnxsim-no-ort,
-# and also check if one of onnxruntime packages is installed, and depends
-# on onnxruntime when no existing installed packages.
-install_requires.extend([
-    'onnx',
-    'rich',
-])
-
-setup_requires.append('pytest-runner')
-
-# read the contents of your README file
-from pathlib import Path
-this_directory = Path(__file__).parent
-long_description = (this_directory / "README.md").read_text()
 
 version_str = VersionInfo.version
 
@@ -292,39 +268,10 @@ if VersionInfo.dev_count is not None:
 #     version_str += f"+{VersionInfo.git_version}"
 
 setuptools.setup(
-    name="onnxsim",
     version=version_str,
-    description='Simplify your ONNX model',
     ext_modules=ext_modules,
     cmdclass=cmdclass,
     packages=packages,
-    license='MIT AND (Apache-2.0 OR BSD-2-Clause)',
     include_package_data=True,
-    install_requires=install_requires,
-    setup_requires=setup_requires,
-    author='ONNX Simplifier Authors',
-    author_email='daquexian566@gmail.com',
-    url='https://github.com/daquexian/onnx-simplifier',
-    keywords='deep-learning ONNX',
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Topic :: Scientific/Engineering',
-        'Topic :: Software Development'
-    ],
-    python_requires='>=3.7',
-    entry_points={
-        'console_scripts': [
-            'onnxsim=onnxsim:main',
-        ],
-    },
     options=setup_opts,
 )


### PR DESCRIPTION
# Migrate from `setup.py`-only to `pyproject.toml` hybrid

## Summary

Adds a `pyproject.toml` at the project root following PEP 517/518, moves all static package metadata out of `setup.py`, and fixes a Python 3.12+ compatibility bug. The cmake-based C++ build logic stays in `setup.py` (hybrid approach).

---

## Changes

**New `pyproject.toml`**
- Declares `setuptools.build_meta:__legacy__` as the PEP 517 build backend, preserving both `pip install` and direct `python setup.py <command>` workflows
- Carries all static metadata: name, description, license, readme, authors, classifiers, entry point, `requires-python = ">=3.10"`, dependencies
- Drops Python 3.7–3.9 from classifiers and `requires-python` (aligned with what CI actually tests)
- `version` remains `dynamic`, resolved from `setup.py` at build time via git tags / `VERSION` file

**Modified `setup.py`**
- **Fixes Python 3.12+ breakage**: replaces `from distutils import sysconfig, log` (removed from stdlib in 3.12) with stdlib `import sysconfig` and `print()`
- Replaces `distutils.sysconfig.get_python_inc()` with `sysconfig.get_path('include')` (stdlib equivalent)
- Removes all metadata now owned by `pyproject.toml`: `name`, `description`, `license`, `install_requires`, `setup_requires`, `classifiers`, `entry_points`, `python_requires`, `author`, `url`, `keywords`, `long_description`
- Removes deprecated `setup_requires = ['pytest-runner']`
- Removes unused imports (`glob`, `platform`, `pathlib`)
- `setup()` now only contains build-specific arguments: `version`, `ext_modules`, `cmdclass`, `packages`, `include_package_data`, `options`

---

## Limitations of the hybrid approach

**1. Version is still computed imperatively in `setup.py`**
The git-tag-based version logic runs on every `python setup.py ...` invocation. There is no declarative version source (e.g. `setuptools-scm`). This means metadata-only queries (e.g. `pip install --dry-run`) still require git to be available and all of `setup.py` to execute successfully.

**2. `assert CMAKE` runs at import time**
`setup.py` asserts cmake is in `PATH` at module level. Any pip operation that imports `setup.py` (including metadata inspection) will fail in environments without cmake — even when cmake is not needed for that operation. This is unchanged from before.

**3. `MANIFEST.in` is still required for sdist**
The source distribution still depends on `MANIFEST.in` to include C++ source files, cmake files, and third-party directories. Modern pyproject.toml-native backends handle this declaratively; here it remains implicit.

**4. Direct `python setup.py` commands still required for some workflows**
`develop` mode (`pip install -e .`) and the `cmake_build` / `create_version` commands are only accessible through the custom `cmdclass` in `setup.py`. There is no PEP 660 editable install support.

**5. `include_package_data=True` remains implicit**
Package data inclusion relies on `MANIFEST.in` and the `include_package_data` flag in `setup()` rather than an explicit `[tool.setuptools.package-data]` declaration in `pyproject.toml`.

**6. Not a path to scikit-build-core**
This migration does not move toward a cmake-native build backend. A future migration to [scikit-build-core](https://scikit-build-core.readthedocs.io/) would resolve limitations 1–5 but requires porting the cmake integration and is a separate, larger effort.
