### PR TITLE
proper exception handling in case 2gb proto error occurs

### DIFF
--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -9,6 +9,7 @@ from typing import List, Literal, Dict, Union, Optional, Tuple, Sequence
 from rich.text import Text
 from rich import print
 import numpy as np
+from google.protobuf.message import EncodeError
 
 import onnx  # type: ignore
 import onnx.checker  # type: ignore
@@ -216,7 +217,7 @@ def simplify(
         check_ok = model_checking.compare(
             model_opt, model, check_n, test_input_shapes, input_data, custom_lib
         )
-    except (ValueError, onnx.onnx_cpp2py_export.checker.ValidationError):
+    except (EncodeError, ValueError, onnx.onnx_cpp2py_export.checker.ValidationError):
         print("[bold magenta]Simplified model larger than 2GB. Trying to save as external data...[/bold magenta]")
         # large models try to convert through a temporary file
         with tempfile.TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
Hello thank you for the effort of maintaining an amazing library.

# Issue (https://github.com/onnxsim/onnxsim/issues/357#issuecomment-4133203176)
When `pip install onnxsim` on python 3.12 as of April 7th I get`protobuf==7.34.1` installed.

https://github.com/onnxsim/onnxsim/blob/6b5da86d6434141d0df64eed532fdbdebc6e8284/requirements.txt#L4
With the latest `protobuf`, `SerializeToString()` on 2gb> ONNX model throws `google.protobuf.message.EncodeError`
https://github.com/onnxsim/onnxsim/blob/6b5da86d6434141d0df64eed532fdbdebc6e8284/onnxsim/onnx_simplifier.py#L197-L198

I noticed v0.6.2 release does not catch this properly skipping the `C.simplify_path` logic
https://github.com/onnxsim/onnxsim/blob/6b5da86d6434141d0df64eed532fdbdebc6e8284/onnxsim/onnx_simplifier.py#L212-L214


# How to reproduce
1. `pip install onnxsim==0.6.2`
2. Download WhisperLargeV3Turbo Encoder ([onnx](https://huggingface.co/onnx-community/whisper-large-v3-turbo/resolve/main/onnx/encoder_model.onnx), [data](https://huggingface.co/onnx-community/whisper-large-v3-turbo/resolve/main/onnx/encoder_model.onnx_data))
3. Run `python3 -m onnxsim encoder_model.onnx sim.onnx --save-as-external-data`

**Expected output:**
```
(test) ➜  Downloads python3 -m onnxsim encoder_model.onnx sim.onnx                               
Simplifying...
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/jerry/miniconda3/envs/test/lib/python3.12/site-packages/onnxsim/__main__.py", line 5, in <module>
    main()
  File "/home/jerry/miniconda3/envs/test/lib/python3.12/site-packages/onnxsim/onnx_simplifier.py", line 489, in main
    model_opt, check_ok = simplify(
                          ^^^^^^^^^
  File "/home/jerry/miniconda3/envs/test/lib/python3.12/site-packages/onnxsim/onnx_simplifier.py", line 198, in simplify
    model_bytes = model.SerializeToString()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^
google.protobuf.message.EncodeError: Failed to serialize proto
```
**After patching `/home/jerry/miniconda3/envs/test/lib/python3.12/site-packages/onnxsim/onnx_simplifier.py`**
```
(test) ➜  Downloads python3 -m onnxsim encoder_model.onnx sim.onnx --save-as-external-data                     
Simplifying...
Simplified model larger than 2GB. Trying to save as external data...
Finish! Here is the difference:
┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
┃            ┃ Original Model ┃ Simplified Model ┃
┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━┩
│ Add        │ 389            │ 389              │
│ Constant   │ 879            │ 432              │
│ Conv       │ 2              │ 2                │
│ Div        │ 99             │ 99               │
│ Erf        │ 34             │ 34               │
│ MatMul     │ 256            │ 192              │
│ Mul        │ 165            │ 165              │
│ Pow        │ 65             │ 65               │
│ ReduceMean │ 130            │ 130              │
│ Reshape    │ 128            │ 128              │
│ Softmax    │ 32             │ 32               │
│ Split      │ 0              │ 32               │
│ Sqrt       │ 65             │ 65               │
│ Sub        │ 65             │ 65               │
│ Transpose  │ 129            │ 129              │
│ Model Size │ 2.4GiB         │ 2.4GiB           │
└────────────┴────────────────┴──────────────────┘
```

# Changes made
- `EncodeError` is now catched under `onnx_simplifier.py`