### PR TITLE
Make onnxruntime optional, fall back to onnx reference evaluator

### DIFF
--- a/onnxsim/backend.py
+++ b/onnxsim/backend.py
@@ -1,0 +1,97 @@
+"""Inference backend used for constant folding and correctness checking.
+
+onnxruntime is preferred when it is available. If it is not installed,
+onnxsim falls back to onnx's built-in reference evaluator so that
+onnxruntime becomes an optional dependency (installing onnxruntime is
+sometimes harmful, see https://github.com/onnxsim/onnxsim/issues/441).
+"""
+
+import os
+from collections import OrderedDict
+from typing import Dict, Optional, Sequence, Union
+
+import numpy as np
+import onnx
+
+try:
+    import onnxruntime as rt  # type: ignore
+
+    _HAS_ONNXRUNTIME = True
+except ImportError:
+    rt = None  # type: ignore
+    _HAS_ONNXRUNTIME = False
+
+
+def has_onnxruntime() -> bool:
+    """Whether onnxruntime is available as the inference backend."""
+    return _HAS_ONNXRUNTIME
+
+
+def _run_with_onnxruntime(
+    model: Union[str, bytes, onnx.ModelProto],
+    inputs: Dict[str, np.ndarray],
+    output_names: Optional[Sequence[str]],
+    custom_lib: Optional[str],
+) -> "OrderedDict[str, np.ndarray]":
+    sess_options = rt.SessionOptions()
+    if custom_lib is not None:
+        if os.path.exists(custom_lib):
+            sess_options.register_custom_ops_library(custom_lib)
+        else:
+            raise ValueError("No such file '{}'".format(custom_lib))
+    sess_options.graph_optimization_level = rt.GraphOptimizationLevel(0)
+    sess_options.log_severity_level = 3
+    if isinstance(model, onnx.ModelProto):
+        model = model.SerializeToString()
+    sess = rt.InferenceSession(
+        model,
+        sess_options=sess_options,
+        providers=["CPUExecutionProvider"],
+    )
+    if output_names is None:
+        output_names = [x.name for x in sess.get_outputs()]
+    run_options = rt.RunOptions()
+    run_options.log_severity_level = 3
+    outputs = sess.run(list(output_names), inputs, run_options=run_options)
+    return OrderedDict(zip(output_names, outputs))
+
+
+def _run_with_reference(
+    model: Union[str, bytes, onnx.ModelProto],
+    inputs: Dict[str, np.ndarray],
+    output_names: Optional[Sequence[str]],
+    custom_lib: Optional[str],
+) -> "OrderedDict[str, np.ndarray]":
+    if custom_lib is not None:
+        raise ValueError(
+            "custom_lib is only supported when onnxruntime is installed"
+        )
+    from onnx.reference import ReferenceEvaluator
+
+    if isinstance(model, str):
+        model = onnx.load(model)
+    elif isinstance(model, bytes):
+        model = onnx.load_from_string(model)
+    sess = ReferenceEvaluator(model)
+    if output_names is None:
+        output_names = list(sess.output_names)
+    outputs = sess.run(list(output_names), inputs)
+    return OrderedDict(zip(output_names, outputs))
+
+
+def run_model(
+    model: Union[str, bytes, onnx.ModelProto],
+    inputs: Dict[str, np.ndarray],
+    output_names: Optional[Sequence[str]] = None,
+    custom_lib: Optional[str] = None,
+) -> "OrderedDict[str, np.ndarray]":
+    """Run ``model`` on ``inputs`` and return an ordered ``{name: array}`` map.
+
+    :param model: onnx ModelProto, serialized bytes, or a file path
+    :param inputs: mapping from input name to numpy array
+    :param output_names: outputs to fetch, ``None`` means all model outputs
+    :param custom_lib: onnxruntime custom ops's shared library (onnxruntime only)
+    """
+    if _HAS_ONNXRUNTIME:
+        return _run_with_onnxruntime(model, inputs, output_names, custom_lib)
+    return _run_with_reference(model, inputs, output_names, custom_lib)

--- a/onnxsim/model_checking.py
+++ b/onnxsim/model_checking.py
@@ -1,11 +1,10 @@
-import os
 from typing import List, Dict, Optional, Union
-from collections import OrderedDict
 
 import onnx
 import onnx.checker
 import numpy as np
-import onnxruntime as rt
+
+from . import backend
 
 Tensors = Dict[str, np.ndarray]
 TensorShape = List[int]
@@ -133,28 +132,7 @@ def compare(
             inputs: Tensors,
             custom_lib: Optional[str] = None
     ) -> Dict[str, np.ndarray]:
-        sess_options = rt.SessionOptions()
-        if custom_lib is not None:
-            if os.path.exists(custom_lib):
-                sess_options.register_custom_ops_library(custom_lib)
-            else:
-                raise ValueError("No such file '{}'".format(custom_lib))
-        sess_options.graph_optimization_level = rt.GraphOptimizationLevel(0)
-        sess_options.log_severity_level = 3
-        if isinstance(model, onnx.ModelProto):
-            model = model.SerializeToString()
-        sess = rt.InferenceSession(
-            model,
-            sess_options=sess_options,
-            providers=["CPUExecutionProvider"],
-        )
-        outputs = [x.name for x in sess.get_outputs()]
-        run_options = rt.RunOptions()
-        run_options.log_severity_level = 3
-        res = OrderedDict(
-            zip(outputs, sess.run(outputs, inputs, run_options=run_options))
-        )
-        return res
+        return backend.run_model(model, inputs, custom_lib=custom_lib)
 
     if input_shapes is None:
         input_shapes = {}

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -16,17 +16,8 @@ import onnx.checker  # type: ignore
 import onnx.helper  # type: ignore
 import onnx.shape_inference  # type: ignore
 import onnx.numpy_helper  # type: ignore
-try:
-    import onnxruntime as rt  # type: ignore
-except ImportError:
-    command = [sys.executable, '-m', 'pip', 'install', 'onnxruntime']
-    print(Text(f"Installing onnxruntime by `{' '.join(command)}`, please wait for a moment..", style="bold magenta"))
-    import subprocess
-    subprocess.check_call(command)
-    import onnxruntime as rt
-
-
 import onnxsim.onnxsim_cpp2py_export as C
+from . import backend
 from . import model_info
 from . import model_checking
 from . import version
@@ -260,20 +251,10 @@ class PyModelExecutor(C.ModelExecutor):
         input_arrs = map(onnx.numpy_helper.to_array, input_tps)
         input_names = [x.name for x in model.graph.input]
         inputs = dict(zip(input_names, input_arrs))
-        sess_options = rt.SessionOptions()
-        sess_options.graph_optimization_level = rt.GraphOptimizationLevel(0)
-        sess_options.log_severity_level = 3
-        sess = rt.InferenceSession(
-            model.SerializeToString(),
-            sess_options=sess_options,
-            providers=["CPUExecutionProvider"],
-        )
-        output_names = [x.name for x in sess.get_outputs()]
-        run_options = rt.RunOptions()
-        run_options.log_severity_level = 3
-        output_arrs = sess.run(output_names, inputs, run_options=run_options)
+        outputs = backend.run_model(model, inputs)
         return [
-            onnx.numpy_helper.from_array(x).SerializeToString() for x in output_arrs
+            onnx.numpy_helper.from_array(x).SerializeToString()
+            for x in outputs.values()
         ]
 
 
@@ -460,6 +441,12 @@ def main():
     overwrite_input_shapes = parse_shapes(args.overwrite_input_shape)
 
     if args.enable_onnxruntime_optimization:
+        if not backend.has_onnxruntime():
+            raise RuntimeError(
+                "--enable-onnxruntime-optimization requires onnxruntime, "
+                "please install it by `pip install onnxruntime`."
+            )
+        import onnxruntime as rt
 
         tmp_file = tempfile.NamedTemporaryFile()
         sess_options = rt.SessionOptions()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ classifiers = [
     "Topic :: Software Development",
 ]
 
+[project.optional-dependencies]
+# onnxruntime is preferred for constant folding and correctness checking.
+# When it is not installed, onnxsim falls back to onnx's reference evaluator.
+onnxruntime = ["onnxruntime >= 1.6.0"]
+
 [project.urls]
 Homepage = "https://github.com/onnxsim/onnxsim"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 onnx
 onnxoptimizer >= 0.2.5
+# onnxruntime is optional; onnxsim falls back to onnx's reference evaluator
+# when it is not installed. See https://github.com/onnxsim/onnxsim/issues/441
 onnxruntime >= 1.6.0
 protobuf >= 3.7.0
 rich != 12.1.0

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -26,7 +26,7 @@ def _make_foldable_model() -> onnx.ModelProto:
         [helper.make_tensor_value_info("y", TensorProto.FLOAT, [2, 2])],
         [a, b],
     )
-    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 18)])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10)
     onnx.checker.check_model(model)
     return model
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,71 @@
+"""Tests for the inference backend fallback (onnxsim/onnxsim#441).
+
+When onnxruntime is not installed, onnxsim should fall back to onnx's
+reference evaluator instead of requiring / auto-installing onnxruntime.
+"""
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+import pytest
+
+import onnxsim
+from onnxsim import backend
+
+
+def _make_foldable_model() -> onnx.ModelProto:
+    """A model whose ``a + b`` can be constant-folded, then added to input."""
+    a = numpy_helper.from_array(np.ones((2, 2), np.float32), "a")
+    b = numpy_helper.from_array(np.ones((2, 2), np.float32) * 2, "b")
+    add_const = helper.make_node("Add", ["a", "b"], ["c"])
+    add_input = helper.make_node("Add", ["c", "x"], ["y"])
+    graph = helper.make_graph(
+        [add_const, add_input],
+        "foldable",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [2, 2])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [2, 2])],
+        [a, b],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 18)])
+    onnx.checker.check_model(model)
+    return model
+
+
+def test_run_model_produces_correct_result():
+    model = _make_foldable_model()
+    x = np.arange(4, dtype=np.float32).reshape(2, 2)
+    outputs = backend.run_model(model, {"x": x})
+    np.testing.assert_allclose(outputs["y"], x + 3.0)
+
+
+def test_reference_evaluator_run_model(monkeypatch):
+    # Force the onnxruntime-less code path.
+    monkeypatch.setattr(backend, "_HAS_ONNXRUNTIME", False)
+    assert not backend.has_onnxruntime()
+
+    model = _make_foldable_model()
+    x = np.arange(4, dtype=np.float32).reshape(2, 2)
+    # Inference now goes through onnx.reference.ReferenceEvaluator.
+    outputs = backend.run_model(model, {"x": x})
+    np.testing.assert_allclose(outputs["y"], x + 3.0)
+
+
+def test_simplify_without_onnxruntime(monkeypatch):
+    # Force the onnxruntime-less code path for both constant folding
+    # (PyModelExecutor.Run) and correctness checking (model_checking).
+    monkeypatch.setattr(backend, "_HAS_ONNXRUNTIME", False)
+
+    model = _make_foldable_model()
+    opt, check_ok = onnxsim.simplify(model, check_n=3)
+    assert check_ok
+    # ``a + b`` is folded into a single constant, leaving only the input Add.
+    assert len(opt.graph.node) == 1
+
+
+def test_reference_evaluator_rejects_custom_lib(monkeypatch):
+    monkeypatch.setattr(backend, "_HAS_ONNXRUNTIME", False)
+    model = _make_foldable_model()
+    with pytest.raises(ValueError):
+        backend.run_model(
+            model, {"x": np.zeros((2, 2), np.float32)}, custom_lib="does_not_exist.so"
+        )


### PR DESCRIPTION
Installing onnxruntime is sometimes harmful, so use onnx's built-in reference evaluator for constant folding and correctness checking when onnxruntime is not available, instead of auto-installing it.

Fixes onnxsim/onnxsim#441