### PR TITLE
Use operator schema determinism attribute to fold constants

### DIFF
--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <fstream>
 #include <numeric>
+#include <unordered_map>
 
 #ifndef NO_BUILTIN_ORT
 #include "onnxruntime/core/framework/endian.h"
@@ -14,6 +15,7 @@
 #endif
 #include "onnx/common/file_utils.h"
 #include "onnx/defs/printer.h"
+#include "onnx/defs/schema.h"
 #include "onnx/shape_inference/implementation.h"
 #include "onnxoptimizer/model_util.h"
 #include "onnxoptimizer/optimize.h"
@@ -49,18 +51,26 @@ bool IsOfficialOp(const std::string& domain, const std::string& op) {
   return experimental_ops.find(op) == experimental_ops.end();
 }
 
-bool IsDeterministic(const std::string& domain, const std::string& op) {
-  // Copy from onnxruntime/core/optimizer/utils.cc
-  constexpr std::array kOnnxDomainNonDeterministicOps{
-      "RandomUniform", "RandomNormal", "RandomUniformLike", "RandomNormalLike",
-      "Multinomial"};
-  if (domain == "ai.onnx" || domain == "ai.onnx.ml" || domain.empty()) {
-    auto iter = std::find(kOnnxDomainNonDeterministicOps.begin(),
-                          kOnnxDomainNonDeterministicOps.end(), op);
-    return iter == kOnnxDomainNonDeterministicOps.end();
+bool IsDeterministic(const std::string& domain, const std::string& op,
+                     int opset_version) {
+  // Query the determinism attribute of the operator schema instead of
+  // maintaining a hardcoded list of non-deterministic ops. See
+  // https://github.com/onnx/onnx/pull/7176.
+  //
+  // The ONNX operator schema registry stores the default ONNX domain as an
+  // empty string.
+  const std::string& lookup_domain = domain == "ai.onnx" ? "" : domain;
+  const auto* schema =
+      onnx::OpSchemaRegistry::Schema(op, opset_version, lookup_domain);
+  if (schema == nullptr) {
+    // Unknown op. Assume it is not deterministic.
+    return false;
   }
-  // Unknown domain. Assume the op is not deterministic.
-  return false;
+  // Only fold ops that are known to be deterministic. Ops whose determinism
+  // cannot be statically determined (e.g. context-dependent functions) are
+  // treated as non-deterministic to be safe.
+  return schema->GetNodeDeterminism() ==
+         onnx::OpSchema::NodeDeterminism::Deterministic;
 }
 
 bool IsQDQ(const std::string& domain, const std::string& op) {
@@ -384,11 +394,26 @@ GetConstantNodes(const onnx::ModelProto& model) {
   std::transform(
       model.graph().initializer().begin(), model.graph().initializer().end(),
       std::back_inserter(const_names), [](const auto& x) { return x.name(); });
+  // Map each domain to its imported opset version so the correct operator
+  // schema can be looked up. The default ONNX domain is normalized to an empty
+  // string, which is how the schema registry stores it.
+  std::unordered_map<std::string, int> domain_to_version;
+  for (const auto& opset : model.opset_import()) {
+    const std::string& domain =
+        opset.domain() == "ai.onnx" ? "" : opset.domain();
+    domain_to_version[domain] = opset.version();
+  }
+  auto opset_version_of = [&domain_to_version](const std::string& domain) {
+    const std::string& key = domain == "ai.onnx" ? "" : domain;
+    auto iter = domain_to_version.find(key);
+    return iter == domain_to_version.end() ? 0 : iter->second;
+  };
   // node is already topo sorted
   for (const auto& node : model.graph().node()) {
     // clang-format off
     if (IsOfficialOp(node.domain(), node.op_type()) &&
-        IsDeterministic(node.domain(), node.op_type()) &&
+        IsDeterministic(node.domain(), node.op_type(),
+                        opset_version_of(node.domain())) &&
         !IsQDQ(node.domain(), node.op_type()) &&
         !HasSubgraph(node) &&
         !ProduceLargeTensor(model, node, config.tensor_size_threshold) &&

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -281,6 +281,66 @@ def test_unset_optional_input():
     assert len(sim_model.graph.initializer) == 1
 
 
+def test_fold_deterministic_op():
+    # An op that the operator schema marks as deterministic and whose inputs are
+    # all constants should be constant-folded away.
+    a = np.random.rand(2, 3).astype(np.float32)
+    b = np.random.rand(2, 3).astype(np.float32)
+    initializers = [
+        onnx.helper.make_tensor('a', onnx.TensorProto.FLOAT, a.shape, a.tobytes(), raw=True),
+        onnx.helper.make_tensor('b', onnx.TensorProto.FLOAT, b.shape, b.tobytes(), raw=True),
+    ]
+    node = onnx.helper.make_node('Add', inputs=['a', 'b'], outputs=['y'])
+    out = onnx.helper.make_tensor_value_info('y', onnx.TensorProto.FLOAT, (2, 3))
+    graph_def = onnx.helper.make_graph(
+        [node], 'test_fold_deterministic_op', [], [out], initializer=initializers)
+    model = onnx.helper.make_model(
+        graph_def, opset_imports=[onnx.helper.make_opsetid("", 14)], ir_version=10)
+
+    sim_model, check_ok = onnxsim.simplify(model, check_n=3)
+    assert check_ok
+    # The Add node is folded into a single constant initializer.
+    assert len(sim_model.graph.node) == 0
+    assert len(sim_model.graph.initializer) == 1
+
+
+def test_do_not_fold_random_op():
+    # RandomUniform is non-deterministic according to the operator schema
+    # determinism attribute, so it must not be constant-folded even though it
+    # has no non-constant inputs.
+    node = onnx.helper.make_node(
+        'RandomUniform', inputs=[], outputs=['y'],
+        shape=[2, 3], dtype=onnx.TensorProto.FLOAT)
+    out = onnx.helper.make_tensor_value_info('y', onnx.TensorProto.FLOAT, (2, 3))
+    graph_def = onnx.helper.make_graph(
+        [node], 'test_do_not_fold_random_op', [], [out])
+    model = onnx.helper.make_model(
+        graph_def, opset_imports=[onnx.helper.make_opsetid("", 14)], ir_version=10)
+
+    sim_model, _ = onnxsim.simplify(model, check_n=0)
+    assert len(sim_model.graph.node) == 1
+    assert sim_model.graph.node[0].op_type == 'RandomUniform'
+    assert len(sim_model.graph.initializer) == 0
+
+
+def test_do_not_fold_random_like_op():
+    # RandomNormalLike is non-deterministic; it must not be folded even when its
+    # input is a constant.
+    x = np.zeros((2, 3), dtype=np.float32)
+    initializers = [
+        onnx.helper.make_tensor('x', onnx.TensorProto.FLOAT, x.shape, x.tobytes(), raw=True),
+    ]
+    node = onnx.helper.make_node('RandomNormalLike', inputs=['x'], outputs=['y'])
+    out = onnx.helper.make_tensor_value_info('y', onnx.TensorProto.FLOAT, (2, 3))
+    graph_def = onnx.helper.make_graph(
+        [node], 'test_do_not_fold_random_like_op', [], [out], initializer=initializers)
+    model = onnx.helper.make_model(
+        graph_def, opset_imports=[onnx.helper.make_opsetid("", 14)], ir_version=10)
+
+    sim_model, _ = onnxsim.simplify(model, check_n=0)
+    assert any(n.op_type == 'RandomNormalLike' for n in sim_model.graph.node)
+
+
 def test_perform_optimization_false():
     def _create_dummy_model():
         class MockModel(torch.nn.Module):


### PR DESCRIPTION
Query OpSchema::GetNodeDeterminism() (onnx/onnx#7176) instead of a hardcoded list of non-deterministic ops when deciding which nodes are safe to constant-fold. GetConstantNodes now maps each imported opset to its version so the correct schema is looked up per node.

Fixes onnxsim/onnxsim#440


Claude-Session: https://claude.ai/code/session_01ExgQdQo6sQiZ6f1Teinnco