### PR TITLE
Remove ModelExecutor::instance_ and pass executor as argument

### DIFF
--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -1,15 +1,3 @@
 from onnxsim.onnx_simplifier import simplify, main
 
-# register python executor
-import atexit
-import onnxsim.onnx_simplifier
-import onnxsim.onnxsim_cpp2py_export
-x = onnxsim.onnx_simplifier.PyModelExecutor()
-onnxsim.onnxsim_cpp2py_export._set_model_executor(x)
-del x  # C++ shared_ptr now owns the instance; no need to keep Python reference
-
-# Ensure the C++ static reference is released before nanobind's module teardown
-# to prevent "leaked instances/types" warnings at interpreter shutdown
-atexit.register(lambda: onnxsim.onnxsim_cpp2py_export._set_model_executor(None))
-
 from .version import version as __version__  # noqa

--- a/onnxsim/bin/onnxsim_bin.cpp
+++ b/onnxsim/bin/onnxsim_bin.cpp
@@ -18,7 +18,7 @@ int main(int argc, char** argv) {
   onnx::LoadProtoFromPath(input_model_filename, model);
 
   model = Simplify(
-      model,
+      *GetBuiltinModelExecutor(), model,
       no_opt ? std::nullopt : std::make_optional<std::vector<std::string>>({}),
       !no_sim, !no_shape_inference, SIZE_MAX);
 

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -69,7 +69,8 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
   using namespace py::literals;
 
   m.def("simplify",
-        [](const py::bytes& model_proto_bytes,
+        [](std::shared_ptr<PyModelExecutor> executor,
+           const py::bytes& model_proto_bytes,
            std::optional<std::vector<std::string>> skip_optimizers,
            bool constant_folding, bool shape_inference,
            size_t tensor_size_threshold) -> py::bytes {
@@ -77,31 +78,30 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
           InitEnv();
           ONNX_NAMESPACE::ModelProto model;
           ParseProtoFromBytes(&model, model_proto_bytes.c_str(), model_proto_bytes.size());
-          auto const result = Simplify(model, skip_optimizers, constant_folding,
-                                       shape_inference, tensor_size_threshold);
+          auto const result = Simplify(*executor, model, skip_optimizers,
+                                       constant_folding, shape_inference,
+                                       tensor_size_threshold);
           std::string out;
           result.SerializeToString(&out);
           return py::bytes(out.data(), out.size());
-        }, "model_bytes"_a, "skip_optimizers"_a.none(),
+        }, "executor"_a, "model_bytes"_a, "skip_optimizers"_a.none(),
         "constant_folding"_a = true, "shape_inference"_a = true, "tensor_size_threshold"_a)
       .def("simplify_path",
-           [](const std::string& in_path, const std::string& out_path,
+           [](std::shared_ptr<PyModelExecutor> executor,
+              const std::string& in_path, const std::string& out_path,
               std::optional<std::vector<std::string>> skip_optimizers,
               bool constant_folding, bool shape_inference,
               size_t tensor_size_threshold) -> bool {
              // force env initialization to register opset
              InitEnv();
-             SimplifyPath(in_path, out_path, skip_optimizers, constant_folding,
-                          shape_inference, tensor_size_threshold);
+             SimplifyPath(*executor, in_path, out_path, skip_optimizers,
+                          constant_folding, shape_inference,
+                          tensor_size_threshold);
              return true;
-           }, "in_path"_a, "out_path"_a,
+           }, "executor"_a, "in_path"_a, "out_path"_a,
            "skip_optimizers"_a.none(),
            "constant_folding"_a = true, "shape_inference"_a = true,
            "tensor_size_threshold"_a)
-      .def("_set_model_executor",
-           [](std::shared_ptr<PyModelExecutor> executor) {
-             ModelExecutor::set_instance(std::move(executor));
-           }, "executor"_a.none())
       .def("_list_optimizers",
            []() {
             py::list ret;

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -199,6 +199,7 @@ def simplify(
             model_bytes = None
             raise EncodeError("Message larger than 2GiB")
         model_opt_bytes = C.simplify(
+            _get_model_executor(),
             model_bytes,
             skipped_optimizers,
             not skip_constant_folding,
@@ -221,6 +222,7 @@ def simplify(
                 save_as_external_data=True,
             )
             check_ok = C.simplify_path(
+                _get_model_executor(),
                 os.path.join(tmpdirname, 'model.onnx'),
                 os.path.join(tmpdirname, 'opt.onnx'),
                 skipped_optimizers,
@@ -256,6 +258,21 @@ class PyModelExecutor(C.ModelExecutor):
             onnx.numpy_helper.from_array(x).SerializeToString()
             for x in outputs.values()
         ]
+
+
+_model_executor: Optional[PyModelExecutor] = None
+
+
+def _get_model_executor() -> PyModelExecutor:
+    """Return the process-wide Python model executor, creating it on demand.
+
+    The executor is passed explicitly to the C++ ``simplify``/``simplify_path``
+    entry points instead of being registered as a global instance.
+    """
+    global _model_executor
+    if _model_executor is None:
+        _model_executor = PyModelExecutor()
+    return _model_executor
 
 
 def main():

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -29,8 +29,6 @@ struct Config {
 
 Config config;
 
-std::shared_ptr<const ModelExecutor> ModelExecutor::instance_ = nullptr;
-
 bool IsOfficialOp(const std::string& domain, const std::string& op) {
   if (domain != "ai.onnx" && domain != "ai.onnx.ml" && !domain.empty()) {
     return false;
@@ -239,10 +237,11 @@ struct CppModelExecutor : public ModelExecutor {
   }
 };
 
-static int __register_cpp_model_executor __attribute__((unused)) = []() {
-  ModelExecutor::set_instance(std::make_shared<CppModelExecutor>());
-  return 0;
-}();
+std::shared_ptr<const ModelExecutor> GetBuiltinModelExecutor() {
+  static std::shared_ptr<const ModelExecutor> executor =
+      std::make_shared<CppModelExecutor>();
+  return executor;
+}
 
 void InitEnv() { GetEnv(); }
 #else
@@ -251,7 +250,8 @@ void InitEnv() {
 }
 #endif
 
-std::vector<onnx::TensorProto> RunOp(onnx::ModelProto& model,
+std::vector<onnx::TensorProto> RunOp(const ModelExecutor& executor,
+                                     onnx::ModelProto& model,
                                      const onnx::NodeProto& op) {
   std::vector<std::string> input_names;
   std::vector<onnx::TensorProto> input_tps;
@@ -302,16 +302,17 @@ std::vector<onnx::TensorProto> RunOp(onnx::ModelProto& model,
 
   using namespace ONNX_NAMESPACE::optimization;
   VLOG(1) << "Running node: " << op;
-  auto output_tps = ModelExecutor::Run(op_model, input_tps);
+  auto output_tps = executor._Run(op_model, input_tps);
   for (size_t i = 0; i < op.output_size(); i++) {
     output_tps[i].set_name(op.output(i));
   }
   return output_tps;
 }
 
-void RunOpAndAddInitializer(onnx::ModelProto& model,
+void RunOpAndAddInitializer(const ModelExecutor& executor,
+                            onnx::ModelProto& model,
                             const onnx::NodeProto& op) {
-  const auto output_tps = RunOp(model, op);
+  const auto output_tps = RunOp(executor, model, op);
   for (const auto& output_tp : output_tps) {
     *model.mutable_graph()->add_initializer() = output_tp;
   }
@@ -440,7 +441,8 @@ onnx::ModelProto _InferShapes(const onnx::ModelProto& model) {
   return result;
 }
 
-onnx::ModelProto _FoldConstant(const onnx::ModelProto& model) {
+onnx::ModelProto _FoldConstant(const ModelExecutor& executor,
+                               const onnx::ModelProto& model) {
   const auto& tmp = model;
   {
     onnx::ModelProto model;
@@ -448,7 +450,7 @@ onnx::ModelProto _FoldConstant(const onnx::ModelProto& model) {
     auto [const_nodes, non_const_nodes] = GetConstantNodes(model);
     for (const auto& x : const_nodes) {
       try {
-        RunOpAndAddInitializer(model, x);
+        RunOpAndAddInitializer(executor, model, x);
       } catch (const std::exception& e) {
         std::cerr << "WARNING: failed to run \"" << x.op_type() <<
           "\" op (name is \"" << x.name() << "\"), skip..." << std::endl;
@@ -513,7 +515,7 @@ onnx::ModelProto Identity(const onnx::ModelProto& model) { return model; }
 void Check(const onnx::ModelProto& model) { onnx::checker::check_model(model); }
 
 onnx::ModelProto Simplify(
-    const onnx::ModelProto& model,
+    const ModelExecutor& executor, const onnx::ModelProto& model,
     std::optional<std::vector<std::string>> skip_optimizers,
     bool constant_folding, bool shape_inference, size_t tensor_size_threshold) {
   Check(model);
@@ -534,7 +536,14 @@ onnx::ModelProto Simplify(
     config.optimizer_passes = passes;
   }
 
-  auto FoldConstant = constant_folding ? _FoldConstant : Identity;
+  std::function<onnx::ModelProto(const onnx::ModelProto&)> FoldConstant;
+  if (constant_folding) {
+    FoldConstant = [&executor](const onnx::ModelProto& model) {
+      return _FoldConstant(executor, model);
+    };
+  } else {
+    FoldConstant = Identity;
+  }
   auto InferShapes = shape_inference ? _InferShapes : Identity;
 
   int fixed_point_iters =
@@ -560,15 +569,16 @@ onnx::ModelProto Simplify(
   return sim_model;
 }
 
-void SimplifyPath(const std::string& in_path, const std::string& out_path,
+void SimplifyPath(const ModelExecutor& executor, const std::string& in_path,
+                  const std::string& out_path,
                   std::optional<std::vector<std::string>> skip_optimizers,
                   bool constant_folding, bool shape_inference,
                   size_t tensor_size_threshold) {
   onnx::ModelProto model;
   onnx::optimization::loadModel(&model, in_path, true);
 
-  model = Simplify(model, skip_optimizers, constant_folding, shape_inference,
-                   tensor_size_threshold);
+  model = Simplify(executor, model, skip_optimizers, constant_folding,
+                   shape_inference, tensor_size_threshold);
 
   onnx::optimization::saveModel(&model, out_path, true, "");
 }

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -8,35 +8,28 @@
 
 struct ModelExecutor {
   virtual ~ModelExecutor() = default;
-  static void set_instance(std::shared_ptr<const ModelExecutor> instance) {
-    instance_ = std::move(instance);
-  }
-  static std::vector<onnx::TensorProto> Run(
-      const onnx::ModelProto& model,
-      const std::vector<onnx::TensorProto>& inputs) {
-    if (instance_ == nullptr) {
-      throw std::runtime_error("empty instance");
-    }
-    return instance_->_Run(model, inputs);
-  }
 
   // public it for pybind11
   virtual std::vector<onnx::TensorProto> _Run(
       const onnx::ModelProto& model,
       const std::vector<onnx::TensorProto>& inputs) const = 0;
-
- private:
-  static std::shared_ptr<const ModelExecutor> instance_;
 };
 
 void InitEnv();
 
+#ifndef NO_BUILTIN_ORT
+// Returns the built-in model executor backed by ONNX Runtime. Only available
+// when onnxsim is built with the built-in ONNX Runtime.
+std::shared_ptr<const ModelExecutor> GetBuiltinModelExecutor();
+#endif
+
 onnx::ModelProto Simplify(
-    const onnx::ModelProto& model,
+    const ModelExecutor& executor, const onnx::ModelProto& model,
     std::optional<std::vector<std::string>> skip_optimizers,
     bool constant_folding, bool shape_inference, size_t tensor_size_threshold);
 
-void SimplifyPath(const std::string& in_path, const std::string& out_path,
+void SimplifyPath(const ModelExecutor& executor, const std::string& in_path,
+                  const std::string& out_path,
                   std::optional<std::vector<std::string>> skip_optimizers,
                   bool constant_folding, bool shape_inference,
                   size_t tensor_size_threshold);

--- a/scripts/convertmodel/interface.cpp
+++ b/scripts/convertmodel/interface.cpp
@@ -22,6 +22,7 @@ em::val onnxsimplify_export(const std::string& data, em::val skip_optimizers, bo
     onnx::ModelProto optimized;
     try {
         optimized = Simplify(
+            *GetBuiltinModelExecutor(),
             xmodel,
             em::vecFromJSArray<std::string>(skip_optimizers),
             constant_folding,


### PR DESCRIPTION
Replace the static ModelExecutor::instance_ singleton (and set_instance/Run static helpers) with an explicit executor argument threaded through Simplify, SimplifyPath, and the constant-folding call chain.

- ModelExecutor is now a pure interface.
- C++/wasm entry points obtain the built-in ORT executor via GetBuiltinModelExecutor().
- The Python side passes its PyModelExecutor per call, dropping the global _set_model_executor registration and the atexit teardown workaround.


Claude-Session: https://claude.ai/code/session_01USXpwH2ts2krgocQgt199U