### PR TITLE
Preserve dynamic dims on non-positive overwrite and keep doc_strings

### DIFF
--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -97,6 +97,34 @@ def check_and_update_input_shapes(model: onnx.ModelProto, input_shapes: Optional
 DEFAULT_TENSOR_SIZE_THRESHOLDHOLD = '1.5GB'
 
 
+def _snapshot_doc_strings(model: onnx.ModelProto) -> dict:
+    """Capture the ``doc_string`` fields that the C++ optimizer discards."""
+    return {
+        "model": model.doc_string,
+        "graph": model.graph.doc_string,
+        "inputs": {i.name: i.doc_string for i in model.graph.input},
+        "outputs": {o.name: o.doc_string for o in model.graph.output},
+    }
+
+
+def _restore_doc_strings(model: onnx.ModelProto, snapshot: dict) -> None:
+    """Restore doc strings captured by :func:`_snapshot_doc_strings`.
+
+    Only fields that the optimizer left empty are restored, so any doc string
+    produced by the optimizer itself takes precedence.
+    """
+    if not model.doc_string and snapshot["model"]:
+        model.doc_string = snapshot["model"]
+    if not model.graph.doc_string and snapshot["graph"]:
+        model.graph.doc_string = snapshot["graph"]
+    for ipt in model.graph.input:
+        if not ipt.doc_string and snapshot["inputs"].get(ipt.name):
+            ipt.doc_string = snapshot["inputs"][ipt.name]
+    for opt in model.graph.output:
+        if not opt.doc_string and snapshot["outputs"].get(opt.name):
+            opt.doc_string = snapshot["outputs"][opt.name]
+
+
 def simplify(
     model: Union[str, onnx.ModelProto],
     check_n: int = 0,
@@ -175,11 +203,21 @@ def simplify(
         for ipt in model.graph.input:
             if ipt.name == name:
                 for i, dim in enumerate(ipt.type.tensor_type.shape.dim):
-                    dim.dim_value = input_shape[i]
+                    # A non-positive value means "keep the original (possibly
+                    # dynamic) dimension" rather than hardcoding an invalid size
+                    # such as 0, which would make the model impossible to run
+                    # (see GitHub issue #237).
+                    if input_shape[i] > 0:
+                        dim.dim_value = input_shape[i]
     if unused_output is not None:
         model = remove_unused_output(model, unused_output)
     if not mutable_initializer and model.ir_version >= 4:
         model = remove_initializer_from_input(model)
+
+    # The C++ optimizer re-serializes the graph and drops the `doc_string`
+    # fields on the model, graph and input/output value infos. Snapshot them
+    # here so they can be restored on the simplified model (GitHub issue #428).
+    doc_strings = _snapshot_doc_strings(model)
 
     def parse_size(size: str) -> int:
         m = re.fullmatch(r"([\d.]+)\s*([KMGT]?B)", size.strip(), re.I)
@@ -236,6 +274,7 @@ def simplify(
                 check_n, test_input_shapes, input_data, custom_lib
             )
             model_opt = onnx.load(os.path.join(tmpdirname, 'opt.onnx'))
+    _restore_doc_strings(model_opt, doc_strings)
     return model_opt, check_ok
 
 

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -341,6 +341,53 @@ def test_do_not_fold_random_like_op():
     assert any(n.op_type == 'RandomNormalLike' for n in sim_model.graph.node)
 
 
+def test_overwrite_input_shape_ignores_non_positive():
+    # A non-positive value in overwrite_input_shapes must not be written to the
+    # graph as a literal (e.g. 0) dimension; the original dimension should be
+    # kept instead so the simplified model stays runnable (GitHub issue #237).
+    x = onnx.helper.make_tensor_value_info(
+        'input', onnx.TensorProto.FLOAT, ['N', 3, 'H', 'W'])
+    y = onnx.helper.make_tensor_value_info(
+        'output', onnx.TensorProto.FLOAT, ['N', 3, 'H', 'W'])
+    node = onnx.helper.make_node('Relu', ['input'], ['output'])
+    graph_def = onnx.helper.make_graph(
+        [node], 'test_overwrite_input_shape_ignores_non_positive', [x], [y])
+    model = onnx.helper.make_model(
+        graph_def, opset_imports=[onnx.helper.make_opsetid("", 13)])
+
+    sim_model, _ = onnxsim.simplify(
+        model, overwrite_input_shapes={'input': [1, 3, 0, 0]})
+    dims = sim_model.graph.input[0].type.tensor_type.shape.dim
+    # The positive value is applied, the non-positive ones are left untouched
+    # (the original dynamic dim params are kept, never set to 0).
+    assert dims[0].dim_value == 1
+    assert dims[2].dim_param == 'H'
+    assert dims[3].dim_param == 'W'
+
+
+def test_preserve_doc_strings():
+    # onnxsim must not drop the doc_string fields of the model / graph / inputs
+    # / outputs while simplifying (GitHub issue #428).
+    x = onnx.helper.make_tensor_value_info('X', onnx.TensorProto.FLOAT, [1, 4])
+    x.doc_string = "input documentation"
+    y = onnx.helper.make_tensor_value_info('Y', onnx.TensorProto.FLOAT, [1, 4])
+    y.doc_string = "output documentation"
+    node = onnx.helper.make_node('Relu', ['X'], ['Y'])
+    graph_def = onnx.helper.make_graph(
+        [node], 'test_preserve_doc_strings', [x], [y])
+    graph_def.doc_string = "graph documentation"
+    model = onnx.helper.make_model(
+        graph_def, opset_imports=[onnx.helper.make_opsetid("", 13)])
+    model.doc_string = "model documentation"
+
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    assert sim_model.doc_string == "model documentation"
+    assert sim_model.graph.doc_string == "graph documentation"
+    assert sim_model.graph.input[0].doc_string == "input documentation"
+    assert sim_model.graph.output[0].doc_string == "output documentation"
+
+
 def test_perform_optimization_false():
     def _create_dummy_model():
         class MockModel(torch.nn.Module):


### PR DESCRIPTION
Two fixes to the Python simplify() wrapper, each with a regression test:

- overwrite_input_shapes: skip non-positive values (e.g. 0) instead of writing them as literal dim_value, which produced an unrunnable model. Non-positive now means "keep the original (possibly dynamic) dim". Fixes #237.

- doc_string: snapshot the model/graph/input/output doc_string fields before the C++ optimizer runs and restore any it dropped, so simplify() no longer strips documentation. Fixes #428.


Claude-Session: https://claude.ai/code/session_01KNoHqJFrXxguUJHMu9LRaH