### PR TITLE
Enable faulthandler in CLI to diagnose native segfaults

### DIFF
--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -315,6 +315,17 @@ def _get_model_executor() -> PyModelExecutor:
 
 
 def main():
+    # onnxsim runs models through native libraries (onnx shape inference,
+    # onnxoptimizer and onnxruntime). A malformed or unusual model can make one
+    # of them crash with a segmentation fault instead of a Python exception,
+    # which is very hard to diagnose from a bare "Segmentation fault" message
+    # (see GitHub issue #426). Enabling faulthandler makes such native crashes
+    # dump a Python traceback to stderr, pinpointing the phase that crashed.
+    import faulthandler
+
+    if not faulthandler.is_enabled():
+        faulthandler.enable()
+
     parser = argparse.ArgumentParser()
     parser.add_argument("input_model", help="Input ONNX model")
     parser.add_argument("output_model", help="Output ONNX model")


### PR DESCRIPTION
onnxsim drives native libraries (onnx shape inference, onnxoptimizer and onnxruntime) during simplification. A model that triggers a bug in one of them can crash the process with a segmentation fault instead of a Python exception, leaving users with only a bare "Segmentation fault" message and no indication of which phase failed (see issue #426).

Enable faulthandler at the start of the CLI so that such native crashes dump a Python traceback to stderr, pinpointing the phase that crashed (shape inference vs constant folding vs onnxruntime). It has no effect on the normal happy path and does not change any behavior.


Claude-Session: https://claude.ai/code/session_01HeAjBfyjFYmrZQ2G9ZrgB9