### PR TITLE
Fix cmake build target argument in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -197,7 +197,7 @@ class cmake_build(setuptools.Command):
             print(f"Run command {cmake_args}")
             subprocess.check_call(cmake_args)
 
-            build_args = [CMAKE, '--build', os.curdir, '--target onnxsim_cpp2py_export']
+            build_args = [CMAKE, '--build', os.curdir, '--target', 'onnxsim_cpp2py_export']
             print(f"Run command {build_args}")
             subprocess.check_call(build_args)
 


### PR DESCRIPTION
## Summary

Fixes #225.

`setup.py` passed the cmake build target as a single string list element:

```python
build_args = [CMAKE, '--build', os.curdir, '--target onnxsim_cpp2py_export']
```

`subprocess.check_call` treats each list element as one distinct argument (no shell splitting), so cmake received the literal argument `--target onnxsim_cpp2py_export` (with an embedded space) instead of the `--target` flag followed by its `onnxsim_cpp2py_export` value. cmake can't parse that, which breaks the build.

## Change

Split the combined string into two separate list elements:

```python
build_args = [CMAKE, '--build', os.curdir, '--target', 'onnxsim_cpp2py_export']
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUjpAhdpbxn6TYYeND21CF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUjpAhdpbxn6TYYeND21CF)_