### PR TITLE
Support shape deduction for QLinearAdd and related QNN contrib ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 # configure onnx-optimizer after onnxruntime, because they both depend on onnx and onnxruntime has its own flags for onnx
 add_subdirectory(third_party/onnx-optimizer EXCLUDE_FROM_ALL)
 
-add_library(onnxsim onnxsim/onnxsim.cpp)
+add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/contrib_schemas.cpp)
 if (ONNXSIM_BUILTIN_ORT)
   target_include_directories(onnxsim PRIVATE ${ONNXRUNTIME_INCLUDE_DIR})
 endif()

--- a/onnxsim/contrib_schemas.cpp
+++ b/onnxsim/contrib_schemas.cpp
@@ -1,0 +1,223 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "contrib_schemas.h"
+
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "onnx/defs/schema.h"
+#include "onnx/defs/shape_inference.h"
+
+namespace onnxsim {
+
+namespace {
+
+constexpr const char* kMSDomain = "com.microsoft";
+
+using onnx::InferenceContext;
+using onnx::OpSchema;
+
+// Shape/type inference for the element-wise binary quantized ops (QLinearAdd,
+// QLinearMul). Inputs are laid out as
+//   A, A_scale, A_zero_point, B, B_scale, B_zero_point, C_scale, C_zero_point
+// so the two data tensors that determine the output shape are inputs 0 and 3.
+void QLinearBinaryShapeInference(InferenceContext& ctx) {
+  // The output is quantized to the same element type as the first operand.
+  onnx::propagateElemTypeFromInputToOutput(ctx, 0, 0);
+  if (onnx::hasInputShape(ctx, 0) && onnx::hasInputShape(ctx, 3)) {
+    onnx::bidirectionalBroadcastShapeInference(
+        ctx.getInputType(0)->tensor_type().shape(),
+        ctx.getInputType(3)->tensor_type().shape(),
+        *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
+  }
+}
+
+// Shape/type inference for QLinearConcat. Inputs are
+//   Y_scale, Y_zero_point, (T, T_scale, T_zero_point)+
+// The output element type follows Y_zero_point (input 1) and the shape is the
+// concatenation of the data tensors (inputs 2, 5, 8, ...) along `axis`.
+void QLinearConcatShapeInference(InferenceContext& ctx) {
+  onnx::propagateElemTypeFromInputToOutput(ctx, 1, 0);
+
+  const auto* axis_attr = ctx.getAttribute("axis");
+  if (axis_attr == nullptr || !axis_attr->has_i()) {
+    return;
+  }
+  int64_t axis = axis_attr->i();
+
+  std::vector<size_t> data_indices;
+  for (size_t i = 2; i < ctx.getNumInputs(); i += 3) {
+    data_indices.push_back(i);
+  }
+  if (data_indices.empty()) {
+    return;
+  }
+
+  // Every data tensor must have a known rank and the ranks must agree.
+  int rank = -1;
+  for (size_t idx : data_indices) {
+    if (!onnx::hasInputShape(ctx, idx)) {
+      return;
+    }
+    const int cur_rank =
+        ctx.getInputType(idx)->tensor_type().shape().dim_size();
+    if (rank == -1) {
+      rank = cur_rank;
+    } else if (rank != cur_rank) {
+      // Inconsistent ranks: leave the output shape unset rather than guessing.
+      return;
+    }
+  }
+  if (rank <= 0) {
+    return;
+  }
+  if (axis < 0) {
+    axis += rank;
+  }
+  if (axis < 0 || axis >= rank) {
+    return;
+  }
+
+  auto* output_shape =
+      ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+  output_shape->clear_dim();
+  for (int i = 0; i < rank; ++i) {
+    output_shape->add_dim();
+  }
+
+  bool axis_dim_known = true;
+  int64_t axis_dim_sum = 0;
+  for (size_t idx : data_indices) {
+    const auto& shape = ctx.getInputType(idx)->tensor_type().shape();
+    for (int d = 0; d < rank; ++d) {
+      const auto& dim = shape.dim(d);
+      if (d == axis) {
+        if (dim.has_dim_value()) {
+          axis_dim_sum += dim.dim_value();
+        } else {
+          axis_dim_known = false;
+        }
+        continue;
+      }
+      // Non-axis dimensions must match across inputs; keep the most specific
+      // information we can (a concrete value, otherwise a symbolic name).
+      auto* out_dim = output_shape->mutable_dim(d);
+      if (!out_dim->has_dim_value() && dim.has_dim_value()) {
+        out_dim->set_dim_value(dim.dim_value());
+      } else if (!out_dim->has_dim_value() && !out_dim->has_dim_param() &&
+                 dim.has_dim_param()) {
+        out_dim->set_dim_param(dim.dim_param());
+      }
+    }
+  }
+  if (axis_dim_known) {
+    output_shape->mutable_dim(axis)->set_dim_value(axis_dim_sum);
+  }
+}
+
+// Registers `schema` unless an equivalent schema is already known. Duplicate
+// registration is turned into a no-op instead of an error so the function stays
+// safe to run alongside a build that already provides these schemas.
+void RegisterIfAbsent(OpSchema&& schema) {
+  const std::string name = schema.Name();
+  if (onnx::OpSchemaRegistry::Schema(name, kMSDomain) != nullptr) {
+    return;
+  }
+  onnx::RegisterSchema(std::move(schema), /*opset_version_to_load=*/1,
+                       /*fail_duplicate_schema=*/false,
+                       /*fail_with_exception=*/false);
+}
+
+OpSchema MakeQLinearBinarySchema(const char* name) {
+  return OpSchema()
+      .SetName(name)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .SetDoc("Quantized element-wise binary op contributed by ONNX Runtime.")
+      .Input(0, "A", "First quantized operand.", "T")
+      .Input(1, "A_scale", "Scale of A.", "tensor(float)")
+      .Input(2, "A_zero_point", "Zero point of A.", "T", OpSchema::Optional)
+      .Input(3, "B", "Second quantized operand.", "T")
+      .Input(4, "B_scale", "Scale of B.", "tensor(float)")
+      .Input(5, "B_zero_point", "Zero point of B.", "T", OpSchema::Optional)
+      .Input(6, "C_scale", "Scale of the output C.", "tensor(float)")
+      .Input(7, "C_zero_point", "Zero point of the output C.", "T",
+             OpSchema::Optional)
+      .Output(0, "C", "Quantized result.", "T")
+      .TypeConstraint("T", {"tensor(uint8)", "tensor(int8)"},
+                      "Constrain input and output to 8-bit integer tensors.")
+      .TypeAndShapeInferenceFunction(QLinearBinaryShapeInference);
+}
+
+OpSchema MakeQLinearUnarySchema(const char* name, bool has_alpha) {
+  OpSchema schema;
+  schema.SetName(name)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .SetDoc("Quantized element-wise unary op contributed by ONNX Runtime.")
+      .Input(0, "X", "Quantized input.", "T")
+      .Input(1, "X_scale", "Scale of X.", "tensor(float)")
+      .Input(2, "X_zero_point", "Zero point of X.", "T", OpSchema::Optional)
+      .Input(3, "Y_scale", "Scale of the output Y.", "tensor(float)")
+      .Input(4, "Y_zero_point", "Zero point of the output Y.", "T",
+             OpSchema::Optional)
+      .Output(0, "Y", "Quantized output.", "T")
+      .TypeConstraint("T", {"tensor(uint8)", "tensor(int8)"},
+                      "Constrain input and output to 8-bit integer tensors.")
+      .TypeAndShapeInferenceFunction(onnx::propagateShapeAndTypeFromFirstInput);
+  if (has_alpha) {
+    schema.Attr("alpha", "Coefficient of leakage.", onnx::AttributeProto::FLOAT,
+                0.01f);
+  }
+  return schema;
+}
+
+OpSchema MakeQLinearConcatSchema() {
+  return OpSchema()
+      .SetName("QLinearConcat")
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .SetDoc("Quantized concatenation contributed by ONNX Runtime.")
+      .Attr("axis", "Axis to concatenate on.", onnx::AttributeProto::INT,
+            /*required=*/true)
+      .Input(0, "Y_scale", "Scale of the output Y.", "TF")
+      .Input(1, "Y_zero_point", "Zero point of the output Y.", "T8")
+      .Input(2, "inputs",
+             "Repeated (tensor, scale, zero_point) triples to concatenate.",
+             "TV", OpSchema::Variadic, /*is_homogeneous=*/false)
+      .Output(0, "Y", "Concatenated quantized result.", "T8")
+      .TypeConstraint("T8", {"tensor(uint8)", "tensor(int8)"},
+                      "Constrain quantized tensors to 8-bit integers.")
+      .TypeConstraint("TF", {"tensor(float)"}, "Constrain scales to float.")
+      .TypeConstraint("TV", {"tensor(uint8)", "tensor(int8)", "tensor(float)"},
+                      "Constrain the variadic inputs.")
+      .TypeAndShapeInferenceFunction(QLinearConcatShapeInference);
+}
+
+void RegisterAll() {
+  // The custom domain must be known to the schema registry before any schema
+  // in it can be registered.
+  auto& domain_range = onnx::OpSchemaRegistry::DomainToVersionRange::Instance();
+  if (domain_range.Map().count(kMSDomain) == 0) {
+    domain_range.AddDomainToVersion(kMSDomain, /*min_version=*/1,
+                                    /*max_version=*/1);
+  }
+
+  RegisterIfAbsent(MakeQLinearBinarySchema("QLinearAdd"));
+  RegisterIfAbsent(MakeQLinearBinarySchema("QLinearMul"));
+  RegisterIfAbsent(MakeQLinearUnarySchema("QLinearSigmoid", /*has_alpha=*/false));
+  RegisterIfAbsent(MakeQLinearUnarySchema("QLinearLeakyRelu", /*has_alpha=*/true));
+  RegisterIfAbsent(MakeQLinearConcatSchema());
+}
+
+}  // namespace
+
+void RegisterContribOpSchemas() {
+  static std::once_flag once;
+  std::call_once(once, RegisterAll);
+}
+
+}  // namespace onnxsim

--- a/onnxsim/contrib_schemas.h
+++ b/onnxsim/contrib_schemas.h
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+namespace onnxsim {
+
+// Import operator schemas for a set of ONNX Runtime "com.microsoft" contrib
+// operators (QLinearAdd and related quantized/QNN ops) into the ONNX operator
+// schema registry.
+//
+// ONNX's own shape inference only knows about operators that have a schema
+// registered in the ONNX registry. Quantized models produced by ONNX Runtime
+// use contrib operators such as QLinearAdd, whose schemas live outside ONNX,
+// so shape deduction stops as soon as it reaches one of them
+// (https://github.com/onnxsim/onnxsim/issues/245). Registering the schemas
+// here lets onnx::shape_inference::InferShapes propagate shapes and types
+// through these ops, which in turn unlocks further simplification.
+//
+// The registration is performed at most once per process and never overrides a
+// schema that is already registered (for example when onnxsim is built with the
+// built-in ONNX Runtime, which registers its own contrib schemas). It is safe
+// to call this function multiple times and from any of the simplification entry
+// points.
+void RegisterContribOpSchemas();
+
+}  // namespace onnxsim

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -13,6 +13,7 @@
 #include "onnxruntime/core/common/endian.h"
 #include "onnxruntime/core/session/onnxruntime_cxx_api.h"
 #endif
+#include "contrib_schemas.h"
 #include "onnx/common/file_utils.h"
 #include "onnx/defs/printer.h"
 #include "onnx/defs/schema.h"
@@ -518,6 +519,10 @@ onnx::ModelProto Simplify(
     const ModelExecutor& executor, const onnx::ModelProto& model,
     std::optional<std::vector<std::string>> skip_optimizers,
     bool constant_folding, bool shape_inference, size_t tensor_size_threshold) {
+  // Make shape inference aware of ONNX Runtime's quantized contrib operators
+  // (QLinearAdd and friends) so shape deduction does not stop at them.
+  onnxsim::RegisterContribOpSchemas();
+
   Check(model);
 
   config.tensor_size_threshold = tensor_size_threshold;

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -388,6 +388,125 @@ def test_preserve_doc_strings():
     assert sim_model.graph.output[0].doc_string == "output documentation"
 
 
+def _make_scalar_initializer(name: str, value, dtype) -> onnx.TensorProto:
+    return onnx.numpy_helper.from_array(np.array(value, dtype=dtype), name)
+
+
+def _quant_params():
+    return [
+        _make_scalar_initializer("s", 0.01, np.float32),
+        _make_scalar_initializer("zp", 128, np.uint8),
+    ]
+
+
+def _build_contrib_model(nodes, inputs, outputs, initializer):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer=initializer)
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[
+            onnx.helper.make_opsetid("", 13),
+            onnx.helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 9
+    return model
+
+
+def _value_info_shape(model: onnx.ModelProto, name: str):
+    for vi in model.graph.value_info:
+        if vi.name == name:
+            tensor_type = vi.type.tensor_type
+            if not tensor_type.HasField("shape"):
+                return None
+            return [d.dim_value for d in tensor_type.shape.dim]
+    return None
+
+
+def test_qlinear_add_shape_inference():
+    # QLinearAdd is an ONNX Runtime "com.microsoft" contrib op. Without a schema
+    # registered for it, ONNX shape inference stops and the intermediate tensor
+    # never gets a shape (GitHub issue #245).
+    nodes = [
+        onnx.helper.make_node(
+            "QLinearAdd",
+            ["A", "s", "zp", "B", "s", "zp", "s", "zp"],
+            ["C"],
+            domain="com.microsoft",
+        ),
+        onnx.helper.make_node("DequantizeLinear", ["C", "s", "zp"], ["out"]),
+    ]
+    inputs = [
+        onnx.helper.make_tensor_value_info("A", onnx.TensorProto.UINT8, [1, 3, 16, 16]),
+        onnx.helper.make_tensor_value_info("B", onnx.TensorProto.UINT8, [1, 3, 16, 16]),
+    ]
+    outputs = [
+        onnx.helper.make_tensor_value_info(
+            "out", onnx.TensorProto.FLOAT, [1, 3, 16, 16]
+        )
+    ]
+    model = _build_contrib_model(nodes, inputs, outputs, _quant_params())
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    assert _value_info_shape(sim_model, "C") == [1, 3, 16, 16]
+
+
+def test_qlinear_concat_shape_inference():
+    nodes = [
+        onnx.helper.make_node(
+            "QLinearConcat",
+            ["s", "zp", "A", "s", "zp", "B", "s", "zp"],
+            ["C"],
+            domain="com.microsoft",
+            axis=1,
+        ),
+        onnx.helper.make_node("DequantizeLinear", ["C", "s", "zp"], ["out"]),
+    ]
+    inputs = [
+        onnx.helper.make_tensor_value_info("A", onnx.TensorProto.UINT8, [1, 3, 16, 16]),
+        onnx.helper.make_tensor_value_info("B", onnx.TensorProto.UINT8, [1, 5, 16, 16]),
+    ]
+    outputs = [
+        onnx.helper.make_tensor_value_info(
+            "out", onnx.TensorProto.FLOAT, [1, 8, 16, 16]
+        )
+    ]
+    model = _build_contrib_model(nodes, inputs, outputs, _quant_params())
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    assert _value_info_shape(sim_model, "C") == [1, 8, 16, 16]
+
+
+def test_unknown_contrib_op_is_tolerated():
+    # Registering schemas for the supported quantized ops must not make the
+    # checker reject other, unregistered "com.microsoft" contrib operators.
+    nodes = [
+        onnx.helper.make_node(
+            "QLinearAdd",
+            ["A", "s", "zp", "B", "s", "zp", "s", "zp"],
+            ["C"],
+            domain="com.microsoft",
+        ),
+        onnx.helper.make_node(
+            "SomeUnknownContribOp", ["C"], ["D"], domain="com.microsoft"
+        ),
+        onnx.helper.make_node("DequantizeLinear", ["C", "s", "zp"], ["out"]),
+    ]
+    inputs = [
+        onnx.helper.make_tensor_value_info("A", onnx.TensorProto.UINT8, [1, 3, 16, 16]),
+        onnx.helper.make_tensor_value_info("B", onnx.TensorProto.UINT8, [1, 3, 16, 16]),
+    ]
+    outputs = [
+        onnx.helper.make_tensor_value_info(
+            "out", onnx.TensorProto.FLOAT, [1, 3, 16, 16]
+        ),
+        onnx.helper.make_tensor_value_info("D", onnx.TensorProto.UINT8, [1, 3, 16, 16]),
+    ]
+    model = _build_contrib_model(nodes, inputs, outputs, _quant_params())
+    sim_model, check_ok = onnxsim.simplify(model, skip_constant_folding=True)
+    assert check_ok
+    assert _value_info_shape(sim_model, "C") == [1, 3, 16, 16]
+
+
 def test_perform_optimization_false():
     def _create_dummy_model():
         class MockModel(torch.nn.Module):


### PR DESCRIPTION
## Summary

Fixes #245.

ONNX shape inference only propagates through operators that have a schema registered in the ONNX operator registry. Quantized models produced by ONNX Runtime use `com.microsoft` contrib operators such as `QLinearAdd`, whose schemas live *outside* ONNX, so shape deduction stopped as soon as it reached one of them — making simplification of quantized models impossible.

This PR imports schemas for these external contrib operators into the ONNX schema registry, each with a type/shape inference function, so `onnx::shape_inference::InferShapes` can deduce shapes and types through them.

## Operators covered

| Operator | Inference |
|---|---|
| `QLinearAdd`, `QLinearMul` | element-wise binary, bidirectional broadcast of the two data operands |
| `QLinearSigmoid`, `QLinearLeakyRelu` | element-wise unary, propagate shape/type from first input |
| `QLinearConcat` | concatenation along `axis` |

## Design notes

- Registration is performed once per process at the start of `Simplify`, first declaring the `com.microsoft` domain in the registry.
- It **never overrides a schema that is already registered**, so it stays safe alongside a build that bundles ONNX Runtime (which registers its own contrib schemas).
- The ONNX checker only verifies operators that have a registered schema, so other, unregistered `com.microsoft` contrib ops keep being tolerated — no regression for models that use them.

## Testing

Built the extension locally and verified end-to-end:

- `QLinearAdd` now yields `C: [1, 3, 16, 16]` (previously no shape was deduced).
- Broadcasting (`QLinearMul` `[1,3,16,16] × [1,3,1,1] → [1,3,16,16]`), the unary ops, and `QLinearConcat` (`3 + 5 → 8` on axis 1) all deduce correctly.
- Dynamic/symbolic input shapes are preserved; a shapeless input does not produce an invalid `value_info`; a model containing an unregistered contrib op still simplifies; and a normal float model still constant-folds with `check_n` verification passing.

Added three regression tests in `tests/test_python_api.py` (`test_qlinear_add_shape_inference`, `test_qlinear_concat_shape_inference`, `test_unknown_contrib_op_is_tolerated`).

## Scope

This focuses on the element-wise and concat QNN ops that the "shape deduction stops at QLinearAdd" trace is about. Ops that need attribute-driven inference (e.g. `QLinearAveragePool`, `QGemm`) are not included, but the new module is structured so they are straightforward to add later.

## Files

- `onnxsim/contrib_schemas.cpp`, `onnxsim/contrib_schemas.h` (new)
- `onnxsim/onnxsim.cpp` — call registration at the start of `Simplify`
- `CMakeLists.txt` — build the new source
- `tests/test_python_api.py` — regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1Uqucr35qS1TzpSFe69JQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1Uqucr35qS1TzpSFe69JQ)_