### PR TITLE
Keep unfoldable const nodes in topological order during constant folding

### DIFF
--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -449,18 +449,34 @@ onnx::ModelProto _FoldConstant(const ModelExecutor& executor,
     onnx::ModelProto model;
     model.CopyFrom(tmp);
     auto [const_nodes, non_const_nodes] = GetConstantNodes(model);
+    (void)non_const_nodes;
+    // Outputs of const nodes that were successfully folded into initializers.
+    std::set<std::string> folded_outputs;
     for (const auto& x : const_nodes) {
       try {
         RunOpAndAddInitializer(executor, model, x);
+        for (const auto& output : x.output()) {
+          folded_outputs.insert(output);
+        }
       } catch (const std::exception& e) {
         std::cerr << "WARNING: failed to run \"" << x.op_type() <<
           "\" op (name is \"" << x.name() << "\"), skip..." << std::endl;
-        non_const_nodes.push_back(x);
       }
     }
-    model.mutable_graph()->clear_node();
-    for (const auto& x : non_const_nodes) {
-      *model.mutable_graph()->add_node() = x;
+    // Rebuild the node list in its original topological order, dropping only
+    // the const nodes that were successfully folded into initializers. A const
+    // node that failed to fold must keep its original position: appending it to
+    // the end can place it after a non-const consumer (e.g. a Loop reading a
+    // SequenceEmpty output), which breaks topological sorting and makes the
+    // resulting model fail onnx's checker (issues #238, #335, #352).
+    google::protobuf::RepeatedPtrField<onnx::NodeProto> original_nodes;
+    original_nodes.Swap(model.mutable_graph()->mutable_node());
+    for (auto& node : original_nodes) {
+      const bool folded = node.output_size() > 0 &&
+                          folded_outputs.count(node.output(0)) > 0;
+      if (!folded) {
+        *model.mutable_graph()->add_node() = std::move(node);
+      }
     }
     return model;
   }

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -5,6 +5,7 @@ import onnxruntime
 import onnxsim
 import os
 
+from onnx import helper, TensorProto
 from typing import Optional
 from onnxsim.test_utils import export_simplify_and_check_by_python_api
 
@@ -177,3 +178,29 @@ def test_ext():
         sim_model, check_ok = onnxsim.simplify(model_fn, check_n=0)
         module = None
         assert check_ok
+
+
+def test_unfoldable_const_node_keeps_topological_order():
+    # A const node (all-constant inputs) that fails to fold must keep its
+    # original position. Here SequenceEmpty is treated as a const node but can't
+    # be folded into an initializer; its output feeds a non-const consumer
+    # (SequenceInsert). If the failed node were moved to the end of the graph it
+    # would land after its consumer and break topological sorting, making the
+    # output fail onnx's checker (issues #238, #335, #352).
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [2])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [2])
+    nodes = [
+        helper.make_node("SequenceEmpty", [], ["seq"]),
+        helper.make_node("SequenceInsert", ["seq", "x"], ["seq2"]),
+        helper.make_node("ConcatFromSequence", ["seq2"], ["y"], axis=0, new_axis=0),
+    ]
+    graph = helper.make_graph(nodes, "g", [x], [y])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    onnx.checker.check_model(model)
+
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    # Output must remain a valid, topologically sorted graph.
+    onnx.checker.check_model(sim_model)
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert op_types.index("SequenceEmpty") < op_types.index("SequenceInsert")


### PR DESCRIPTION
In _FoldConstant, a node with all-constant inputs that failed to fold (e.g. SequenceEmpty, whose output is a sequence and cannot become a tensor initializer) was appended to the end of the node list. That placed it after non-const consumers of its output (Loop, SequenceInsert, MatMul, ...), breaking topological order so the simplified model failed onnx's checker with "Nodes in a graph must be topologically sorted".

Rebuild the node list in its original topological order instead, dropping only the const nodes that were successfully folded into initializers. Failed const nodes keep their original position.

Fixes #238, #335, #352.


Claude-Session: https://claude.ai/code/session_01EaK3CrupmCh3DA7U8KMtAT