### PR TITLE
Support NVIDIA ModelOpt fp8 QDQ models (issue #348)

### DIFF
--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -97,6 +97,71 @@ def check_and_update_input_shapes(model: onnx.ModelProto, input_shapes: Optional
 DEFAULT_TENSOR_SIZE_THRESHOLDHOLD = '1.5GB'
 
 
+# ONNX ``TensorProto`` element types that onnxoptimizer's tensor-value hashing
+# (``cse_util.h``) knows how to hash. Any other type makes those passes raise
+# ``RuntimeError: no supported data type: <N>``. We enumerate the *supported*
+# types (rather than the unsupported ones) so that element types added to ONNX
+# in the future are treated as unhashable by default instead of silently
+# crashing the optimizer.
+_CSE_HASHABLE_ELEM_TYPES = frozenset({
+    onnx.TensorProto.UNDEFINED,
+    onnx.TensorProto.BOOL,
+    onnx.TensorProto.INT8,
+    onnx.TensorProto.INT16,
+    onnx.TensorProto.INT32,
+    onnx.TensorProto.INT64,
+    onnx.TensorProto.UINT8,
+    onnx.TensorProto.UINT16,
+    onnx.TensorProto.UINT32,
+    onnx.TensorProto.UINT64,
+    onnx.TensorProto.FLOAT,
+    onnx.TensorProto.DOUBLE,
+    onnx.TensorProto.FLOAT16,
+    onnx.TensorProto.BFLOAT16,
+    onnx.TensorProto.COMPLEX64,
+    onnx.TensorProto.COMPLEX128,
+    onnx.TensorProto.STRING,
+})
+
+# onnxoptimizer passes that hash tensor *values* via ``cse_util.h``. They crash
+# on tensors whose element type they cannot hash -- for example the
+# ``float8_e4m3fn`` zero points in NVIDIA ModelOpt fp8 QDQ models (see GitHub
+# issue #348), or int4/uint4/float8 tensors in general.
+_TENSOR_VALUE_HASHING_OPTIMIZERS = (
+    "eliminate_common_subexpression",
+    "eliminate_duplicate_initializer",
+)
+
+
+def _iter_tensor_data_types(graph: onnx.GraphProto):
+    """Yield the ``data_type`` of every tensor stored inside ``graph``.
+
+    Covers initializers, ``Constant`` (and other) tensor/tensors attributes and
+    recurses into subgraphs, i.e. all the places onnxoptimizer might hash a
+    tensor value.
+    """
+    for initializer in graph.initializer:
+        yield initializer.data_type
+    for node in graph.node:
+        for attr in node.attribute:
+            if attr.HasField("t"):
+                yield attr.t.data_type
+            for tensor in attr.tensors:
+                yield tensor.data_type
+            if attr.HasField("g"):
+                yield from _iter_tensor_data_types(attr.g)
+            for subgraph in attr.graphs:
+                yield from _iter_tensor_data_types(subgraph)
+
+
+def _has_cse_unhashable_tensor(model: onnx.ModelProto) -> bool:
+    """Whether ``model`` contains a tensor onnxoptimizer's CSE cannot hash."""
+    return any(
+        data_type not in _CSE_HASHABLE_ELEM_TYPES
+        for data_type in _iter_tensor_data_types(model.graph)
+    )
+
+
 def _snapshot_doc_strings(model: onnx.ModelProto) -> dict:
     """Capture the ``doc_string`` fields that the C++ optimizer discards."""
     return {
@@ -219,6 +284,31 @@ def simplify(
         model = remove_unused_output(model, unused_output)
     if not mutable_initializer and model.ir_version >= 4:
         model = remove_initializer_from_input(model)
+
+    # onnxoptimizer's common-subexpression / duplicate-initializer passes hash
+    # tensor values and crash with "no supported data type: <N>" on element
+    # types they cannot hash, such as the float8 zero points produced by NVIDIA
+    # ModelOpt fp8 QDQ models (GitHub issue #348). When such a tensor is present
+    # we transparently skip those two passes so the rest of the simplification
+    # still runs, instead of failing outright. ``skipped_optimizers is None``
+    # means "skip every optimizer", so there is nothing to add in that case.
+    if skipped_optimizers is not None and _has_cse_unhashable_tensor(model):
+        added = [
+            opt for opt in _TENSOR_VALUE_HASHING_OPTIMIZERS
+            if opt not in skipped_optimizers
+        ]
+        if added:
+            skipped_optimizers.extend(added)
+            print(
+                Text(
+                    "The model contains tensors with element types that "
+                    "onnxoptimizer cannot hash (e.g. float8/int4 in NVIDIA "
+                    "ModelOpt fp8 QDQ models). Skipping the optimizers "
+                    f"{added} to avoid a crash; all other simplifications "
+                    "still run.",
+                    style="bold magenta",
+                )
+            )
 
     # The C++ optimizer re-serializes the graph and drops the `doc_string`
     # fields on the model, graph and input/output value infos. Snapshot them

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -204,3 +204,61 @@ def test_unfoldable_const_node_keeps_topological_order():
     onnx.checker.check_model(sim_model)
     op_types = [n.op_type for n in sim_model.graph.node]
     assert op_types.index("SequenceEmpty") < op_types.index("SequenceInsert")
+
+
+def test_fp8_qdq_model():
+    # Regression test for GitHub issue #348. NVIDIA ModelOpt emits fp8 QDQ
+    # models whose QuantizeLinear/DequantizeLinear zero points use the
+    # ``float8_e4m3fn`` element type (17). onnxoptimizer's tensor-value hashing
+    # passes (eliminate_common_subexpression / eliminate_duplicate_initializer)
+    # cannot hash such tensors and used to abort the whole simplification with
+    # "RuntimeError: no supported data type: 17". onnxsim now detects these
+    # tensors and transparently skips the offending passes instead of crashing.
+    def fp8_zero_point(name: str) -> onnx.TensorProto:
+        # A single float8_e4m3fn zero, expressed as its raw byte so the test
+        # does not depend on ml_dtypes.
+        return helper.make_tensor(name, TensorProto.FLOAT8E4M3FN, [], b"\x00", raw=True)
+
+    weight = helper.make_tensor(
+        "W", TensorProto.FLOAT, [4, 3], [0.1 * i for i in range(12)]
+    )
+    w_scale = helper.make_tensor("w_scale", TensorProto.FLOAT, [], [0.05])
+    a_scale = helper.make_tensor("a_scale", TensorProto.FLOAT, [], [0.1])
+
+    nodes = [
+        # activation QDQ (dynamic input, must be preserved)
+        helper.make_node("QuantizeLinear", ["X", "a_scale", "a_zp"], ["X_q"]),
+        helper.make_node("DequantizeLinear", ["X_q", "a_scale", "a_zp"], ["X_dq"]),
+        # weight QDQ (constant inputs) plus a duplicated weight zero point to
+        # exercise eliminate_duplicate_initializer as well.
+        helper.make_node("QuantizeLinear", ["W", "w_scale", "w_zp"], ["W_q"]),
+        helper.make_node("DequantizeLinear", ["W_q", "w_scale", "w_zp2"], ["W_dq"]),
+        helper.make_node("MatMul", ["X_dq", "W_dq"], ["Y"]),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "fp8_qdq",
+        [helper.make_tensor_value_info("X", TensorProto.FLOAT, [2, 4])],
+        [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [2, 3])],
+        [
+            weight,
+            w_scale,
+            a_scale,
+            fp8_zero_point("a_zp"),
+            fp8_zero_point("w_zp"),
+            fp8_zero_point("w_zp2"),
+        ],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+
+    # Must not raise "no supported data type: 17".
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+    # The fp8 QDQ structure must survive simplification.
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert op_types.count("QuantizeLinear") == 2
+    assert op_types.count("DequantizeLinear") == 2
+    assert "MatMul" in op_types


### PR DESCRIPTION
NVIDIA ModelOpt emits fp8 quantize/dequantize (QDQ) models whose QuantizeLinear/DequantizeLinear zero points use the float8_e4m3fn element type (17). Running onnxsim on such a model aborted with:

    RuntimeError: no supported data type: 17

The failure comes from onnxoptimizer's tensor-value hashing, shared by the eliminate_common_subexpression and eliminate_duplicate_initializer passes (cse_util.h). Their hash switch only covers the "classic" element types and throws on float8 (and int4/uint4) tensors. Upstream onnxoptimizer -- even master -- still lacks these types, so the fix has to live in onnxsim.

Detect tensors whose element type onnxoptimizer cannot hash (scanning initializers and Constant/tensor attributes, recursing into subgraphs) and transparently add those two passes to the skip list, printing an informational message. All other simplification -- shape inference, constant folding (QDQ nodes are already excluded from folding) and correctness checking -- runs unchanged, so fp8 QDQ models now simplify instead of crashing.

Add a regression test that builds an fp8 QDQ MatMul model (activation and weight QDQ, with a duplicated fp8 zero point to also exercise eliminate_duplicate_initializer) and asserts simplification succeeds and preserves the QDQ structure.