### PR TITLE
Skip crash-prone eliminate_if_with_const_cond pass (issue #452)

### DIFF
--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -543,12 +543,28 @@ onnx::ModelProto Simplify(
 
   config.tensor_size_threshold = tensor_size_threshold;
   config.optimizer_passes.clear();
+  // The onnxoptimizer pass "eliminate_if_with_const_cond" folds an `If` whose
+  // condition is a compile-time constant by inlining the taken branch. It
+  // segfaults when that branch's output is produced by an initializer instead
+  // of a node -- a state onnxsim itself reaches when the earlier
+  // "extract_constant_to_initializer" pass turns a subgraph `Constant` into a
+  // subgraph initializer. The pass builds its output map only from subgraph
+  // node outputs, so the branch output is missing and it dereferences a null
+  // Value. Always skip it so simplification degrades to leaving the `If` in
+  // place rather than aborting the whole process. Actually folding a
+  // constant-condition `If` is tracked separately (GitHub issue #275).
+  // See GitHub issue #452.
+  static const std::set<std::string> always_skip_passes = {
+      "eliminate_if_with_const_cond"};
   // skip_optimizers == nullopt means skiping all optimizers, so
   // config.optimizer_passes is empty
   if (skip_optimizers) {
     std::vector<std::string> passes;
     const auto all_passes = onnx::optimization::GetFuseAndEliminationPass();
     for (const auto& pass : all_passes) {
+      if (always_skip_passes.count(pass) > 0) {
+        continue;
+      }
       if (std::find(skip_optimizers->begin(), skip_optimizers->end(), pass) ==
           skip_optimizers->end()) {
         passes.push_back(pass);

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -204,3 +204,33 @@ def test_unfoldable_const_node_keeps_topological_order():
     onnx.checker.check_model(sim_model)
     op_types = [n.op_type for n in sim_model.graph.node]
     assert op_types.index("SequenceEmpty") < op_types.index("SequenceInsert")
+
+
+def test_if_with_const_cond_does_not_segfault():
+    # An `If` whose condition is a constant, with branches that each just
+    # produce a constant, used to crash simplify() with a segfault (exit 139).
+    # onnxsim's constant folding turns the branch `Constant` nodes into subgraph
+    # initializers, and the onnxoptimizer "eliminate_if_with_const_cond" pass
+    # then dereferenced a null value while inlining the taken branch. simplify()
+    # must instead complete and return a valid model (GitHub issue #452).
+    tv = helper.make_tensor("tv", TensorProto.FLOAT, [2], [1.0, 2.0])
+    fv = helper.make_tensor("fv", TensorProto.FLOAT, [2], [3.0, 4.0])
+    then_b = helper.make_graph(
+        [helper.make_node("Constant", [], ["to"], value=tv)], "tb", [],
+        [helper.make_tensor_value_info("to", TensorProto.FLOAT, [2])])
+    else_b = helper.make_graph(
+        [helper.make_node("Constant", [], ["fo"], value=fv)], "fb", [],
+        [helper.make_tensor_value_info("fo", TensorProto.FLOAT, [2])])
+    if_node = helper.make_node(
+        "If", ["c"], ["Y"], then_branch=then_b, else_branch=else_b)
+    graph = helper.make_graph(
+        [if_node], "g", [],
+        [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [2])],
+        [helper.make_tensor("c", TensorProto.BOOL, [], [True])])
+    model = helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 13)])
+    onnx.checker.check_model(model)
+
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    onnx.checker.check_model(sim_model)


### PR DESCRIPTION
simplify() segfaulted (exit 139) on a model with an `If` node whose condition is a constant and whose branches each just produce a constant.

Root cause is in the vendored onnxoptimizer pass
"eliminate_if_with_const_cond". onnxsim's optimizer first runs "extract_constant_to_initializer", which turns each branch's `Constant` node into a subgraph initializer. "eliminate_if_with_const_cond" then inlines the taken branch but builds its output map only from subgraph *node* outputs, so the branch output (now an initializer) is absent from that map and the pass dereferences a null Value while rewiring the `If` outputs.

The bug lives in a submodule that tracks upstream onnx/optimizer (and is not fixed upstream), and a native segfault cannot be caught in-process, so guard against it by never running this pass. Simplification now degrades to leaving the `If` in place instead of aborting the process, which is the behaviour the issue asks for. Actually folding a constant-condition `If` remains tracked separately in issue #275.

Add a regression test that builds the minimal reproducer and asserts simplify() completes and returns a valid model.

Fixes https://github.com/onnxsim/onnxsim/issues/452

Claude-Session: https://claude.ai/code/session_015SWadB1EaDwAuu1FJPG1e7