### PR TITLE
Add Rust wrapper for onnxsim

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,7 @@ jobs:
   lint:
     name: fmt / clippy (no native build)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       ONNXSIM_NO_BUILD: "1"
     steps:
@@ -34,6 +35,9 @@ jobs:
   build:
     name: build + smoke test (native)
     runs-on: ubuntu-latest
+    # The first build compiles ONNX Runtime, onnx, and protobuf from source
+    # (sccache warms subsequent runs), so allow generous headroom.
+    timeout-minutes: 120
     env:
       CMAKE_GENERATOR: Ninja
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
@@ -48,6 +52,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install build tools
         run: sudo apt-get update && sudo apt-get install -y ninja-build
+      # ONNX Runtime source is not a git submodule; onnxsim-sys downloads it on
+      # demand. Cache it so it is fetched at most once per version.
+      - name: Cache ONNX Runtime source
+        uses: actions/cache@v4
+        with:
+          path: third_party/onnxruntime-1.27.1
+          key: onnxruntime-src-1.27.1
       - name: Build the workspace (compiles and links the native library)
         run: cargo build --release --workspace
       - name: Run tests (unit + linked integration tests)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,56 @@
+name: Rust wrapper
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: rust
+
+jobs:
+  # Fast checks that do not require building the native ONNX Runtime stack.
+  # These only type-check/lint (no linking), so the native library is not needed.
+  lint:
+    name: fmt / clippy (no native build)
+    runs-on: ubuntu-latest
+    env:
+      ONNXSIM_NO_BUILD: "1"
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - name: rustfmt
+        run: cargo fmt --all --check
+      - name: clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+  # Full build that compiles the C API and links it against onnxsim.
+  build:
+    name: build + smoke test (native)
+    runs-on: ubuntu-latest
+    env:
+      CMAKE_GENERATOR: Ninja
+      CMAKE_CXX_COMPILER_LAUNCHER: sccache
+      SCCACHE_GHA_ENABLED: "on"
+      ACTIONS_CACHE_SERVICE_V2: "on"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y ninja-build
+      - name: Build the workspace (compiles and links the native library)
+        run: cargo build --release --workspace
+      - name: Run tests (unit + linked integration tests)
+        run: |
+          cargo test --release --workspace
+          cargo test --release -- --ignored list_optimizers_is_non_empty

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,7 @@ onnxsim/version.py
 # Rust
 /rust/target/
 rust/Cargo.lock
+
+# ONNX Runtime source fetched on demand by the Rust build (see build_wasm.sh)
+/third_party/onnxruntime-*/
+/third_party/v*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,7 @@ test*.py
 
 .setuptools-cmake-build/
 onnxsim/version.py
+
+# Rust
+/rust/target/
+rust/Cargo.lock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,17 @@ if (ONNXSIM_C_API)
   if (NOT ONNXSIM_BUILTIN_ORT)
     message(FATAL_ERROR "ONNXSIM_C_API requires ONNXSIM_BUILTIN_ORT=ON")
   endif()
+  # In the builtin-ORT path onnx_optimizer is built as a shared library
+  # (build_ort.cmake sets BUILD_SHARED_LIBS ON), but it inherits the
+  # project-wide "hidden" visibility preset, so it exports none of its symbols.
+  # onnxsim/onnxsim_c call into it across the shared-library boundary (e.g.
+  # OptimizeFixed, GetFuseAndEliminationPass), which then fail to resolve at
+  # runtime with "undefined symbol". Restore default visibility so those symbols
+  # are exported. (The Python build avoids this by linking it statically.)
+  if (TARGET onnx_optimizer)
+    set_target_properties(onnx_optimizer PROPERTIES CXX_VISIBILITY_PRESET default
+                                                    VISIBILITY_INLINES_HIDDEN FALSE)
+  endif()
   add_library(onnxsim_c SHARED onnxsim/capi/onnxsim_c_api.cpp)
   target_link_libraries(onnxsim_c PRIVATE onnxsim onnx_optimizer onnx)
   target_include_directories(onnxsim_c PUBLIC onnxsim/capi)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,13 @@ endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if (ONNXSIM_BUILTIN_ORT)
+  # The top-level project only enables CXX, but ONNX Runtime (added below as a
+  # subdirectory) compiles C and assembly sources. Enable the languages it needs
+  # before configuring it. Emscripten's toolchain handles this on its own.
+  if (NOT EMSCRIPTEN)
+    enable_language(C)
+    enable_language(ASM)
+  endif()
   include(cmake/build_ort.cmake)
   if (EMSCRIPTEN)
     set(ORT_NAME onnxruntime_webassembly)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CMAKE_CXX_STANDARD 20)
 option(ONNXSIM_PYTHON "" OFF)
 option(ONNXSIM_BUILTIN_ORT "" ON)
 option(ONNXSIM_WASM_NODE "For node (enable NODERAWFS etc.)" OFF)
+option(ONNXSIM_C_API "Build the C ABI shared library used by the Rust wrapper and other FFI consumers" OFF)
 
 if (ONNXSIM_PYTHON AND EMSCRIPTEN)
   message(STATUS "python and emscripten cannot be built at the same time")
@@ -77,6 +78,19 @@ if (EMSCRIPTEN)
   target_link_libraries(onnxsim_bin embind "-Wl,--whole-archive" onnxsim "-Wl,--no-whole-archive")
 else()
   target_link_libraries(onnxsim_bin onnxsim)
+endif()
+
+if (ONNXSIM_C_API)
+  if (NOT ONNXSIM_BUILTIN_ORT)
+    message(FATAL_ERROR "ONNXSIM_C_API requires ONNXSIM_BUILTIN_ORT=ON")
+  endif()
+  add_library(onnxsim_c SHARED onnxsim/capi/onnxsim_c_api.cpp)
+  target_link_libraries(onnxsim_c PRIVATE onnxsim onnx_optimizer onnx)
+  target_include_directories(onnxsim_c PUBLIC onnxsim/capi)
+  # The exported symbols opt back into default visibility via ONNXSIM_C_API in
+  # the header, so the project-wide "hidden" preset keeps everything else local.
+  set_target_properties(onnxsim_c PROPERTIES C_VISIBILITY_PRESET hidden
+                                             CXX_VISIBILITY_PRESET hidden)
 endif()
 
 if (ONNXSIM_PYTHON)

--- a/onnxsim/capi/onnxsim_c_api.cpp
+++ b/onnxsim/capi/onnxsim_c_api.cpp
@@ -1,0 +1,173 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#define ONNXSIM_C_API_BUILD
+#include "onnxsim_c_api.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "onnx/proto_utils.h"
+#include "onnxoptimizer/optimize.h"
+#include "onnxsim.h"
+
+#ifdef NO_BUILTIN_ORT
+#error "The onnxsim C API requires the built-in ONNX Runtime (ONNXSIM_BUILTIN_ORT=ON)."
+#endif
+
+namespace {
+
+// Duplicate a std::string into a malloc'd, NUL-terminated C string so the
+// caller can free it with std::free (via onnxsim_free_string). Returns nullptr
+// on allocation failure.
+char* DupCString(const std::string& s) {
+  char* p = static_cast<char*>(std::malloc(s.size() + 1));
+  if (p != nullptr) {
+    std::memcpy(p, s.data(), s.size());
+    p[s.size()] = '\0';
+  }
+  return p;
+}
+
+void SetError(char** out_error, const std::string& message) {
+  if (out_error != nullptr) {
+    *out_error = DupCString(message);
+  }
+}
+
+// Translate the (pointer array, is_null) FFI encoding into the optional vector
+// the C++ core expects.
+std::optional<std::vector<std::string>> BuildSkipOptimizers(
+    const char* const* skip_optimizers, size_t num_skip_optimizers,
+    int skip_optimizers_is_null) {
+  if (skip_optimizers_is_null != 0) {
+    return std::nullopt;
+  }
+  std::vector<std::string> passes;
+  passes.reserve(num_skip_optimizers);
+  for (size_t i = 0; i < num_skip_optimizers; ++i) {
+    const char* name = skip_optimizers != nullptr ? skip_optimizers[i] : nullptr;
+    passes.emplace_back(name != nullptr ? name : "");
+  }
+  return passes;
+}
+
+}  // namespace
+
+extern "C" {
+
+OnnxsimStatus onnxsim_simplify(const void* model_data, size_t model_size,
+                               const char* const* skip_optimizers,
+                               size_t num_skip_optimizers,
+                               int skip_optimizers_is_null, int constant_folding,
+                               int shape_inference, size_t tensor_size_threshold,
+                               void** out_data, size_t* out_size,
+                               char** out_error) {
+  if (out_data != nullptr) {
+    *out_data = nullptr;
+  }
+  if (out_size != nullptr) {
+    *out_size = 0;
+  }
+  if (out_error != nullptr) {
+    *out_error = nullptr;
+  }
+  if (model_data == nullptr || out_data == nullptr || out_size == nullptr) {
+    SetError(out_error, "onnxsim_simplify: required argument is NULL");
+    return ONNXSIM_ERROR;
+  }
+  try {
+    // Force env initialization to register opsets, matching the Python binding.
+    InitEnv();
+    onnx::ModelProto model;
+    if (!ParseProtoFromBytes(&model, static_cast<const char*>(model_data),
+                             model_size)) {
+      SetError(out_error, "failed to parse ONNX ModelProto from input bytes");
+      return ONNXSIM_ERROR;
+    }
+    onnx::ModelProto result = Simplify(
+        *GetBuiltinModelExecutor(), model,
+        BuildSkipOptimizers(skip_optimizers, num_skip_optimizers,
+                            skip_optimizers_is_null),
+        constant_folding != 0, shape_inference != 0, tensor_size_threshold);
+
+    std::string out;
+    if (!result.SerializeToString(&out)) {
+      SetError(out_error, "failed to serialize the simplified ModelProto");
+      return ONNXSIM_ERROR;
+    }
+    // malloc(0) may return nullptr; hand back a distinct non-null pointer so the
+    // caller can always free it and can rely on out_data != NULL on success.
+    void* buffer = std::malloc(out.size() != 0 ? out.size() : 1);
+    if (buffer == nullptr) {
+      SetError(out_error, "out of memory while copying the simplified model");
+      return ONNXSIM_ERROR;
+    }
+    std::memcpy(buffer, out.data(), out.size());
+    *out_data = buffer;
+    *out_size = out.size();
+    return ONNXSIM_OK;
+  } catch (const std::exception& e) {
+    SetError(out_error, e.what());
+    return ONNXSIM_ERROR;
+  } catch (...) {
+    SetError(out_error, "unknown error while simplifying the model");
+    return ONNXSIM_ERROR;
+  }
+}
+
+OnnxsimStatus onnxsim_simplify_path(const char* in_path, const char* out_path,
+                                    const char* const* skip_optimizers,
+                                    size_t num_skip_optimizers,
+                                    int skip_optimizers_is_null,
+                                    int constant_folding, int shape_inference,
+                                    size_t tensor_size_threshold,
+                                    char** out_error) {
+  if (out_error != nullptr) {
+    *out_error = nullptr;
+  }
+  if (in_path == nullptr || out_path == nullptr) {
+    SetError(out_error, "onnxsim_simplify_path: in_path/out_path is NULL");
+    return ONNXSIM_ERROR;
+  }
+  try {
+    InitEnv();
+    SimplifyPath(*GetBuiltinModelExecutor(), in_path, out_path,
+                 BuildSkipOptimizers(skip_optimizers, num_skip_optimizers,
+                                    skip_optimizers_is_null),
+                 constant_folding != 0, shape_inference != 0,
+                 tensor_size_threshold);
+    return ONNXSIM_OK;
+  } catch (const std::exception& e) {
+    SetError(out_error, e.what());
+    return ONNXSIM_ERROR;
+  } catch (...) {
+    SetError(out_error, "unknown error while simplifying the model");
+    return ONNXSIM_ERROR;
+  }
+}
+
+char* onnxsim_list_optimizers(void) {
+  try {
+    std::string joined;
+    for (const auto& pass : onnx::optimization::GetFuseAndEliminationPass()) {
+      if (!joined.empty()) {
+        joined.push_back('\n');
+      }
+      joined.append(pass);
+    }
+    return DupCString(joined);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+void onnxsim_free_buffer(void* data) { std::free(data); }
+
+void onnxsim_free_string(char* data) { std::free(data); }
+
+}  // extern "C"

--- a/onnxsim/capi/onnxsim_c_api.h
+++ b/onnxsim/capi/onnxsim_c_api.h
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * A minimal, stable C ABI over the onnxsim C++ core. It exists so that other
+ * languages (e.g. Rust, Go, C) can drive the simplifier without dealing with
+ * C++ name mangling, exceptions, or the onnx::ModelProto type across the FFI
+ * boundary. Models are exchanged as serialized ONNX ModelProto bytes, exactly
+ * like the Python binding does.
+ */
+#ifndef ONNXSIM_C_API_H_
+#define ONNXSIM_C_API_H_
+
+#include <stddef.h>
+
+#if defined(_WIN32)
+#if defined(ONNXSIM_C_API_BUILD)
+#define ONNXSIM_C_API __declspec(dllexport)
+#else
+#define ONNXSIM_C_API __declspec(dllimport)
+#endif
+#else
+#define ONNXSIM_C_API __attribute__((visibility("default")))
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Return codes for every fallible entry point. */
+typedef enum OnnxsimStatus {
+  ONNXSIM_OK = 0,
+  ONNXSIM_ERROR = 1,
+} OnnxsimStatus;
+
+/*
+ * Simplify a model given as a serialized ONNX ModelProto.
+ *
+ * skip_optimizers semantics mirror the C++/Python API:
+ *   - skip_optimizers_is_null != 0  => skip ALL optimizer passes (no graph
+ *     optimization is performed); `skip_optimizers`/`num_skip_optimizers` are
+ *     ignored.
+ *   - skip_optimizers_is_null == 0  => run every fuse/elimination pass EXCEPT
+ *     the `num_skip_optimizers` passes named in `skip_optimizers` (pass 0 to
+ *     run all of them).
+ *
+ * constant_folding / shape_inference are treated as booleans (0 = false).
+ * tensor_size_threshold bounds the byte size of tensors produced by constant
+ * folding that are kept as initializers.
+ *
+ * On ONNXSIM_OK, *out_data / *out_size receive a newly allocated buffer holding
+ * the serialized simplified ModelProto; release it with onnxsim_free_buffer.
+ * On ONNXSIM_ERROR, *out_error receives a newly allocated, NUL-terminated
+ * message; release it with onnxsim_free_string. Either out_* pointer may be
+ * NULL if the caller does not want that value.
+ */
+ONNXSIM_C_API OnnxsimStatus onnxsim_simplify(
+    const void* model_data, size_t model_size,
+    const char* const* skip_optimizers, size_t num_skip_optimizers,
+    int skip_optimizers_is_null, int constant_folding, int shape_inference,
+    size_t tensor_size_threshold, void** out_data, size_t* out_size,
+    char** out_error);
+
+/*
+ * Same as onnxsim_simplify, but reads the input model from `in_path` and writes
+ * the simplified model to `out_path`. On failure, *out_error receives a message
+ * (free with onnxsim_free_string).
+ */
+ONNXSIM_C_API OnnxsimStatus onnxsim_simplify_path(
+    const char* in_path, const char* out_path,
+    const char* const* skip_optimizers, size_t num_skip_optimizers,
+    int skip_optimizers_is_null, int constant_folding, int shape_inference,
+    size_t tensor_size_threshold, char** out_error);
+
+/*
+ * Return the names of all available fuse/elimination optimizer passes as a
+ * single NUL-terminated string with one pass name per line ('\n' separated).
+ * Returns NULL on allocation failure. Release with onnxsim_free_string.
+ */
+ONNXSIM_C_API char* onnxsim_list_optimizers(void);
+
+/* Free a buffer returned via an out_data parameter. NULL is ignored. */
+ONNXSIM_C_API void onnxsim_free_buffer(void* data);
+
+/* Free a string returned via an out_error parameter or onnxsim_list_optimizers.
+ * NULL is ignored. */
+ONNXSIM_C_API void onnxsim_free_string(char* data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ONNXSIM_C_API_H_ */

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,12 @@
+[workspace]
+resolver = "2"
+members = ["onnxsim-sys", "onnxsim"]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/onnxsim/onnxsim"
+homepage = "https://github.com/onnxsim/onnxsim"
+authors = ["ONNX Simplifier contributors"]
+rust-version = "1.70"

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,115 @@
+# onnxsim — Rust bindings
+
+Safe Rust bindings to the [ONNX Simplifier](https://github.com/onnxsim/onnxsim).
+Simplify ONNX models (shape inference + constant folding) directly from Rust,
+using the same C++ core as the Python package and the CLI — no need to shell out
+to `onnxsim` or embed a Python interpreter.
+
+This addresses [onnxsim/onnxsim#292](https://github.com/onnxsim/onnxsim/issues/292),
+which requested a Rust wrapper so importers such as [Burn](https://github.com/tracel-ai/burn),
+[tract](https://github.com/sonos/tract) and [wonnx](https://github.com/webonnx/wonnx)
+can simplify models as part of their own pipelines.
+
+## Layout
+
+| Crate         | Role                                                             |
+| ------------- | --------------------------------------------------------------- |
+| `onnxsim`     | Safe, idiomatic API. Depend on this.                            |
+| `onnxsim-sys` | Raw FFI declarations + the build script that links the C core.  |
+
+Both wrap `onnxsim/capi/onnxsim_c_api.h`, a small C ABI over the C++ simplifier.
+
+## Usage
+
+```toml
+[dependencies]
+onnxsim = { git = "https://github.com/onnxsim/onnxsim", subdir = "rust/onnxsim" }
+```
+
+In-memory (serialized `ModelProto` bytes, e.g. from the `prost`/`protobuf`
+generated ONNX types, or straight from disk):
+
+```rust
+let model = std::fs::read("model.onnx")?;
+let simplified = onnxsim::simplify(&model)?;
+std::fs::write("model.opt.onnx", &simplified)?;
+```
+
+File in, file out:
+
+```rust
+onnxsim::simplify_path("model.onnx", "model.opt.onnx")?;
+```
+
+With options:
+
+```rust
+let opts = onnxsim::Options::new()
+    .shape_inference(false)                       // skip if it crashes on your model
+    .skip_optimizer("eliminate_nop_transpose")    // keep a specific pass off
+    .tensor_size_threshold(512 * 1024 * 1024);
+let simplified = onnxsim::simplify_with(&model, &opts)?;
+```
+
+List the optimizer passes you can skip:
+
+```rust
+for name in onnxsim::list_optimizers() {
+    println!("{name}");
+}
+```
+
+## Building the native library
+
+`onnxsim-sys` needs the `onnxsim_c` shared library. Its build script supports
+three modes:
+
+1. **From source (default).** Runs CMake to build the full onnxsim stack
+   (ONNX Runtime, onnx-optimizer, protobuf). This is heavy the first time and
+   requires the git submodules to be checked out:
+
+   ```sh
+   git submodule update --init --recursive
+   cargo build
+   ```
+
+2. **Pre-built library.** If you already have `onnxsim_c` (and its dependencies)
+   built, point the build script at the directory (or directories, `:`-separated)
+   holding the shared libraries:
+
+   ```sh
+   ONNXSIM_LIB_DIR=/path/to/libs cargo build
+   ```
+
+   To produce it from this repo:
+
+   ```sh
+   cmake -B build -DONNXSIM_C_API=ON -DONNXSIM_BUILTIN_ORT=ON
+   cmake --build build --target onnxsim_c
+   ```
+
+3. **Skip building** (for `cargo check` / docs.rs). Set `ONNXSIM_NO_BUILD=1`
+   (docs.rs sets `DOCS_RS` automatically). The crate type-checks but cannot be
+   linked into a runnable binary.
+
+### Environment variables
+
+| Variable             | Effect                                                        |
+| -------------------- | ------------------------------------------------------------- |
+| `ONNXSIM_NO_BUILD`   | Skip the native build entirely (type-check only).             |
+| `ONNXSIM_LIB_DIR`    | `:`-separated dirs holding a pre-built `onnxsim_c`.           |
+| `ONNXSIM_SOURCE_DIR` | Override the path to the onnxsim C++ source (default `../..`). |
+
+## Examples & tests
+
+```sh
+cargo run --example simplify -- input.onnx output.onnx
+cargo test          # pure-Rust unit tests run without the native lib
+```
+
+The integration test in `onnxsim/tests/` is ignored by default because it needs
+the linked native library and an ONNX model; see the file header to enable it.
+
+## License
+
+Apache-2.0, matching the parent project.

--- a/rust/README.md
+++ b/rust/README.md
@@ -65,13 +65,18 @@ for name in onnxsim::list_optimizers() {
 three modes:
 
 1. **From source (default).** Runs CMake to build the full onnxsim stack
-   (ONNX Runtime, onnx-optimizer, protobuf). This is heavy the first time and
-   requires the git submodules to be checked out:
+   (ONNX Runtime, onnx-optimizer, protobuf). This is heavy the first time. Check
+   out the git submodules first (for onnx-optimizer); the ONNX Runtime source is
+   not a submodule and is downloaded automatically on the first build:
 
    ```sh
    git submodule update --init --recursive
    cargo build
    ```
+
+   Set `ONNXSIM_SKIP_ORT_DOWNLOAD=1` to forbid the automatic download (the build
+   then requires the ONNX Runtime source to already be present at
+   `third_party/onnxruntime-1.27.1`).
 
 2. **Pre-built library.** If you already have `onnxsim_c` (and its dependencies)
    built, point the build script at the directory (or directories, `:`-separated)
@@ -96,9 +101,10 @@ three modes:
 
 | Variable             | Effect                                                        |
 | -------------------- | ------------------------------------------------------------- |
-| `ONNXSIM_NO_BUILD`   | Skip the native build entirely (type-check only).             |
-| `ONNXSIM_LIB_DIR`    | `:`-separated dirs holding a pre-built `onnxsim_c`.           |
-| `ONNXSIM_SOURCE_DIR` | Override the path to the onnxsim C++ source (default `../..`). |
+| `ONNXSIM_NO_BUILD`        | Skip the native build entirely (type-check only).        |
+| `ONNXSIM_LIB_DIR`         | `:`-separated dirs holding a pre-built `onnxsim_c`.      |
+| `ONNXSIM_SOURCE_DIR`      | Override the onnxsim C++ source path (default `../..`).  |
+| `ONNXSIM_SKIP_ORT_DOWNLOAD` | Forbid the automatic ONNX Runtime source download.    |
 
 ## Examples & tests
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -30,25 +30,35 @@ In-memory (serialized `ModelProto` bytes, e.g. from the `prost`/`protobuf`
 generated ONNX types, or straight from disk):
 
 ```rust
-let model = std::fs::read("model.onnx")?;
-let simplified = onnxsim::simplify(&model)?;
-std::fs::write("model.opt.onnx", &simplified)?;
+fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let model = std::fs::read("model.onnx")?;
+    let simplified = onnxsim::simplify(&model)?;
+    std::fs::write("model.opt.onnx", &simplified)?;
+    Ok(())
+}
 ```
 
 File in, file out:
 
 ```rust
-onnxsim::simplify_path("model.onnx", "model.opt.onnx")?;
+fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+    onnxsim::simplify_path("model.onnx", "model.opt.onnx")?;
+    Ok(())
+}
 ```
 
 With options:
 
 ```rust
-let opts = onnxsim::Options::new()
-    .shape_inference(false)                       // skip if it crashes on your model
-    .skip_optimizer("eliminate_nop_transpose")    // keep a specific pass off
-    .tensor_size_threshold(512 * 1024 * 1024);
-let simplified = onnxsim::simplify_with(&model, &opts)?;
+fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let model = std::fs::read("model.onnx")?;
+    let opts = onnxsim::Options::new()
+        .shape_inference(false)                       // skip if it crashes on your model
+        .skip_optimizer("eliminate_nop_transpose")    // keep a specific pass off
+        .tensor_size_threshold(512 * 1024 * 1024);
+    let simplified = onnxsim::simplify_with(&model, &opts)?;
+    Ok(())
+}
 ```
 
 List the optimizer passes you can skip:

--- a/rust/onnxsim-sys/Cargo.toml
+++ b/rust/onnxsim-sys/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "onnxsim-sys"
+description = "Low-level FFI bindings to the ONNX Simplifier (onnxsim) C API"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+links = "onnxsim_c"
+build = "build.rs"
+categories = ["external-ffi-bindings", "science"]
+keywords = ["onnx", "onnxsim", "ffi", "machine-learning"]
+
+[build-dependencies]
+cmake = "0.1"
+
+[lib]
+doctest = false

--- a/rust/onnxsim-sys/build.rs
+++ b/rust/onnxsim-sys/build.rs
@@ -9,15 +9,22 @@
 //!    the fast path for CI and for users who built onnxsim separately.
 //! 3. **From source** — otherwise, configure and build the C API target with
 //!    CMake. This compiles the full onnxsim stack (ONNX Runtime, onnx-optimizer,
-//!    protobuf) and is correspondingly slow the first time.
+//!    protobuf) and is correspondingly slow the first time. The ONNX Runtime
+//!    source (which onnxsim vendors by download rather than as a git submodule)
+//!    is fetched automatically if it is not already present.
 
 use std::env;
 use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// ONNX Runtime version onnxsim builds against; must match `cmake/build_ort.cmake`.
+const ONNXRUNTIME_VERSION: &str = "1.27.1";
 
 fn main() {
     println!("cargo:rerun-if-env-changed=ONNXSIM_NO_BUILD");
     println!("cargo:rerun-if-env-changed=ONNXSIM_LIB_DIR");
     println!("cargo:rerun-if-env-changed=ONNXSIM_SOURCE_DIR");
+    println!("cargo:rerun-if-env-changed=ONNXSIM_SKIP_ORT_DOWNLOAD");
 
     // Mode 1: skip building entirely (docs.rs / `cargo check`).
     if env::var_os("DOCS_RS").is_some() || env::var_os("ONNXSIM_NO_BUILD").is_some() {
@@ -44,6 +51,11 @@ fn main() {
         source_dir.join("onnxsim/capi/onnxsim_c_api.cpp").display()
     );
 
+    // onnxsim vendors ONNX Runtime by downloading a source tarball (see
+    // build_wasm.sh) rather than as a git submodule, so `submodules: recursive`
+    // does not provide it. Fetch it here if the builtin-ORT build needs it.
+    ensure_onnxruntime_source(&source_dir);
+
     let dst = cmake::Config::new(&source_dir)
         .define("ONNXSIM_C_API", "ON")
         .define("ONNXSIM_BUILTIN_ORT", "ON")
@@ -64,6 +76,97 @@ fn main() {
     // Expose where the shared libraries live so downstream crates / test
     // harnesses can set LD_LIBRARY_PATH if needed.
     println!("cargo:root={}", build_dir.display());
+}
+
+/// Ensure the ONNX Runtime source tree exists at
+/// `<source_dir>/third_party/onnxruntime-<version>`, downloading and extracting
+/// it if necessary. Mirrors the bootstrap in `build_wasm.sh`.
+fn ensure_onnxruntime_source(source_dir: &Path) {
+    let third_party = source_dir.join("third_party");
+    let ort_dir = third_party.join(format!("onnxruntime-{ONNXRUNTIME_VERSION}"));
+
+    // The `cmake` subdirectory is what `build_ort.cmake` adds; treat its
+    // presence as "already extracted".
+    if ort_dir.join("cmake").is_dir() {
+        return;
+    }
+
+    if env::var_os("ONNXSIM_SKIP_ORT_DOWNLOAD").is_some() {
+        panic!(
+            "ONNX Runtime source was not found at {} and ONNXSIM_SKIP_ORT_DOWNLOAD \
+             is set. Place the ONNX Runtime {} source there or unset the variable \
+             to allow an automatic download.",
+            ort_dir.display(),
+            ONNXRUNTIME_VERSION
+        );
+    }
+
+    let url = format!(
+        "https://github.com/microsoft/onnxruntime/archive/refs/tags/v{ONNXRUNTIME_VERSION}.zip"
+    );
+    // Download into OUT_DIR so a failed/partial download never pollutes the
+    // source tree, then extract into third_party/.
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let zip_path = out_dir.join(format!("onnxruntime-{ONNXRUNTIME_VERSION}.zip"));
+
+    println!(
+        "cargo:warning=Downloading ONNX Runtime {ONNXRUNTIME_VERSION} source (needed for the \
+         builtin-ORT build); this happens once."
+    );
+    download(&url, &zip_path);
+
+    std::fs::create_dir_all(&third_party)
+        .unwrap_or_else(|e| panic!("failed to create {}: {e}", third_party.display()));
+    extract_zip(&zip_path, &third_party);
+
+    if !ort_dir.join("cmake").is_dir() {
+        panic!(
+            "extracted ONNX Runtime but {} still does not exist; the archive layout may have \
+             changed",
+            ort_dir.join("cmake").display()
+        );
+    }
+}
+
+/// Download `url` to `dest`, trying `curl` then `wget`.
+fn download(url: &str, dest: &Path) {
+    let curl_ok = run(Command::new("curl")
+        .args(["-L", "--fail", "--silent", "--show-error", "-o"])
+        .arg(dest)
+        .arg(url));
+    if curl_ok {
+        return;
+    }
+    let wget_ok = run(Command::new("wget").arg("-q").arg("-O").arg(dest).arg(url));
+    if wget_ok {
+        return;
+    }
+    panic!(
+        "failed to download ONNX Runtime from {url}. Install curl or wget, or pre-place the \
+         extracted source at <repo>/third_party/onnxruntime-{ONNXRUNTIME_VERSION}."
+    );
+}
+
+/// Extract a zip archive into `dest_dir` using CMake's built-in `tar` (CMake is
+/// always available in this build path, and its `tar` handles zip archives).
+fn extract_zip(zip_path: &Path, dest_dir: &Path) {
+    let cmake_bin = env::var("CMAKE").unwrap_or_else(|_| "cmake".to_string());
+    let ok = run(Command::new(&cmake_bin)
+        .current_dir(dest_dir)
+        .args(["-E", "tar", "xf"])
+        .arg(zip_path));
+    if !ok {
+        panic!(
+            "failed to extract {} into {} using `{cmake_bin} -E tar`",
+            zip_path.display(),
+            dest_dir.display()
+        );
+    }
+}
+
+/// Run a command, returning true on a successful exit status.
+fn run(cmd: &mut Command) -> bool {
+    matches!(cmd.status(), Ok(status) if status.success())
 }
 
 /// Root of the onnxsim C++ project (the directory holding the top-level

--- a/rust/onnxsim-sys/build.rs
+++ b/rust/onnxsim-sys/build.rs
@@ -1,0 +1,135 @@
+//! Build script for `onnxsim-sys`.
+//!
+//! It links the `onnxsim_c` shared library, obtaining it in one of three ways:
+//!
+//! 1. **Skip** — if `DOCS_RS` or `ONNXSIM_NO_BUILD` is set, emit nothing and let
+//!    the crate type-check without linking (used by `cargo check` and docs.rs).
+//! 2. **Pre-built** — if `ONNXSIM_LIB_DIR` is set, link against a `onnxsim_c`
+//!    library already present in the listed directories (`:`-separated). This is
+//!    the fast path for CI and for users who built onnxsim separately.
+//! 3. **From source** — otherwise, configure and build the C API target with
+//!    CMake. This compiles the full onnxsim stack (ONNX Runtime, onnx-optimizer,
+//!    protobuf) and is correspondingly slow the first time.
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=ONNXSIM_NO_BUILD");
+    println!("cargo:rerun-if-env-changed=ONNXSIM_LIB_DIR");
+    println!("cargo:rerun-if-env-changed=ONNXSIM_SOURCE_DIR");
+
+    // Mode 1: skip building entirely (docs.rs / `cargo check`).
+    if env::var_os("DOCS_RS").is_some() || env::var_os("ONNXSIM_NO_BUILD").is_some() {
+        return;
+    }
+
+    // Mode 2: link against a pre-built library.
+    if let Some(lib_dirs) = env::var_os("ONNXSIM_LIB_DIR") {
+        for dir in env::split_paths(&lib_dirs) {
+            add_search_dir(&dir);
+        }
+        println!("cargo:rustc-link-lib=dylib=onnxsim_c");
+        return;
+    }
+
+    // Mode 3: build from source with CMake.
+    let source_dir = source_dir();
+    println!(
+        "cargo:rerun-if-changed={}",
+        source_dir.join("CMakeLists.txt").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        source_dir.join("onnxsim/capi/onnxsim_c_api.cpp").display()
+    );
+
+    let dst = cmake::Config::new(&source_dir)
+        .define("ONNXSIM_C_API", "ON")
+        .define("ONNXSIM_BUILTIN_ORT", "ON")
+        .define("ONNXSIM_PYTHON", "OFF")
+        .define("CMAKE_BUILD_TYPE", "Release")
+        // No install() rules exist for onnxsim_c, so build the target in place
+        // and locate the artifacts under the CMake build tree ourselves.
+        .build_target("onnxsim_c")
+        .very_verbose(false)
+        .build();
+
+    let build_dir = dst.join("build");
+    for dir in find_lib_dirs(&build_dir) {
+        add_search_dir(&dir);
+    }
+    println!("cargo:rustc-link-lib=dylib=onnxsim_c");
+
+    // Expose where the shared libraries live so downstream crates / test
+    // harnesses can set LD_LIBRARY_PATH if needed.
+    println!("cargo:root={}", build_dir.display());
+}
+
+/// Root of the onnxsim C++ project (the directory holding the top-level
+/// `CMakeLists.txt`). Defaults to two levels up from this crate.
+fn source_dir() -> PathBuf {
+    if let Some(dir) = env::var_os("ONNXSIM_SOURCE_DIR") {
+        return PathBuf::from(dir);
+    }
+    let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    manifest
+        .parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .expect("onnxsim-sys must live at <repo>/rust/onnxsim-sys")
+}
+
+/// Emit link-search and rpath directives for a directory.
+fn add_search_dir(dir: &Path) {
+    println!("cargo:rustc-link-search=native={}", dir.display());
+    // Help the dynamic loader find onnxsim_c and its transitive dependencies at
+    // runtime without requiring LD_LIBRARY_PATH to be set by hand.
+    if cfg!(any(target_os = "linux", target_os = "macos")) {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,{}", dir.display());
+    }
+}
+
+/// Recursively find directories under `root` that contain a built shared
+/// library, so both `onnxsim_c` and its transitive dependencies (ONNX Runtime,
+/// onnx, ...) can be found at link and run time.
+fn find_lib_dirs(root: &Path) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    collect_lib_dirs(root, &mut dirs);
+    dirs.sort();
+    dirs.dedup();
+    dirs
+}
+
+fn collect_lib_dirs(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+    let mut has_lib = false;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_lib_dirs(&path, out);
+        } else if !has_lib && is_shared_library(&path) {
+            has_lib = true;
+        }
+    }
+    if has_lib {
+        out.push(dir.to_path_buf());
+    }
+}
+
+fn is_shared_library(path: &Path) -> bool {
+    let name = match path.file_name().and_then(|n| n.to_str()) {
+        Some(name) => name,
+        None => return false,
+    };
+    if cfg!(target_os = "windows") {
+        name.ends_with(".lib") || name.ends_with(".dll")
+    } else if cfg!(target_os = "macos") {
+        name.contains(".dylib")
+    } else {
+        name.contains(".so")
+    }
+}

--- a/rust/onnxsim-sys/src/lib.rs
+++ b/rust/onnxsim-sys/src/lib.rs
@@ -1,0 +1,86 @@
+//! Low-level FFI bindings to the ONNX Simplifier (`onnxsim`) C API.
+//!
+//! These declarations mirror `onnxsim/capi/onnxsim_c_api.h` one-to-one. They are
+//! `unsafe` and do no memory management on their own — every buffer or string
+//! handed back through an out-parameter must be released with the matching
+//! `onnxsim_free_*` function. Prefer the safe [`onnxsim`] crate unless you need
+//! raw access.
+//!
+//! [`onnxsim`]: https://crates.io/crates/onnxsim
+#![allow(non_camel_case_types)]
+
+use std::os::raw::{c_char, c_int, c_void};
+
+/// Return code shared by every fallible entry point.
+///
+/// Mirrors the `OnnxsimStatus` enum in the C header.
+pub const ONNXSIM_OK: c_int = 0;
+/// Failure return code; an error message is written to the `out_error` slot.
+pub const ONNXSIM_ERROR: c_int = 1;
+
+extern "C" {
+    /// Simplify a serialized ONNX `ModelProto`.
+    ///
+    /// See `onnxsim_c_api.h` for the full contract. In brief:
+    /// `skip_optimizers_is_null != 0` skips every optimizer pass; otherwise all
+    /// passes run except the `num_skip_optimizers` names in `skip_optimizers`.
+    /// On success (`ONNXSIM_OK`) `out_data`/`out_size` own a buffer to free with
+    /// [`onnxsim_free_buffer`]; on failure (`ONNXSIM_ERROR`) `out_error` owns a
+    /// string to free with [`onnxsim_free_string`].
+    ///
+    /// # Safety
+    /// All non-null pointers must be valid; `model_data` must point to at least
+    /// `model_size` bytes and `skip_optimizers` to `num_skip_optimizers`
+    /// NUL-terminated strings when `skip_optimizers_is_null == 0`.
+    pub fn onnxsim_simplify(
+        model_data: *const c_void,
+        model_size: usize,
+        skip_optimizers: *const *const c_char,
+        num_skip_optimizers: usize,
+        skip_optimizers_is_null: c_int,
+        constant_folding: c_int,
+        shape_inference: c_int,
+        tensor_size_threshold: usize,
+        out_data: *mut *mut c_void,
+        out_size: *mut usize,
+        out_error: *mut *mut c_char,
+    ) -> c_int;
+
+    /// Simplify a model read from `in_path`, writing the result to `out_path`.
+    ///
+    /// # Safety
+    /// `in_path`/`out_path` must be valid NUL-terminated paths; the
+    /// `skip_optimizers` rules match [`onnxsim_simplify`].
+    pub fn onnxsim_simplify_path(
+        in_path: *const c_char,
+        out_path: *const c_char,
+        skip_optimizers: *const *const c_char,
+        num_skip_optimizers: usize,
+        skip_optimizers_is_null: c_int,
+        constant_folding: c_int,
+        shape_inference: c_int,
+        tensor_size_threshold: usize,
+        out_error: *mut *mut c_char,
+    ) -> c_int;
+
+    /// Return the available optimizer pass names as a newline-separated,
+    /// NUL-terminated string (or null on allocation failure). Free with
+    /// [`onnxsim_free_string`].
+    ///
+    /// # Safety
+    /// Always safe to call; the returned pointer must be freed exactly once.
+    pub fn onnxsim_list_optimizers() -> *mut c_char;
+
+    /// Free a buffer produced by an `out_data` parameter. Null is ignored.
+    ///
+    /// # Safety
+    /// `data` must have come from this library and not be freed twice.
+    pub fn onnxsim_free_buffer(data: *mut c_void);
+
+    /// Free a string produced by an `out_error` parameter or
+    /// [`onnxsim_list_optimizers`]. Null is ignored.
+    ///
+    /// # Safety
+    /// `data` must have come from this library and not be freed twice.
+    pub fn onnxsim_free_string(data: *mut c_char);
+}

--- a/rust/onnxsim/Cargo.toml
+++ b/rust/onnxsim/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "onnxsim"
+description = "Safe Rust bindings to the ONNX Simplifier (onnxsim): constant-folding and graph simplification for ONNX models"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+readme = "README.md"
+categories = ["api-bindings", "science"]
+keywords = ["onnx", "onnxsim", "simplifier", "machine-learning", "inference"]
+
+[dependencies]
+onnxsim-sys = { path = "../onnxsim-sys", version = "0.1.0" }
+
+[package.metadata.docs.rs]
+# docs.rs cannot build the native ONNX Runtime stack; skip it and just render docs.
+rustc-args = []
+rustdoc-args = []

--- a/rust/onnxsim/examples/simplify.rs
+++ b/rust/onnxsim/examples/simplify.rs
@@ -1,0 +1,30 @@
+//! Simplify an ONNX model from the command line.
+//!
+//! Usage:
+//!     cargo run --example simplify -- <input.onnx> <output.onnx>
+//!
+//! Requires the native `onnxsim_c` library to be built/linked (see the crate
+//! README for build modes).
+
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 3 {
+        eprintln!("usage: {} <input.onnx> <output.onnx>", args[0]);
+        return ExitCode::from(2);
+    }
+    let input = &args[1];
+    let output = &args[2];
+
+    match onnxsim::simplify_path(input, output) {
+        Ok(()) => {
+            println!("simplified {input} -> {output}");
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprintln!("error: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/rust/onnxsim/src/lib.rs
+++ b/rust/onnxsim/src/lib.rs
@@ -1,0 +1,413 @@
+//! Safe Rust bindings to the [ONNX Simplifier](https://github.com/onnxsim/onnxsim)
+//! (`onnxsim`).
+//!
+//! ONNX models exported from training frameworks often contain redundant
+//! operators — dynamic shape gymnastics, no-op reshapes, constant subgraphs.
+//! `onnxsim` runs shape inference and constant folding to replace those with
+//! their computed results, producing a smaller, simpler, semantically identical
+//! graph. This crate wraps the same C++ core the Python package and CLI use, so
+//! Rust projects (e.g. model importers) can simplify models in-process instead
+//! of shelling out.
+//!
+//! # Quick start
+//!
+//! Simplify a model already in memory as serialized `ModelProto` bytes:
+//!
+//! ```no_run
+//! let model_bytes: Vec<u8> = std::fs::read("model.onnx")?;
+//! let simplified: Vec<u8> = onnxsim::simplify(&model_bytes)?;
+//! std::fs::write("model.opt.onnx", &simplified)?;
+//! # Ok::<(), onnxsim::Error>(())
+//! ```
+//!
+//! Or operate directly on files (lets the C++ side stream models larger than
+//! would be convenient to hold in a single buffer):
+//!
+//! ```no_run
+//! onnxsim::simplify_path("model.onnx", "model.opt.onnx")?;
+//! # Ok::<(), onnxsim::Error>(())
+//! ```
+//!
+//! # Tuning
+//!
+//! [`Options`] controls constant folding, shape inference, which optimizer
+//! passes run, and the size threshold for folded tensors:
+//!
+//! ```no_run
+//! let opts = onnxsim::Options::new()
+//!     .shape_inference(false) // some models crash ONNX shape inference
+//!     .skip_optimizer("eliminate_nop_transpose");
+//! let simplified = onnxsim::simplify_with(&std::fs::read("model.onnx")?, &opts)?;
+//! # Ok::<(), onnxsim::Error>(())
+//! ```
+
+use std::ffi::{CStr, CString};
+use std::fmt;
+use std::os::raw::{c_char, c_int, c_void};
+use std::path::Path;
+use std::ptr;
+
+/// Default upper bound on the byte size of a constant-folded tensor kept as an
+/// initializer. Matches the Python package default of `1.5GB`.
+pub const DEFAULT_TENSOR_SIZE_THRESHOLD: usize = 1_610_612_736; // 1.5 * 2^30
+
+/// Errors returned by the simplifier.
+#[derive(Debug)]
+pub enum Error {
+    /// The C++ core reported a failure. Carries its message.
+    Simplify(String),
+    /// An argument could not be converted for the FFI boundary (e.g. a path or
+    /// optimizer name containing an interior NUL byte, or a non-UTF-8 path).
+    InvalidArgument(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Simplify(msg) => write!(f, "onnxsim failed: {msg}"),
+            Error::InvalidArgument(msg) => write!(f, "invalid argument: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Configuration for a simplification run.
+///
+/// Build with [`Options::new`] and the chained setters; every field has a sane
+/// default so `Options::default()` reproduces the CLI's out-of-the-box
+/// behaviour (all passes on, constant folding and shape inference enabled).
+#[derive(Debug, Clone)]
+pub struct Options {
+    /// Optimizer-pass control.
+    /// * `None` — skip **all** optimizer passes (no graph optimization).
+    /// * `Some(list)` — run every fuse/elimination pass except the names in
+    ///   `list` (an empty list runs them all).
+    skip_optimizers: Option<Vec<String>>,
+    constant_folding: bool,
+    shape_inference: bool,
+    tensor_size_threshold: usize,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Options {
+            skip_optimizers: Some(Vec::new()),
+            constant_folding: true,
+            shape_inference: true,
+            tensor_size_threshold: DEFAULT_TENSOR_SIZE_THRESHOLD,
+        }
+    }
+}
+
+impl Options {
+    /// Create options with the default configuration.
+    pub fn new() -> Self {
+        Options::default()
+    }
+
+    /// Enable or disable constant folding (default: enabled).
+    pub fn constant_folding(mut self, enabled: bool) -> Self {
+        self.constant_folding = enabled;
+        self
+    }
+
+    /// Enable or disable ONNX shape inference (default: enabled).
+    ///
+    /// Disabling can be a useful workaround: shape inference occasionally
+    /// crashes or errors on unusual models.
+    pub fn shape_inference(mut self, enabled: bool) -> Self {
+        self.shape_inference = enabled;
+        self
+    }
+
+    /// Set the maximum byte size of a constant-folded tensor that will be kept
+    /// as an initializer (default: [`DEFAULT_TENSOR_SIZE_THRESHOLD`]).
+    pub fn tensor_size_threshold(mut self, bytes: usize) -> Self {
+        self.tensor_size_threshold = bytes;
+        self
+    }
+
+    /// Disable **all** optimizer passes. Constant folding and shape inference
+    /// (if enabled) still run.
+    pub fn without_optimizers(mut self) -> Self {
+        self.skip_optimizers = None;
+        self
+    }
+
+    /// Run every optimizer pass except the ones named here.
+    ///
+    /// Replaces any previously configured skip list and re-enables optimization
+    /// if it had been turned off with [`Options::without_optimizers`]. Use
+    /// [`list_optimizers`] to discover valid names.
+    pub fn skip_optimizers<I, S>(mut self, names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.skip_optimizers = Some(names.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Add a single optimizer pass to the skip list (enabling optimization if it
+    /// was disabled).
+    pub fn skip_optimizer<S: Into<String>>(mut self, name: S) -> Self {
+        self.skip_optimizers
+            .get_or_insert_with(Vec::new)
+            .push(name.into());
+        self
+    }
+}
+
+/// Simplify a serialized ONNX `ModelProto` with default options.
+///
+/// Returns the serialized simplified model.
+pub fn simplify(model_bytes: &[u8]) -> Result<Vec<u8>, Error> {
+    simplify_with(model_bytes, &Options::default())
+}
+
+/// Simplify a serialized ONNX `ModelProto` with the given [`Options`].
+///
+/// Returns the serialized simplified model.
+pub fn simplify_with(model_bytes: &[u8], options: &Options) -> Result<Vec<u8>, Error> {
+    let ffi = FfiSkipOptimizers::new(options)?;
+
+    let mut out_data: *mut c_void = ptr::null_mut();
+    let mut out_size: usize = 0;
+    let mut out_error: *mut c_char = ptr::null_mut();
+
+    let status = unsafe {
+        onnxsim_sys::onnxsim_simplify(
+            model_bytes.as_ptr() as *const c_void,
+            model_bytes.len(),
+            ffi.ptr(),
+            ffi.len(),
+            ffi.is_null_flag(),
+            bool_to_c(options.constant_folding),
+            bool_to_c(options.shape_inference),
+            options.tensor_size_threshold,
+            &mut out_data,
+            &mut out_size,
+            &mut out_error,
+        )
+    };
+
+    if status == onnxsim_sys::ONNXSIM_OK {
+        // Copy the C-owned buffer into a Vec, then release the original.
+        let result =
+            unsafe { std::slice::from_raw_parts(out_data as *const u8, out_size) }.to_vec();
+        unsafe { onnxsim_sys::onnxsim_free_buffer(out_data) };
+        Ok(result)
+    } else {
+        Err(take_error(out_error))
+    }
+}
+
+/// Simplify the model at `input_path`, writing the result to `output_path`,
+/// using default options.
+pub fn simplify_path<P: AsRef<Path>, Q: AsRef<Path>>(
+    input_path: P,
+    output_path: Q,
+) -> Result<(), Error> {
+    simplify_path_with(input_path, output_path, &Options::default())
+}
+
+/// Simplify the model at `input_path`, writing the result to `output_path`,
+/// using the given [`Options`].
+pub fn simplify_path_with<P: AsRef<Path>, Q: AsRef<Path>>(
+    input_path: P,
+    output_path: Q,
+    options: &Options,
+) -> Result<(), Error> {
+    let in_c = path_to_cstring(input_path.as_ref())?;
+    let out_c = path_to_cstring(output_path.as_ref())?;
+    let ffi = FfiSkipOptimizers::new(options)?;
+
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let status = unsafe {
+        onnxsim_sys::onnxsim_simplify_path(
+            in_c.as_ptr(),
+            out_c.as_ptr(),
+            ffi.ptr(),
+            ffi.len(),
+            ffi.is_null_flag(),
+            bool_to_c(options.constant_folding),
+            bool_to_c(options.shape_inference),
+            options.tensor_size_threshold,
+            &mut out_error,
+        )
+    };
+
+    if status == onnxsim_sys::ONNXSIM_OK {
+        Ok(())
+    } else {
+        Err(take_error(out_error))
+    }
+}
+
+/// Return the names of all available fuse/elimination optimizer passes.
+///
+/// These are the names accepted by [`Options::skip_optimizer`] and
+/// [`Options::skip_optimizers`].
+pub fn list_optimizers() -> Vec<String> {
+    let raw = unsafe { onnxsim_sys::onnxsim_list_optimizers() };
+    if raw.is_null() {
+        return Vec::new();
+    }
+    let text = unsafe { CStr::from_ptr(raw) }
+        .to_string_lossy()
+        .into_owned();
+    unsafe { onnxsim_sys::onnxsim_free_string(raw) };
+    text.lines()
+        .filter(|line| !line.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Owns the `CString`s and pointer array backing the `skip_optimizers` FFI
+/// arguments, keeping them alive for the duration of a call.
+struct FfiSkipOptimizers {
+    // `_owned` keeps the C strings alive; `ptrs` points into them.
+    _owned: Vec<CString>,
+    ptrs: Vec<*const c_char>,
+    is_null: bool,
+}
+
+impl FfiSkipOptimizers {
+    fn new(options: &Options) -> Result<Self, Error> {
+        match &options.skip_optimizers {
+            None => Ok(FfiSkipOptimizers {
+                _owned: Vec::new(),
+                ptrs: Vec::new(),
+                is_null: true,
+            }),
+            Some(names) => {
+                let mut owned = Vec::with_capacity(names.len());
+                for name in names {
+                    let c = CString::new(name.as_str()).map_err(|_| {
+                        Error::InvalidArgument(format!(
+                            "optimizer name contains an interior NUL byte: {name:?}"
+                        ))
+                    })?;
+                    owned.push(c);
+                }
+                let ptrs = owned.iter().map(|c| c.as_ptr()).collect();
+                Ok(FfiSkipOptimizers {
+                    _owned: owned,
+                    ptrs,
+                    is_null: false,
+                })
+            }
+        }
+    }
+
+    fn ptr(&self) -> *const *const c_char {
+        if self.ptrs.is_empty() {
+            ptr::null()
+        } else {
+            self.ptrs.as_ptr()
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.ptrs.len()
+    }
+
+    fn is_null_flag(&self) -> c_int {
+        bool_to_c(self.is_null)
+    }
+}
+
+fn bool_to_c(value: bool) -> c_int {
+    if value {
+        1
+    } else {
+        0
+    }
+}
+
+/// Consume a C-owned error string, returning a Rust `Error` and freeing the
+/// original allocation.
+fn take_error(out_error: *mut c_char) -> Error {
+    if out_error.is_null() {
+        return Error::Simplify("unknown error (no message provided)".to_string());
+    }
+    let message = unsafe { CStr::from_ptr(out_error) }
+        .to_string_lossy()
+        .into_owned();
+    unsafe { onnxsim_sys::onnxsim_free_string(out_error) };
+    Error::Simplify(message)
+}
+
+#[cfg(unix)]
+fn path_to_cstring(path: &Path) -> Result<CString, Error> {
+    use std::os::unix::ffi::OsStrExt;
+    CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        Error::InvalidArgument(format!("path contains an interior NUL byte: {path:?}"))
+    })
+}
+
+#[cfg(not(unix))]
+fn path_to_cstring(path: &Path) -> Result<CString, Error> {
+    let s = path
+        .to_str()
+        .ok_or_else(|| Error::InvalidArgument(format!("path is not valid UTF-8: {path:?}")))?;
+    CString::new(s).map_err(|_| {
+        Error::InvalidArgument(format!("path contains an interior NUL byte: {path:?}"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These tests exercise pure-Rust logic and do not touch the FFI, so they
+    // run under `cargo test` even without the native library linked.
+
+    #[test]
+    fn default_options() {
+        let opts = Options::default();
+        assert!(opts.constant_folding);
+        assert!(opts.shape_inference);
+        assert_eq!(opts.skip_optimizers, Some(Vec::new()));
+        assert_eq!(opts.tensor_size_threshold, DEFAULT_TENSOR_SIZE_THRESHOLD);
+    }
+
+    #[test]
+    fn without_optimizers_sets_null() {
+        let opts = Options::new().without_optimizers();
+        let ffi = FfiSkipOptimizers::new(&opts).unwrap();
+        assert!(ffi.is_null);
+        assert_eq!(ffi.is_null_flag(), 1);
+        assert!(ffi.ptr().is_null());
+    }
+
+    #[test]
+    fn skip_optimizer_reenables_optimization() {
+        let opts = Options::new()
+            .without_optimizers()
+            .skip_optimizer("eliminate_nop_transpose");
+        assert_eq!(
+            opts.skip_optimizers,
+            Some(vec!["eliminate_nop_transpose".to_string()])
+        );
+    }
+
+    #[test]
+    fn ffi_skip_optimizers_layout() {
+        let opts = Options::new().skip_optimizers(["a", "bb"]);
+        let ffi = FfiSkipOptimizers::new(&opts).unwrap();
+        assert!(!ffi.is_null);
+        assert_eq!(ffi.len(), 2);
+        assert!(!ffi.ptr().is_null());
+    }
+
+    #[test]
+    fn interior_nul_is_rejected() {
+        let opts = Options::new().skip_optimizer("bad\0name");
+        assert!(matches!(
+            FfiSkipOptimizers::new(&opts),
+            Err(Error::InvalidArgument(_))
+        ));
+    }
+}

--- a/rust/onnxsim/src/lib.rs
+++ b/rust/onnxsim/src/lib.rs
@@ -14,18 +14,22 @@
 //! Simplify a model already in memory as serialized `ModelProto` bytes:
 //!
 //! ```no_run
-//! let model_bytes: Vec<u8> = std::fs::read("model.onnx")?;
-//! let simplified: Vec<u8> = onnxsim::simplify(&model_bytes)?;
-//! std::fs::write("model.opt.onnx", &simplified)?;
-//! # Ok::<(), onnxsim::Error>(())
+//! fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+//!     let model_bytes: Vec<u8> = std::fs::read("model.onnx")?;
+//!     let simplified: Vec<u8> = onnxsim::simplify(&model_bytes)?;
+//!     std::fs::write("model.opt.onnx", &simplified)?;
+//!     Ok(())
+//! }
 //! ```
 //!
 //! Or operate directly on files (lets the C++ side stream models larger than
 //! would be convenient to hold in a single buffer):
 //!
 //! ```no_run
-//! onnxsim::simplify_path("model.onnx", "model.opt.onnx")?;
-//! # Ok::<(), onnxsim::Error>(())
+//! fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+//!     onnxsim::simplify_path("model.onnx", "model.opt.onnx")?;
+//!     Ok(())
+//! }
 //! ```
 //!
 //! # Tuning
@@ -34,11 +38,13 @@
 //! passes run, and the size threshold for folded tensors:
 //!
 //! ```no_run
-//! let opts = onnxsim::Options::new()
-//!     .shape_inference(false) // some models crash ONNX shape inference
-//!     .skip_optimizer("eliminate_nop_transpose");
-//! let simplified = onnxsim::simplify_with(&std::fs::read("model.onnx")?, &opts)?;
-//! # Ok::<(), onnxsim::Error>(())
+//! fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+//!     let opts = onnxsim::Options::new()
+//!         .shape_inference(false) // some models crash ONNX shape inference
+//!         .skip_optimizer("eliminate_nop_transpose");
+//!     let simplified = onnxsim::simplify_with(&std::fs::read("model.onnx")?, &opts)?;
+//!     Ok(())
+//! }
 //! ```
 
 use std::ffi::{CStr, CString};

--- a/rust/onnxsim/tests/integration.rs
+++ b/rust/onnxsim/tests/integration.rs
@@ -1,0 +1,42 @@
+//! End-to-end tests that require the native `onnxsim_c` library to be linked.
+//!
+//! They are `#[ignore]`d so they don't run (or force a native build) during a
+//! plain `cargo test`. Once the library is available, run them with:
+//!
+//! ```sh
+//! cargo test -- --ignored
+//! ```
+//!
+//! `roundtrip_simplify_path` additionally needs a real model; point it at one
+//! with `ONNXSIM_TEST_MODEL=/path/to/model.onnx`.
+
+#[test]
+#[ignore = "requires the native onnxsim_c library"]
+fn list_optimizers_is_non_empty() {
+    let passes = onnxsim::list_optimizers();
+    assert!(
+        !passes.is_empty(),
+        "expected at least one optimizer pass to be reported"
+    );
+}
+
+#[test]
+#[ignore = "requires the native onnxsim_c library and a model file"]
+fn roundtrip_simplify_path() {
+    let model = match std::env::var("ONNXSIM_TEST_MODEL") {
+        Ok(path) => path,
+        Err(_) => {
+            eprintln!("set ONNXSIM_TEST_MODEL to run this test");
+            return;
+        }
+    };
+    let dir = std::env::temp_dir();
+    let out = dir.join("onnxsim_rust_test_out.onnx");
+    onnxsim::simplify_path(&model, &out).expect("simplify_path should succeed");
+    let simplified = std::fs::read(&out).expect("output model should exist");
+    assert!(
+        !simplified.is_empty(),
+        "simplified model should not be empty"
+    );
+    let _ = std::fs::remove_file(&out);
+}


### PR DESCRIPTION
Provide a Rust binding so importers like Burn, tract and wonnx can simplify ONNX models in-process instead of shelling out to the CLI or embedding Python.

Layers:
- onnxsim/capi/onnxsim_c_api.{h,cpp}: a small, stable C ABI over the C++ core (simplify from bytes, simplify from/to paths, list optimizers). Models cross the FFI boundary as serialized ModelProto bytes, matching the Python binding. Exported symbols opt into default visibility.
- CMake: new ONNXSIM_C_API option that builds the onnxsim_c shared lib.
- rust/onnxsim-sys: raw FFI declarations plus a build script that links onnxsim_c via a pre-built lib (ONNXSIM_LIB_DIR), a full CMake source build, or a skip mode (ONNXSIM_NO_BUILD / docs.rs) for type-checking.
- rust/onnxsim: safe, idiomatic API (simplify, simplify_with, simplify_path, Options builder, list_optimizers) with an Error type, unit tests, an example, and a gated integration test.
- CI: rust.yml runs fmt/clippy without a native build and a full build+test job.

closes #292

Claude-Session: https://claude.ai/code/session_01QZ8nu7qfB3kHAnEtz4jNzB