### PR TITLE
Add partial shape evaluation via ONNX data propagation (issue #139)

### DIFF
--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -442,42 +442,6 @@ onnx::ModelProto _InferShapes(const onnx::ModelProto& model) {
   return result;
 }
 
-// Read an integer initializer (INT32/INT64) into an int64 vector. Returns false
-// if the tensor is not an integer type onnxsim knows how to read.
-bool ReadIntInitializer(const onnx::TensorProto& tp, std::vector<int64_t>& out) {
-  out.clear();
-  const auto dtype = tp.data_type();
-  if (dtype != onnx::TensorProto::INT64 && dtype != onnx::TensorProto::INT32) {
-    return false;
-  }
-  if (tp.has_raw_data()) {
-    // onnxsim assumes little endian everywhere (see TensorProtoToTensor).
-    const std::string& raw = tp.raw_data();
-    if (dtype == onnx::TensorProto::INT64) {
-      const size_t n = raw.size() / sizeof(int64_t);
-      const int64_t* p = reinterpret_cast<const int64_t*>(raw.data());
-      out.assign(p, p + n);
-    } else {
-      const size_t n = raw.size() / sizeof(int32_t);
-      const int32_t* p = reinterpret_cast<const int32_t*>(raw.data());
-      out.assign(p, p + n);
-    }
-  } else if (dtype == onnx::TensorProto::INT64) {
-    out.assign(tp.int64_data().begin(), tp.int64_data().end());
-  } else {
-    out.assign(tp.int32_data().begin(), tp.int32_data().end());
-  }
-  return true;
-}
-
-// A single dimension of a (possibly partially known) tensor shape. `known` is
-// true when the dimension is a fixed integer stored in `value`; otherwise the
-// dimension is symbolic/dynamic.
-struct MaybeDim {
-  bool known;
-  int64_t value;
-};
-
 // Build a lookup from tensor name to its type, gathering shapes from every
 // place a shape can be declared: value_info (populated by shape inference),
 // graph inputs and graph outputs. Pointers reference `model`, so the map must
@@ -496,204 +460,147 @@ std::unordered_map<std::string, const onnx::TypeProto*> BuildTypeMap(
   return type_map;
 }
 
-// Fetch the (partially known) shape of `name` from `type_map`. Returns false
-// when the rank is unknown (no shape recorded); returns true with one MaybeDim
-// per dimension otherwise. A rank-0 (scalar) tensor yields an empty `dims`.
-bool GetTensorDims(
+// Fetch the element type and a fully static shape of `name` from `type_map`.
+// Returns false unless the tensor has a known integer (INT64/INT32) element
+// type and a shape whose every dimension is a fixed value. A rank-0 (scalar)
+// tensor yields an empty `dims` (element count 1).
+bool GetStaticIntTensorInfo(
     const std::unordered_map<std::string, const onnx::TypeProto*>& type_map,
-    const std::string& name, std::vector<MaybeDim>& dims) {
+    const std::string& name, onnx::TensorProto::DataType& elem_type,
+    std::vector<int64_t>& dims) {
   auto iter = type_map.find(name);
   if (iter == type_map.end() || !iter->second->has_tensor_type()) {
     return false;
   }
   const auto& tensor_type = iter->second->tensor_type();
+  elem_type = static_cast<onnx::TensorProto::DataType>(tensor_type.elem_type());
+  if (elem_type != onnx::TensorProto::INT64 &&
+      elem_type != onnx::TensorProto::INT32) {
+    return false;
+  }
   if (!tensor_type.has_shape()) {
     // Rank is unknown.
     return false;
   }
   dims.clear();
   for (const auto& dim : tensor_type.shape().dim()) {
-    if (dim.has_dim_value()) {
-      dims.push_back({true, dim.dim_value()});
-    } else {
-      dims.push_back({false, 0});
+    if (!dim.has_dim_value()) {
+      return false;
     }
+    dims.push_back(dim.dim_value());
   }
   return true;
 }
 
-bool IsDefaultDomain(const std::string& domain) {
-  return domain.empty() || domain == "ai.onnx";
-}
-
-// Build a 1-D INT64 initializer named `name` from `values`.
-onnx::TensorProto MakeInt64Initializer(const std::string& name,
-                                       const std::vector<int64_t>& values) {
-  onnx::TensorProto tp;
-  tp.set_name(name);
-  tp.set_data_type(onnx::TensorProto::INT64);
-  tp.add_dims(static_cast<int64_t>(values.size()));
-  for (const auto& v : values) {
-    tp.add_int64_data(v);
-  }
-  return tp;
-}
-
-// Partial shape evaluation (issue #139).
+// Partial shape evaluation (issue #139) via ONNX data propagation.
 //
 // The plain constant folder only folds a node when *all* of its inputs are
-// constant, so a `Shape` op is never folded: its input is an activation. But
-// `Shape` depends solely on the input's shape, and after shape inference some
-// (or all) of those dimensions are statically known even when others stay
-// dynamic. This pass exploits that:
+// constant, so shape-computing ops like `Shape` are never folded: their input
+// is an activation. Yet those ops depend solely on shapes, which shape
+// inference knows -- fully or partially -- even when some dimensions stay
+// dynamic.
 //
-//   * A `Shape` whose selected dimensions are *all* static becomes a constant
-//     initializer directly.
-//   * A `Gather` reading constant indices from a `Shape` output becomes a
-//     constant initializer whenever every gathered dimension is static -- even
-//     if the surrounding shape has dynamic dimensions. This is the mask-rcnn
-//     pattern from issue #139: `Shape([batch, C, H, W]) -> Gather([1, 2, 3])`
-//     is `[C, H, W]` regardless of the dynamic batch dimension.
+// ONNX shape inference can *propagate* those partially known values: with data
+// propagation enabled it fills a DataValueMap mapping each tensor to a
+// TensorShapeProto whose entries are either a concrete dim_value or a symbolic
+// dim_param. Ops across the shape family (Shape, Gather, Slice, Concat,
+// Squeeze/Unsqueeze, Cast, Add/Sub/Mul, ...) participate, so a chain like
+//   Shape([batch, C, H, W]) -> Gather([1, 2, 3])  ==>  [C, H, W]
+// is propagated end to end and comes out fully concrete even though the batch
+// dimension stays dynamic (the mask-rcnn pattern from issue #139).
 //
-// Downstream ops (Unsqueeze, Concat, ...) then fold through the normal constant
-// folder, and now-dead Shape/Gather nodes are removed by the optimizer.
+// This pass folds every node whose lone output has a fully concrete propagated
+// value into a constant initializer. Downstream ops then fold through the
+// ordinary constant folder, and now-dead nodes are removed by the optimizer.
 onnx::ModelProto _EvalPartialShape(const onnx::ModelProto& input_model) {
   onnx::ModelProto model;
+  onnx::shape_inference::DataValueMap data_map;
   try {
-    model = _InferShapes(input_model);
+    model.CopyFrom(input_model);
+    const onnx::ShapeInferenceOptions options(/*check_type=*/false,
+                                              /*error_mode=*/0,
+                                              /*enable_data_propagation=*/true);
+    onnx::shape_inference::InferShapes(model, onnx::OpSchemaRegistry::Instance(),
+                                       options, &data_map);
   } catch (const std::exception&) {
-    // If shape inference fails we simply have no extra shapes to exploit.
+    // If shape inference fails we simply have no propagated values to exploit.
+    return input_model;
+  }
+
+  if (data_map.empty()) {
     return input_model;
   }
 
   const auto type_map = BuildTypeMap(model);
 
-  std::unordered_map<std::string, const onnx::TensorProto*> init_map;
-  for (const auto& init : model.graph().initializer()) {
-    init_map[init.name()] = &init;
-  }
-
-  // For every `Shape` node, precompute the (partially known) vector of
-  // dimensions it produces, honoring the optional `start`/`end` attributes
-  // (opset 15+). Keyed by the Shape node's output name.
-  std::unordered_map<std::string, std::vector<MaybeDim>> shape_outputs;
-  for (const auto& node : model.graph().node()) {
-    if (node.op_type() != "Shape" || !IsDefaultDomain(node.domain())) {
-      continue;
-    }
-    if (node.input_size() < 1 || node.output_size() < 1) {
-      continue;
-    }
-    std::vector<MaybeDim> dims;
-    if (!GetTensorDims(type_map, node.input(0), dims)) {
-      continue;
-    }
-    const int64_t rank = static_cast<int64_t>(dims.size());
-    int64_t start = 0;
-    int64_t end = rank;
-    for (const auto& attr : node.attribute()) {
-      if (attr.name() == "start") {
-        start = attr.i();
-      } else if (attr.name() == "end") {
-        end = attr.i();
-      }
-    }
-    if (start < 0) start += rank;
-    if (end < 0) end += rank;
-    start = std::clamp<int64_t>(start, 0, rank);
-    end = std::clamp<int64_t>(end, 0, rank);
-    if (end < start) end = start;
-    shape_outputs[node.output(0)] =
-        std::vector<MaybeDim>(dims.begin() + start, dims.begin() + end);
-  }
-
-  if (shape_outputs.empty()) {
-    return input_model;
-  }
-
-  // Node output(0) names whose producing node is being replaced by an
-  // initializer, plus the initializers to add.
+  // Node output(0) names being replaced by an initializer, plus the
+  // initializers to add.
   std::set<std::string> replaced_outputs;
   std::vector<onnx::TensorProto> new_initializers;
 
-  // Case 1: a Shape whose every selected dimension is static folds to a
-  // constant.
-  for (const auto& [output, dims] : shape_outputs) {
-    const bool all_known = std::all_of(
-        dims.begin(), dims.end(), [](const MaybeDim& d) { return d.known; });
-    if (!all_known) {
-      continue;
-    }
-    std::vector<int64_t> values;
-    for (const auto& d : dims) {
-      values.push_back(d.value);
-    }
-    new_initializers.push_back(MakeInt64Initializer(output, values));
-    replaced_outputs.insert(output);
-  }
-
-  // Case 2: a Gather with constant indices reading a Shape output folds to a
-  // constant whenever every gathered dimension is static.
   for (const auto& node : model.graph().node()) {
-    if (node.op_type() != "Gather" || !IsDefaultDomain(node.domain())) {
+    // Shape-family ops are single-output; only replace a node when its lone
+    // output is fully known, so dropping it can never orphan a second output.
+    if (node.output_size() != 1) {
       continue;
     }
-    if (node.input_size() < 2 || node.output_size() < 1) {
-      continue;
-    }
-    // The Shape output is 1-D, so only axis 0 makes sense.
-    int64_t axis = 0;
-    for (const auto& attr : node.attribute()) {
-      if (attr.name() == "axis") {
-        axis = attr.i();
-      }
-    }
-    if (axis != 0) {
-      continue;
-    }
-    auto shape_iter = shape_outputs.find(node.input(0));
-    if (shape_iter == shape_outputs.end()) {
-      continue;
-    }
-    const auto& dims = shape_iter->second;
-    const int64_t length = static_cast<int64_t>(dims.size());
-
-    auto idx_iter = init_map.find(node.input(1));
-    if (idx_iter == init_map.end()) {
-      continue;
-    }
-    const onnx::TensorProto& indices_tp = *idx_iter->second;
-    std::vector<int64_t> indices;
-    if (!ReadIntInitializer(indices_tp, indices)) {
+    const std::string& output = node.output(0);
+    auto data_iter = data_map.find(output);
+    if (data_iter == data_map.end()) {
       continue;
     }
 
-    bool foldable = true;
+    // Every element must be statically known. Data propagation represents an
+    // unknown element as a dimension with neither dim_value nor dim_param, so
+    // requiring dim_value on every entry both proves the value is concrete and
+    // filters out activations whose rank alone is known.
+    const onnx::TensorShapeProto& value = data_iter->second;
+    bool fully_known = true;
     std::vector<int64_t> values;
-    for (int64_t idx : indices) {
-      const int64_t norm = idx < 0 ? idx + length : idx;
-      if (norm < 0 || norm >= length || !dims[norm].known) {
-        foldable = false;
+    for (const auto& dim : value.dim()) {
+      if (!dim.has_dim_value()) {
+        fully_known = false;
         break;
       }
-      values.push_back(dims[norm].value);
+      values.push_back(dim.dim_value());
     }
-    if (!foldable) {
+    if (!fully_known) {
       continue;
     }
 
-    // The output has the same shape as the indices tensor (data is 1-D).
-    onnx::TensorProto tp;
-    tp.set_name(node.output(0));
-    tp.set_data_type(onnx::TensorProto::INT64);
-    for (const auto& dim : indices_tp.dims()) {
-      tp.add_dims(dim);
+    // Materialize an initializer with the output's real dtype and shape. The
+    // propagated data is a flat sequence, so require a fully static shape whose
+    // element count matches what was propagated.
+    onnx::TensorProto::DataType elem_type;
+    std::vector<int64_t> dims;
+    if (!GetStaticIntTensorInfo(type_map, output, elem_type, dims)) {
+      continue;
     }
-    for (const auto& v : values) {
-      tp.add_int64_data(v);
+    int64_t element_count = 1;
+    for (int64_t d : dims) {
+      element_count *= d;
+    }
+    if (element_count != static_cast<int64_t>(values.size())) {
+      continue;
+    }
+
+    onnx::TensorProto tp;
+    tp.set_name(output);
+    tp.set_data_type(elem_type);
+    for (int64_t d : dims) {
+      tp.add_dims(d);
+    }
+    if (elem_type == onnx::TensorProto::INT64) {
+      for (int64_t v : values) {
+        tp.add_int64_data(v);
+      }
+    } else {
+      for (int64_t v : values) {
+        tp.add_int32_data(static_cast<int32_t>(v));
+      }
     }
     new_initializers.push_back(std::move(tp));
-    replaced_outputs.insert(node.output(0));
+    replaced_outputs.insert(output);
   }
 
   if (replaced_outputs.empty()) {
@@ -704,7 +611,7 @@ onnx::ModelProto _EvalPartialShape(const onnx::ModelProto& input_model) {
   google::protobuf::RepeatedPtrField<onnx::NodeProto> original_nodes;
   original_nodes.Swap(model.mutable_graph()->mutable_node());
   for (auto& node : original_nodes) {
-    const bool replaced = node.output_size() > 0 &&
+    const bool replaced = node.output_size() == 1 &&
                           replaced_outputs.count(node.output(0)) > 0;
     if (!replaced) {
       *model.mutable_graph()->add_node() = std::move(node);

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -509,8 +509,8 @@ bool GetStaticIntTensorInfo(
 // is propagated end to end and comes out fully concrete even though the batch
 // dimension stays dynamic (the mask-rcnn pattern from issue #139).
 //
-// This pass folds every node whose lone output has a fully concrete propagated
-// value into a constant initializer. Downstream ops then fold through the
+// This pass rewrites every node whose lone output has a fully concrete
+// propagated value into a `Constant` node. Downstream ops then fold through the
 // ordinary constant folder, and now-dead nodes are removed by the optimizer.
 onnx::ModelProto _EvalPartialShape(const onnx::ModelProto& input_model) {
   onnx::ModelProto model;
@@ -533,10 +533,9 @@ onnx::ModelProto _EvalPartialShape(const onnx::ModelProto& input_model) {
 
   const auto type_map = BuildTypeMap(model);
 
-  // Node output(0) names being replaced by an initializer, plus the
-  // initializers to add.
-  std::set<std::string> replaced_outputs;
-  std::vector<onnx::TensorProto> new_initializers;
+  // Maps the output of a foldable node to the constant tensor it produces. Each
+  // such node is rewritten into a `Constant` node holding this value.
+  std::unordered_map<std::string, onnx::TensorProto> folded_values;
 
   for (const auto& node : model.graph().node()) {
     // Shape-family ops are single-output; only replace a node when its lone
@@ -568,7 +567,7 @@ onnx::ModelProto _EvalPartialShape(const onnx::ModelProto& input_model) {
       continue;
     }
 
-    // Materialize an initializer with the output's real dtype and shape. The
+    // Build the constant tensor with the output's real dtype and shape. The
     // propagated data is a flat sequence, so require a fully static shape whose
     // element count matches what was propagated.
     onnx::TensorProto::DataType elem_type;
@@ -585,7 +584,6 @@ onnx::ModelProto _EvalPartialShape(const onnx::ModelProto& input_model) {
     }
 
     onnx::TensorProto tp;
-    tp.set_name(output);
     tp.set_data_type(elem_type);
     for (int64_t d : dims) {
       tp.add_dims(d);
@@ -599,26 +597,34 @@ onnx::ModelProto _EvalPartialShape(const onnx::ModelProto& input_model) {
         tp.add_int32_data(static_cast<int32_t>(v));
       }
     }
-    new_initializers.push_back(std::move(tp));
-    replaced_outputs.insert(output);
+    folded_values.emplace(output, std::move(tp));
   }
 
-  if (replaced_outputs.empty()) {
+  if (folded_values.empty()) {
     return input_model;
   }
 
-  // Drop the replaced nodes (keeping topological order) and add the constants.
+  // Rewrite each foldable node into a `Constant` node in the same position,
+  // keeping the graph topologically sorted. Emitting a `Constant` node (rather
+  // than injecting an initializer) leaves the value in producer form, so the
+  // ordinary constant folder and optimizer decide how to materialize it.
   google::protobuf::RepeatedPtrField<onnx::NodeProto> original_nodes;
   original_nodes.Swap(model.mutable_graph()->mutable_node());
   for (auto& node : original_nodes) {
-    const bool replaced = node.output_size() == 1 &&
-                          replaced_outputs.count(node.output(0)) > 0;
-    if (!replaced) {
+    auto iter = node.output_size() == 1 ? folded_values.find(node.output(0))
+                                        : folded_values.end();
+    if (iter == folded_values.end()) {
       *model.mutable_graph()->add_node() = std::move(node);
+      continue;
     }
-  }
-  for (auto& init : new_initializers) {
-    *model.mutable_graph()->add_initializer() = std::move(init);
+    onnx::NodeProto* constant = model.mutable_graph()->add_node();
+    constant->set_name(node.name());
+    constant->set_op_type("Constant");
+    constant->add_output(iter->first);
+    onnx::AttributeProto* attr = constant->add_attribute();
+    attr->set_name("value");
+    attr->set_type(onnx::AttributeProto::TENSOR);
+    *attr->mutable_t() = std::move(iter->second);
   }
   return model;
 }

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -442,6 +442,280 @@ onnx::ModelProto _InferShapes(const onnx::ModelProto& model) {
   return result;
 }
 
+// Read an integer initializer (INT32/INT64) into an int64 vector. Returns false
+// if the tensor is not an integer type onnxsim knows how to read.
+bool ReadIntInitializer(const onnx::TensorProto& tp, std::vector<int64_t>& out) {
+  out.clear();
+  const auto dtype = tp.data_type();
+  if (dtype != onnx::TensorProto::INT64 && dtype != onnx::TensorProto::INT32) {
+    return false;
+  }
+  if (tp.has_raw_data()) {
+    // onnxsim assumes little endian everywhere (see TensorProtoToTensor).
+    const std::string& raw = tp.raw_data();
+    if (dtype == onnx::TensorProto::INT64) {
+      const size_t n = raw.size() / sizeof(int64_t);
+      const int64_t* p = reinterpret_cast<const int64_t*>(raw.data());
+      out.assign(p, p + n);
+    } else {
+      const size_t n = raw.size() / sizeof(int32_t);
+      const int32_t* p = reinterpret_cast<const int32_t*>(raw.data());
+      out.assign(p, p + n);
+    }
+  } else if (dtype == onnx::TensorProto::INT64) {
+    out.assign(tp.int64_data().begin(), tp.int64_data().end());
+  } else {
+    out.assign(tp.int32_data().begin(), tp.int32_data().end());
+  }
+  return true;
+}
+
+// A single dimension of a (possibly partially known) tensor shape. `known` is
+// true when the dimension is a fixed integer stored in `value`; otherwise the
+// dimension is symbolic/dynamic.
+struct MaybeDim {
+  bool known;
+  int64_t value;
+};
+
+// Build a lookup from tensor name to its type, gathering shapes from every
+// place a shape can be declared: value_info (populated by shape inference),
+// graph inputs and graph outputs. Pointers reference `model`, so the map must
+// not outlive it and `model` must not be mutated while the map is in use.
+std::unordered_map<std::string, const onnx::TypeProto*> BuildTypeMap(
+    const onnx::ModelProto& model) {
+  std::unordered_map<std::string, const onnx::TypeProto*> type_map;
+  auto add = [&type_map](const onnx::ValueInfoProto& vi) {
+    if (vi.has_type()) {
+      type_map[vi.name()] = &vi.type();
+    }
+  };
+  for (const auto& vi : model.graph().value_info()) add(vi);
+  for (const auto& vi : model.graph().input()) add(vi);
+  for (const auto& vi : model.graph().output()) add(vi);
+  return type_map;
+}
+
+// Fetch the (partially known) shape of `name` from `type_map`. Returns false
+// when the rank is unknown (no shape recorded); returns true with one MaybeDim
+// per dimension otherwise. A rank-0 (scalar) tensor yields an empty `dims`.
+bool GetTensorDims(
+    const std::unordered_map<std::string, const onnx::TypeProto*>& type_map,
+    const std::string& name, std::vector<MaybeDim>& dims) {
+  auto iter = type_map.find(name);
+  if (iter == type_map.end() || !iter->second->has_tensor_type()) {
+    return false;
+  }
+  const auto& tensor_type = iter->second->tensor_type();
+  if (!tensor_type.has_shape()) {
+    // Rank is unknown.
+    return false;
+  }
+  dims.clear();
+  for (const auto& dim : tensor_type.shape().dim()) {
+    if (dim.has_dim_value()) {
+      dims.push_back({true, dim.dim_value()});
+    } else {
+      dims.push_back({false, 0});
+    }
+  }
+  return true;
+}
+
+bool IsDefaultDomain(const std::string& domain) {
+  return domain.empty() || domain == "ai.onnx";
+}
+
+// Build a 1-D INT64 initializer named `name` from `values`.
+onnx::TensorProto MakeInt64Initializer(const std::string& name,
+                                       const std::vector<int64_t>& values) {
+  onnx::TensorProto tp;
+  tp.set_name(name);
+  tp.set_data_type(onnx::TensorProto::INT64);
+  tp.add_dims(static_cast<int64_t>(values.size()));
+  for (const auto& v : values) {
+    tp.add_int64_data(v);
+  }
+  return tp;
+}
+
+// Partial shape evaluation (issue #139).
+//
+// The plain constant folder only folds a node when *all* of its inputs are
+// constant, so a `Shape` op is never folded: its input is an activation. But
+// `Shape` depends solely on the input's shape, and after shape inference some
+// (or all) of those dimensions are statically known even when others stay
+// dynamic. This pass exploits that:
+//
+//   * A `Shape` whose selected dimensions are *all* static becomes a constant
+//     initializer directly.
+//   * A `Gather` reading constant indices from a `Shape` output becomes a
+//     constant initializer whenever every gathered dimension is static -- even
+//     if the surrounding shape has dynamic dimensions. This is the mask-rcnn
+//     pattern from issue #139: `Shape([batch, C, H, W]) -> Gather([1, 2, 3])`
+//     is `[C, H, W]` regardless of the dynamic batch dimension.
+//
+// Downstream ops (Unsqueeze, Concat, ...) then fold through the normal constant
+// folder, and now-dead Shape/Gather nodes are removed by the optimizer.
+onnx::ModelProto _EvalPartialShape(const onnx::ModelProto& input_model) {
+  onnx::ModelProto model;
+  try {
+    model = _InferShapes(input_model);
+  } catch (const std::exception&) {
+    // If shape inference fails we simply have no extra shapes to exploit.
+    return input_model;
+  }
+
+  const auto type_map = BuildTypeMap(model);
+
+  std::unordered_map<std::string, const onnx::TensorProto*> init_map;
+  for (const auto& init : model.graph().initializer()) {
+    init_map[init.name()] = &init;
+  }
+
+  // For every `Shape` node, precompute the (partially known) vector of
+  // dimensions it produces, honoring the optional `start`/`end` attributes
+  // (opset 15+). Keyed by the Shape node's output name.
+  std::unordered_map<std::string, std::vector<MaybeDim>> shape_outputs;
+  for (const auto& node : model.graph().node()) {
+    if (node.op_type() != "Shape" || !IsDefaultDomain(node.domain())) {
+      continue;
+    }
+    if (node.input_size() < 1 || node.output_size() < 1) {
+      continue;
+    }
+    std::vector<MaybeDim> dims;
+    if (!GetTensorDims(type_map, node.input(0), dims)) {
+      continue;
+    }
+    const int64_t rank = static_cast<int64_t>(dims.size());
+    int64_t start = 0;
+    int64_t end = rank;
+    for (const auto& attr : node.attribute()) {
+      if (attr.name() == "start") {
+        start = attr.i();
+      } else if (attr.name() == "end") {
+        end = attr.i();
+      }
+    }
+    if (start < 0) start += rank;
+    if (end < 0) end += rank;
+    start = std::clamp<int64_t>(start, 0, rank);
+    end = std::clamp<int64_t>(end, 0, rank);
+    if (end < start) end = start;
+    shape_outputs[node.output(0)] =
+        std::vector<MaybeDim>(dims.begin() + start, dims.begin() + end);
+  }
+
+  if (shape_outputs.empty()) {
+    return input_model;
+  }
+
+  // Node output(0) names whose producing node is being replaced by an
+  // initializer, plus the initializers to add.
+  std::set<std::string> replaced_outputs;
+  std::vector<onnx::TensorProto> new_initializers;
+
+  // Case 1: a Shape whose every selected dimension is static folds to a
+  // constant.
+  for (const auto& [output, dims] : shape_outputs) {
+    const bool all_known = std::all_of(
+        dims.begin(), dims.end(), [](const MaybeDim& d) { return d.known; });
+    if (!all_known) {
+      continue;
+    }
+    std::vector<int64_t> values;
+    for (const auto& d : dims) {
+      values.push_back(d.value);
+    }
+    new_initializers.push_back(MakeInt64Initializer(output, values));
+    replaced_outputs.insert(output);
+  }
+
+  // Case 2: a Gather with constant indices reading a Shape output folds to a
+  // constant whenever every gathered dimension is static.
+  for (const auto& node : model.graph().node()) {
+    if (node.op_type() != "Gather" || !IsDefaultDomain(node.domain())) {
+      continue;
+    }
+    if (node.input_size() < 2 || node.output_size() < 1) {
+      continue;
+    }
+    // The Shape output is 1-D, so only axis 0 makes sense.
+    int64_t axis = 0;
+    for (const auto& attr : node.attribute()) {
+      if (attr.name() == "axis") {
+        axis = attr.i();
+      }
+    }
+    if (axis != 0) {
+      continue;
+    }
+    auto shape_iter = shape_outputs.find(node.input(0));
+    if (shape_iter == shape_outputs.end()) {
+      continue;
+    }
+    const auto& dims = shape_iter->second;
+    const int64_t length = static_cast<int64_t>(dims.size());
+
+    auto idx_iter = init_map.find(node.input(1));
+    if (idx_iter == init_map.end()) {
+      continue;
+    }
+    const onnx::TensorProto& indices_tp = *idx_iter->second;
+    std::vector<int64_t> indices;
+    if (!ReadIntInitializer(indices_tp, indices)) {
+      continue;
+    }
+
+    bool foldable = true;
+    std::vector<int64_t> values;
+    for (int64_t idx : indices) {
+      const int64_t norm = idx < 0 ? idx + length : idx;
+      if (norm < 0 || norm >= length || !dims[norm].known) {
+        foldable = false;
+        break;
+      }
+      values.push_back(dims[norm].value);
+    }
+    if (!foldable) {
+      continue;
+    }
+
+    // The output has the same shape as the indices tensor (data is 1-D).
+    onnx::TensorProto tp;
+    tp.set_name(node.output(0));
+    tp.set_data_type(onnx::TensorProto::INT64);
+    for (const auto& dim : indices_tp.dims()) {
+      tp.add_dims(dim);
+    }
+    for (const auto& v : values) {
+      tp.add_int64_data(v);
+    }
+    new_initializers.push_back(std::move(tp));
+    replaced_outputs.insert(node.output(0));
+  }
+
+  if (replaced_outputs.empty()) {
+    return input_model;
+  }
+
+  // Drop the replaced nodes (keeping topological order) and add the constants.
+  google::protobuf::RepeatedPtrField<onnx::NodeProto> original_nodes;
+  original_nodes.Swap(model.mutable_graph()->mutable_node());
+  for (auto& node : original_nodes) {
+    const bool replaced = node.output_size() > 0 &&
+                          replaced_outputs.count(node.output(0)) > 0;
+    if (!replaced) {
+      *model.mutable_graph()->add_node() = std::move(node);
+    }
+  }
+  for (auto& init : new_initializers) {
+    *model.mutable_graph()->add_initializer() = std::move(init);
+  }
+  return model;
+}
+
 onnx::ModelProto _FoldConstant(const ModelExecutor& executor,
                                const onnx::ModelProto& model) {
   const auto& tmp = model;
@@ -560,7 +834,9 @@ onnx::ModelProto Simplify(
   std::function<onnx::ModelProto(const onnx::ModelProto&)> FoldConstant;
   if (constant_folding) {
     FoldConstant = [&executor](const onnx::ModelProto& model) {
-      return _FoldConstant(executor, model);
+      // Partial shape evaluation (issue #139) turns Shape/Gather-on-shape into
+      // constants that the ordinary constant folder can then propagate.
+      return _FoldConstant(executor, _EvalPartialShape(model));
     };
   } else {
     FoldConstant = Identity;

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -180,6 +180,20 @@ def test_ext():
         assert check_ok
 
 
+def _constant_value(model, name):
+    # Return the constant value produced for `name`, whether it is delivered as
+    # a graph initializer or as a Constant node's value attribute, else None.
+    for initializer in model.graph.initializer:
+        if initializer.name == name:
+            return numpy_helper.to_array(initializer)
+    for node in model.graph.node:
+        if node.op_type == "Constant" and name in node.output:
+            for attr in node.attribute:
+                if attr.name == "value":
+                    return numpy_helper.to_array(attr.t)
+    return None
+
+
 def test_partial_shape_evaluation_gather():
     # Partial shape evaluation for https://github.com/onnxsim/onnxsim/issues/139
     # The input's leading dimension is dynamic, but a Gather that reads only the
@@ -203,9 +217,9 @@ def test_partial_shape_evaluation_gather():
     # batch dimension is dynamic.
     assert "Shape" not in op_types
     assert "Gather" not in op_types
-    initializers = {i.name: i for i in sim_model.graph.initializer}
-    assert "g" in initializers
-    assert list(numpy_helper.to_array(initializers["g"])) == [3, 4, 5]
+    value = _constant_value(sim_model, "g")
+    assert value is not None
+    assert list(value) == [3, 4, 5]
 
 
 def test_partial_shape_evaluation_keeps_dynamic_gather():
@@ -226,8 +240,10 @@ def test_partial_shape_evaluation_keeps_dynamic_gather():
     assert check_ok
     onnx.checker.check_model(sim_model)
     op_types = [n.op_type for n in sim_model.graph.node]
-    # The dynamic dimension cannot be pre-computed, so the ops stay.
+    # The dynamic dimension cannot be pre-computed, so the ops stay and "g" is
+    # not turned into a constant.
     assert "Gather" in op_types
+    assert _constant_value(sim_model, "g") is None
 
 
 def test_unfoldable_const_node_keeps_topological_order():

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -5,7 +5,7 @@ import onnxruntime
 import onnxsim
 import os
 
-from onnx import helper, TensorProto
+from onnx import helper, numpy_helper, TensorProto
 from typing import Optional
 from onnxsim.test_utils import export_simplify_and_check_by_python_api
 
@@ -178,6 +178,56 @@ def test_ext():
         sim_model, check_ok = onnxsim.simplify(model_fn, check_n=0)
         module = None
         assert check_ok
+
+
+def test_partial_shape_evaluation_gather():
+    # Partial shape evaluation for https://github.com/onnxsim/onnxsim/issues/139
+    # The input's leading dimension is dynamic, but a Gather that reads only the
+    # static dimensions of its shape must still be pre-computed into a constant.
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, ["batch", 3, 4, 5])
+    g = helper.make_tensor_value_info("g", TensorProto.INT64, [3])
+    indices = helper.make_tensor("indices", TensorProto.INT64, [3], [1, 2, 3])
+    nodes = [
+        helper.make_node("Shape", ["x"], ["s"]),
+        helper.make_node("Gather", ["s", "indices"], ["g"], axis=0),
+    ]
+    graph = helper.make_graph(nodes, "g", [x], [g], initializer=[indices])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    onnx.checker.check_model(model)
+
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+    op_types = [n.op_type for n in sim_model.graph.node]
+    # The whole Shape -> Gather chain collapses to a constant even though the
+    # batch dimension is dynamic.
+    assert "Shape" not in op_types
+    assert "Gather" not in op_types
+    initializers = {i.name: i for i in sim_model.graph.initializer}
+    assert "g" in initializers
+    assert list(numpy_helper.to_array(initializers["g"])) == [3, 4, 5]
+
+
+def test_partial_shape_evaluation_keeps_dynamic_gather():
+    # A Gather that reads the dynamic dimension must NOT be folded: its value is
+    # unknown until runtime.
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, ["batch", 3, 4, 5])
+    g = helper.make_tensor_value_info("g", TensorProto.INT64, [1])
+    indices = helper.make_tensor("indices", TensorProto.INT64, [1], [0])
+    nodes = [
+        helper.make_node("Shape", ["x"], ["s"]),
+        helper.make_node("Gather", ["s", "indices"], ["g"], axis=0),
+    ]
+    graph = helper.make_graph(nodes, "g", [x], [g], initializer=[indices])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    onnx.checker.check_model(model)
+
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+    op_types = [n.op_type for n in sim_model.graph.node]
+    # The dynamic dimension cannot be pre-computed, so the ops stay.
+    assert "Gather" in op_types
 
 
 def test_unfoldable_const_node_keeps_topological_order():


### PR DESCRIPTION
## Summary

Implements partial shape evaluation, as requested in [issue #139](https://github.com/onnxsim/onnxsim/issues/139).

The plain constant folder only folds a node when **all** of its inputs are constant, so a shape-computing op like `Shape` is never folded — its input is an activation. Yet `Shape` depends solely on the input's *shape*, which shape inference knows fully or partially even when some dimensions stay dynamic. As a result, a pattern like `Shape([batch, C, H, W]) -> Gather([1, 2, 3])` was left dynamic even though the gathered dimensions `[C, H, W]` are constant. This pattern shows up frequently in mask-rcnn models.

## Approach

The pass is built on ONNX's **data propagation**, which is the upstream mechanism for exactly this. Running shape inference with data propagation enabled fills a `DataValueMap` mapping each tensor to a `TensorShapeProto` whose entries are either a concrete `dim_value` or a symbolic `dim_param`:

```cpp
onnx::shape_inference::DataValueMap data_map;
onnx::ShapeInferenceOptions options(/*check_type=*/false, /*error_mode=*/0, /*data_prop=*/true);
onnx::shape_inference::InferShapes(model, onnx::OpSchemaRegistry::Instance(), options, &data_map);
```

The whole shape-op family (`Shape`, `Gather`, `Slice`, `Concat`, `Squeeze`/`Unsqueeze`, `Cast`, `Add`/`Sub`/`Mul`, …) participates, so a chain like `Shape([batch, C, H, W]) -> Gather([1, 2, 3])` is propagated end to end and comes out fully concrete even though the batch dimension stays dynamic.

The pass folds every node whose lone output has a fully concrete propagated value into a constant initializer, using the output's real dtype and shape from `value_info`. Downstream ops then fold through the ordinary constant folder, and now-dead nodes are removed by the optimizer.

**Soundness:** data propagation encodes an *unknown* element as a dimension with neither `dim_value` nor `dim_param`, so requiring `dim_value` on every entry both proves the value is constant and rejects activations whose rank alone is known.

## Testing

Built the extension locally and verified against it:

- **Issue #139 case** — `Shape([batch,3,4,5]) -> Gather([1,2,3])` folds to the constant `[3,4,5]` even with a dynamic batch dimension.
- **Dynamic dimension preserved** — `Gather([0])` on the dynamic batch dim is correctly *not* folded.
- **Broader coverage** — `Shape -> Slice([1:4])` and `Shape -> Gather(scalar) -> Unsqueeze -> Concat` chains also fold.
- **No regression** — the existing constant-folding topological-order test still passes.

Two regression tests are added in `tests/test_simple.py` (`test_partial_shape_evaluation_gather` and `test_partial_shape_evaluation_keeps_dynamic_gather`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaiF42YLTKFM7LmSBd7iDW

closes https://github.com/onnxsim/onnxsim/issues/139

---
_Generated by [Claude Code](https://claude.ai/code/session_01UaiF42YLTKFM7LmSBd7iDW)_