### PR TITLE
Support custom operators in default ONNX domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ assert check, "Simplified ONNX model could not be validated"
 
 You can see more details of the API in [onnxsim/onnx_simplifier.py](onnxsim/onnx_simplifier.py)
 
+## Custom operators
+
+Models that contain custom operators, such as TensorRT plugins
+(`BatchedNMS_TRT`, `EfficientNMS_TRT`, ...), are supported. onnxsim keeps these
+ops unchanged and simplifies the rest of the graph around them. This works
+whether the custom op lives in a vendor-specific domain (e.g. `TRT`) or in the
+default ONNX domain, so you no longer need to manually move it into a custom
+domain to get past validation (issues
+[#107](https://github.com/onnxsim/onnxsim/issues/107) and
+[#220](https://github.com/onnxsim/onnxsim/issues/220)).
+
 ## Projects Using ONNX Simplifier
 
 * [MXNet](https://mxnet.apache.org/versions/1.9.1/api/python/docs/tutorials/deploy/export/onnx.html#Simplify-the-exported-ONNX-model)

--- a/onnxsim/model_checking.py
+++ b/onnxsim/model_checking.py
@@ -1,7 +1,8 @@
-from typing import List, Dict, Optional, Union
+from typing import Iterable, List, Dict, Optional, Set, Union
 
 import onnx
 import onnx.checker
+import onnx.defs
 import numpy as np
 
 from . import backend
@@ -9,6 +10,40 @@ from . import backend
 Tensors = Dict[str, np.ndarray]
 TensorShape = List[int]
 TensorShapes = Dict[Optional[str], TensorShape]
+
+
+def _iter_graph_nodes(graph: onnx.GraphProto) -> Iterable[onnx.NodeProto]:
+    """Yield every node in ``graph``, recursing into subgraph attributes."""
+    for node in graph.node:
+        yield node
+        for attr in node.attribute:
+            if attr.HasField("g"):
+                yield from _iter_graph_nodes(attr.g)
+            for subgraph in attr.graphs:
+                yield from _iter_graph_nodes(subgraph)
+
+
+def _custom_default_domain_ops(model: onnx.ModelProto) -> Set[str]:
+    """Return op types in the default ONNX domain that have no ONNX schema.
+
+    These are custom operators such as TensorRT plugins (e.g. ``BatchedNMS_TRT``)
+    that were exported into the default domain. ``onnx.checker.check_model``
+    rejects such a model with "No Op registered for <op> with domain_version of
+    <n>" (GitHub issues #107, #220). onnxsim preserves these ops unchanged, so
+    the checker error about them is expected and tolerated.
+    """
+    try:
+        known = {
+            (schema.domain, schema.name)
+            for schema in onnx.defs.get_all_schemas_with_history()
+        }
+    except Exception:
+        known = set()
+    custom_ops = set()
+    for node in _iter_graph_nodes(model.graph):
+        if node.domain in ("", "ai.onnx") and ("", node.op_type) not in known:
+            custom_ops.add(node.op_type)
+    return custom_ops
 
 
 def compare(
@@ -136,7 +171,24 @@ def compare(
 
     if input_shapes is None:
         input_shapes = {}
-    onnx.checker.check_model(model_opt)
+    try:
+        onnx.checker.check_model(model_opt)
+    except onnx.checker.ValidationError as e:
+        # A model containing a custom op in the default ONNX domain (e.g. a
+        # TensorRT plugin like BatchedNMS_TRT) fails validation with "No Op
+        # registered for <op> ...". onnxsim preserves such ops unchanged, so
+        # tolerate that specific error instead of failing (GitHub issues #107,
+        # #220). Any other validation error is a genuine problem and re-raised.
+        custom_ops = _custom_default_domain_ops(model_opt)
+        message = str(e)
+        if custom_ops and any(op in message for op in custom_ops):
+            print(
+                "The model contains custom operator(s) {} in the default ONNX "
+                "domain (e.g. a TensorRT plugin). They are preserved unchanged "
+                "and skipped during model checking.".format(sorted(custom_ops))
+            )
+        else:
+            raise
     for i in range(n_times):
         print(f'Checking {i}/{n_times}...')
         if input_data is None:

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <fstream>
 #include <numeric>
+#include <set>
+#include <string>
 #include <unordered_map>
 
 #ifndef NO_BUILTIN_ORT
@@ -529,6 +531,88 @@ std::function<T(const T&)> FixedPointFn(const std::function<T(const T&)>& f1,
 
 onnx::ModelProto Identity(const onnx::ModelProto& model) { return model; }
 
+// Recursively collect the op types of operators that live in ONNX's *default*
+// domain but have no registered schema. These are custom operators -- most
+// commonly TensorRT plugins such as ``BatchedNMS_TRT`` or ``EfficientNMS_TRT``
+// -- that were exported into the default domain instead of a vendor-specific
+// one.
+//
+// Custom ops that already live in a non-default domain (e.g. ``com.microsoft``
+// or ``TRT``) are intentionally ignored: onnx::checker::check_model already
+// tolerates unknown ops in non-standard domains, which is exactly the manual
+// workaround reported in GitHub issue #220.
+void CollectCustomDefaultDomainOps(const onnx::GraphProto& graph,
+                                   int default_opset_version,
+                                   std::set<std::string>& custom_ops) {
+  for (const auto& node : graph.node()) {
+    const std::string& domain = node.domain();
+    const bool is_default_domain = domain.empty() || domain == "ai.onnx";
+    if (is_default_domain &&
+        onnx::OpSchemaRegistry::Schema(node.op_type(), default_opset_version,
+                                       /*domain=*/"") == nullptr) {
+      custom_ops.insert(node.op_type());
+    }
+    // Recurse into subgraphs held in node attributes (If/Loop/Scan bodies).
+    for (const auto& attr : node.attribute()) {
+      if (attr.has_g()) {
+        CollectCustomDefaultDomainOps(attr.g(), default_opset_version, custom_ops);
+      }
+      for (const auto& subgraph : attr.graphs()) {
+        CollectCustomDefaultDomainOps(subgraph, default_opset_version, custom_ops);
+      }
+    }
+  }
+}
+
+// Register a permissive placeholder schema for every default-domain custom op
+// found in ``model``. Without a schema, onnx::checker::check_model rejects the
+// model with "No Op registered for <op> with domain_version of <n>" and
+// simplification never even starts (GitHub issues #107 and #220). The
+// placeholder accepts any number of inputs/outputs of any tensor type and any
+// attributes, so the checker passes and the op is preserved untouched through
+// simplification. It carries no shape/type inference function, so shape
+// inference simply flows past the op as before.
+void RegisterCustomDefaultDomainOpSchemas(const onnx::ModelProto& model) {
+  int default_opset_version = 1;
+  for (const auto& opset : model.opset_import()) {
+    if (opset.domain().empty() || opset.domain() == "ai.onnx") {
+      default_opset_version =
+          std::max(default_opset_version, static_cast<int>(opset.version()));
+    }
+  }
+
+  std::set<std::string> custom_ops;
+  CollectCustomDefaultDomainOps(model.graph(), default_opset_version, custom_ops);
+
+  for (const auto& op_type : custom_ops) {
+    onnx::OpSchema schema;
+    schema.SetName(op_type)
+        .SetDomain("")
+        .SinceVersion(1)
+        .SetDoc(
+            "Placeholder schema registered by onnxsim for a custom operator "
+            "(e.g. a TensorRT plugin) exported into the default ONNX domain, so "
+            "that the model passes validation and is simplified with the "
+            "operator preserved unchanged.")
+        .Input(0, "inputs", "Variadic inputs of the custom operator.", "T",
+               onnx::OpSchema::Variadic, /*is_homogeneous=*/false,
+               /*min_arity=*/0)
+        .Output(0, "outputs", "Variadic outputs of the custom operator.", "T",
+                onnx::OpSchema::Variadic, /*is_homogeneous=*/false,
+                /*min_arity=*/0)
+        .TypeConstraint("T", onnx::OpSchema::all_tensor_types(),
+                        "Allow inputs and outputs of any tensor type.")
+        // Custom ops carry arbitrary, plugin-specific attributes; accept them
+        // all rather than trying to enumerate them.
+        .AllowUncheckedAttributes();
+    // Never fail or throw: a duplicate registration (e.g. simplifying two models
+    // that use the same custom op in one process) is a harmless no-op.
+    onnx::RegisterSchema(std::move(schema), /*opset_version_to_load=*/1,
+                         /*fail_duplicate_schema=*/false,
+                         /*fail_with_exception=*/false);
+  }
+}
+
 void Check(const onnx::ModelProto& model) { onnx::checker::check_model(model); }
 
 onnx::ModelProto Simplify(
@@ -538,6 +622,10 @@ onnx::ModelProto Simplify(
   // Make shape inference aware of ONNX Runtime's quantized contrib operators
   // (QLinearAdd and friends) so shape deduction does not stop at them.
   onnxsim::RegisterContribOpSchemas();
+  // Register permissive placeholder schemas for custom ops exported into the
+  // default ONNX domain (e.g. TensorRT plugins such as BatchedNMS_TRT) so the
+  // checker below does not reject the model (GitHub issues #107, #220).
+  RegisterCustomDefaultDomainOpSchemas(model);
 
   Check(model);
 

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -595,6 +595,113 @@ def test_run_coerces_non_ndarray_output():
     assert check_ok
 
 
+def _make_batched_nms_trt_model():
+    # A model whose only compute node is the TensorRT plugin ``BatchedNMS_TRT``
+    # exported into the *default* ONNX domain, exactly as reported in GitHub
+    # issue #107 ("No Op registered for BatchedNMS_TRT with domain_version of 9").
+    boxes = onnx.helper.make_tensor_value_info(
+        "boxes", onnx.TensorProto.FLOAT, [1, 100, 1, 4]
+    )
+    scores = onnx.helper.make_tensor_value_info(
+        "scores", onnx.TensorProto.FLOAT, [1, 100, 5]
+    )
+    num_detections = onnx.helper.make_tensor_value_info(
+        "num_detections", onnx.TensorProto.INT32, [1, 1]
+    )
+    nmsed_boxes = onnx.helper.make_tensor_value_info(
+        "nmsed_boxes", onnx.TensorProto.FLOAT, [1, 20, 4]
+    )
+    nmsed_scores = onnx.helper.make_tensor_value_info(
+        "nmsed_scores", onnx.TensorProto.FLOAT, [1, 20]
+    )
+    nmsed_classes = onnx.helper.make_tensor_value_info(
+        "nmsed_classes", onnx.TensorProto.FLOAT, [1, 20]
+    )
+    node = onnx.helper.make_node(
+        "BatchedNMS_TRT",
+        ["boxes", "scores"],
+        ["num_detections", "nmsed_boxes", "nmsed_scores", "nmsed_classes"],
+        # plugin-specific attributes of assorted types
+        shareLocation=1,
+        backgroundLabelId=-1,
+        numClasses=5,
+        topK=100,
+        keepTopK=20,
+        scoreThreshold=0.3,
+        iouThreshold=0.5,
+        isNormalized=1,
+        clipBoxes=1,
+    )
+    graph = onnx.helper.make_graph(
+        [node],
+        "batched_nms_trt",
+        [boxes, scores],
+        [num_detections, nmsed_boxes, nmsed_scores, nmsed_classes],
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 9)]
+    )
+    model.ir_version = 6
+    return model
+
+
+def test_custom_trt_op_in_default_domain_is_simplified():
+    # Regression test for GitHub issues #107 and #220. A custom TensorRT plugin
+    # op (``BatchedNMS_TRT``) exported into the default ONNX domain used to make
+    # onnxsim fail in onnx.checker.check_model with
+    #     No Op registered for BatchedNMS_TRT with domain_version of 9
+    # onnxsim now registers a permissive placeholder schema for such ops so the
+    # model passes validation and is simplified with the op preserved.
+    model = _make_batched_nms_trt_model()
+
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+
+    nms_nodes = [n for n in sim_model.graph.node if n.op_type == "BatchedNMS_TRT"]
+    assert len(nms_nodes) == 1
+    # The op stays in the default domain and keeps its attributes.
+    assert nms_nodes[0].domain in ("", "ai.onnx")
+    attr_names = {a.name for a in nms_nodes[0].attribute}
+    assert {"numClasses", "keepTopK", "iouThreshold"} <= attr_names
+
+
+def test_custom_trt_op_does_not_block_surrounding_simplification():
+    # The presence of a default-domain custom op must not prevent onnxsim from
+    # simplifying the rest of the graph. Here a redundant Identity feeding the
+    # plugin should be eliminated while the custom op survives (issues #107/#220).
+    boxes = onnx.helper.make_tensor_value_info(
+        "boxes", onnx.TensorProto.FLOAT, [1, 100, 1, 4]
+    )
+    scores = onnx.helper.make_tensor_value_info(
+        "scores", onnx.TensorProto.FLOAT, [1, 100, 5]
+    )
+    out = onnx.helper.make_tensor_value_info(
+        "num_detections", onnx.TensorProto.INT32, [1, 1]
+    )
+    nodes = [
+        onnx.helper.make_node("Identity", ["boxes"], ["boxes_id"]),
+        onnx.helper.make_node(
+            "BatchedNMS_TRT",
+            ["boxes_id", "scores"],
+            ["num_detections"],
+            numClasses=5,
+            topK=100,
+            keepTopK=20,
+        ),
+    ]
+    graph = onnx.helper.make_graph(nodes, "g", [boxes, scores], [out])
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 11)]
+    )
+    model.ir_version = 6
+
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert "Identity" not in op_types
+    assert op_types.count("BatchedNMS_TRT") == 1
+
+
 def test_perform_optimization_false():
     def _create_dummy_model():
         class MockModel(torch.nn.Module):


### PR DESCRIPTION
## Summary

This PR adds support for custom operators (such as TensorRT plugins) that are exported into the default ONNX domain, fixing issues #107 and #220. Previously, onnxsim would fail validation when encountering such operators because they lack registered ONNX schemas. Now the tool gracefully handles these custom ops by registering permissive placeholder schemas and preserving them unchanged during simplification.

## Key Changes

- **C++ backend (onnxsim.cpp)**:
  - Added `CollectCustomDefaultDomainOps()` function to recursively identify custom operators in the default ONNX domain that lack registered schemas
  - Added `RegisterCustomDefaultDomainOpSchemas()` function to register permissive placeholder schemas for these custom ops, allowing model validation to pass
  - Integrated schema registration into the `Simplify()` function before model checking

- **Python model checking (model_checking.py)**:
  - Added `_iter_graph_nodes()` helper to traverse all nodes including those in subgraphs
  - Added `_custom_default_domain_ops()` function to identify custom operators in the default domain
  - Modified `forward()` validation to gracefully handle and tolerate validation errors for known custom operators while still catching genuine validation issues

- **Tests (test_python_api.py)**:
  - Added `_make_batched_nms_trt_model()` helper to create a test model with a `BatchedNMS_TRT` custom operator
  - Added `test_custom_trt_op_in_default_domain_is_simplified()` to verify custom ops are preserved during simplification
  - Added `test_custom_trt_op_does_not_block_surrounding_simplification()` to ensure custom ops don't prevent optimization of surrounding graph nodes

- **Documentation (README.md)**:
  - Added "Custom operators" section documenting support for TensorRT plugins and other custom operators in both vendor-specific and default ONNX domains

## Implementation Details

The solution works by:
1. Detecting custom operators in the default ONNX domain that have no registered schema
2. Registering permissive placeholder schemas that accept any inputs/outputs/attributes
3. Allowing model validation to pass while preserving the custom ops unchanged
4. Continuing normal simplification on the rest of the graph

This approach is non-invasive and doesn't require users to manually move custom operators to vendor-specific domains.

https://claude.ai/code/session_01PmGW1uScfBXmD6StJBxbsp