### PR TITLE
Optimize peak memory usage by releasing models earlier

### DIFF
--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -340,13 +340,38 @@ def simplify(
             not skip_shape_inference,
             tensor_size_threshold,
         )
+        # The serialized original (~1x model) is not needed once the C++
+        # simplifier has consumed it -- the large-model fallback below
+        # re-serializes from ``model`` rather than reusing these bytes. Free it
+        # now so it is not held alive while the simplified result is
+        # deserialized, which would otherwise inflate peak memory for no reason.
+        del model_bytes
         if len(model_opt_bytes) == 0:
             raise ValueError("Simplified model larger than 2GB")
+        # With ``check_n == 0`` the original model is never read again:
+        # ``model_checking.compare`` only touches it inside the ``range(check_n)``
+        # loop, so it merely runs ``onnx.checker.check_model`` on the result.
+        # Release the original before deserializing the result to lower peak
+        # memory. Only do so when we own the model (a caller-provided
+        # ``ModelProto`` is still referenced by the caller, so dropping our
+        # reference would not free anything). This must come *after* the
+        # ``len(model_opt_bytes) == 0`` check above -- that is the ">2GB
+        # optimized model" trigger whose fallback re-simplifies from ``model``.
+        if check_n == 0 and model_owned:
+            model = None
         model_opt = onnx.load_from_string(model_opt_bytes)
         check_ok = model_checking.compare(
             model_opt, model, check_n, test_input_shapes, input_data, custom_lib
         )
     except (EncodeError, ValueError, onnx.onnx_cpp2py_export.checker.ValidationError):
+        if model is None:
+            # We released the original model above because ``check_n == 0`` made
+            # it unnecessary. The large-model fallback re-simplifies from it, so
+            # it cannot run here. This is not the recoverable >2GB case (that is
+            # caught by the ``len(model_opt_bytes) == 0`` check before the model
+            # is freed), so surface the exception directly instead of crashing
+            # on a ``None`` model.
+            raise
         print("[bold magenta]Simplified model larger than 2GB. Trying to save as external data...[/bold magenta]")
         # large models try to convert through a temporary file
         with tempfile.TemporaryDirectory() as tmpdirname:

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -574,11 +574,26 @@ bool GetStaticIntTensorInfo(
 // This pass rewrites every node whose lone output has a fully concrete
 // propagated value into a `Constant` node. Downstream ops then fold through the
 // ordinary constant folder, and now-dead nodes are removed by the optimizer.
-onnx::ModelProto _EvalPartialShape(const onnx::ModelProto& input_model) {
-  onnx::ModelProto model;
+void _EvalPartialShape(onnx::ModelProto& model) {
+  // This pass runs shape inference with *data propagation* (lenient options)
+  // purely to discover foldable shape values; it must not otherwise change the
+  // model. InferShapes mutates value_info and output types in place, so
+  // snapshot those annotations and restore them on the paths that fold nothing,
+  // leaving the model byte-for-byte unchanged (the old code returned the
+  // untouched input there). The snapshot is metadata only -- no tensor weights
+  // -- so it is cheap, unlike the full-model ``CopyFrom`` it replaces. Restoring
+  // also keeps this pass's data-propagation value_info out of the model, which
+  // matters: it differs from the regular shape-inference pass's value_info, and
+  // leaving it behind could make the outer fixed point oscillate.
+  auto saved_value_info = model.graph().value_info();
+  auto saved_output = model.graph().output();
+  auto restore = [&]() {
+    *model.mutable_graph()->mutable_value_info() = saved_value_info;
+    *model.mutable_graph()->mutable_output() = saved_output;
+  };
+
   onnx::shape_inference::DataValueMap data_map;
   try {
-    model.CopyFrom(input_model);
     const onnx::ShapeInferenceOptions options(/*check_type=*/false,
                                               /*error_mode=*/0,
                                               /*enable_data_propagation=*/true);
@@ -586,11 +601,13 @@ onnx::ModelProto _EvalPartialShape(const onnx::ModelProto& input_model) {
                                        options, &data_map);
   } catch (const std::exception&) {
     // If shape inference fails we simply have no propagated values to exploit.
-    return input_model;
+    restore();
+    return;
   }
 
   if (data_map.empty()) {
-    return input_model;
+    restore();
+    return;
   }
 
   const auto type_map = BuildTypeMap(model);
@@ -663,7 +680,8 @@ onnx::ModelProto _EvalPartialShape(const onnx::ModelProto& input_model) {
   }
 
   if (folded_values.empty()) {
-    return input_model;
+    restore();
+    return;
   }
 
   // Rewrite each foldable node into a `Constant` node in the same position,
@@ -688,7 +706,6 @@ onnx::ModelProto _EvalPartialShape(const onnx::ModelProto& input_model) {
     attr->set_type(onnx::AttributeProto::TENSOR);
     *attr->mutable_t() = std::move(iter->second);
   }
-  return model;
 }
 
 onnx::ModelProto _FoldConstant(const ModelExecutor& executor,
@@ -953,7 +970,8 @@ onnx::ModelProto Simplify(
     FoldConstant = [&executor](onnx::ModelProto& model) {
       // Partial shape evaluation (issue #139) turns Shape/Gather-on-shape into
       // constants that the ordinary constant folder can then propagate.
-      model = _FoldConstant(executor, _EvalPartialShape(model));
+      _EvalPartialShape(model);
+      model = _FoldConstant(executor, model);
     };
   } else {
     FoldConstant = Identity;

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -673,37 +673,82 @@ onnx::ModelProto Optimize(const onnx::ModelProto& model) {
   return onnx::optimization::OptimizeFixed(model, config.optimizer_passes);
 }
 
+// A 128-bit fingerprint of a model, used by FixedPointFn to detect when an
+// iteration stopped changing the model without keeping a second full ModelProto
+// around just for the comparison. Two models with the same fingerprint are
+// treated as equal; the odds of a false match are ~2^-128 per comparison, and a
+// false match would only stop simplification one round early (the model stays
+// valid), never produce an incorrect model.
+struct ModelFingerprint {
+  uint64_t h1;
+  uint64_t h2;
+  bool operator==(const ModelFingerprint& other) const {
+    return h1 == other.h1 && h2 == other.h2;
+  }
+};
+
+ModelFingerprint Fingerprint(const onnx::ModelProto& model) {
+  // ModelProto contains no protobuf ``map<>`` fields, so serialization order is
+  // stable and equal models serialize to identical bytes.
+  const std::string bytes = model.SerializeAsString();
+  // Two independent rolling hashes (FNV-1a and a splitmix-style mix) combined
+  // into a 128-bit value.
+  uint64_t h1 = 1469598103934665603ULL;  // FNV-1a offset basis
+  uint64_t h2 = 0;
+  for (unsigned char c : bytes) {
+    h1 = (h1 ^ c) * 1099511628211ULL;  // FNV-1a prime
+    h2 = (h2 + c) * 0x9E3779B97F4A7C15ULL;
+    h2 ^= h2 >> 29;
+  }
+  h2 ^= bytes.size();
+  return {h1, h2};
+}
+
+// Alternately apply ``f1`` and ``f2`` until the model stops changing (a joint
+// fixed point) or ``max_iters`` alternations elapse. Each application produces a
+// fresh model, so ``model`` is move-assigned in place and only a single
+// ModelProto is held live across the loop; convergence is detected by comparing
+// the fingerprints of consecutive states rather than keeping the previous
+// ModelProto for a ``MessageDifferencer::Equals`` call. This mirrors the
+// original consecutive-pair comparison exactly -- it stops as soon as the last
+// applied function left the model unchanged -- while roughly halving the number
+// of full model copies held at once (which matters because these fixed points
+// nest).
 template <typename T>
 std::function<T(const T&)> FixedPointFn(const std::function<T(const T&)>& f1,
                                         const std::function<T(const T&)>& f2,
                                         size_t max_iters, bool* converged) {
-  return [f1, f2, max_iters, converged](const T& x) {
+  return [f1, f2, max_iters, converged](const T& x) -> T {
     size_t _max_iters = max_iters;
-    T tmp1 = f1(x);
-    T tmp2 = f2(tmp1);
-    T& y1 = tmp1;
-    T& y2 = tmp2;
+    T model = f1(x);
+    ModelFingerprint fp_prev = Fingerprint(model);
+    model = f2(model);
+    ModelFingerprint fp_cur = Fingerprint(model);
     while (_max_iters-- > 0) {
-      if (google::protobuf::util::MessageDifferencer::Equals(y1, y2)) {
+      if (fp_cur == fp_prev) {
         if (converged) {
           *converged = true;
         }
-        return y2;
+        return model;
       }
-      y1 = f1(y2);
-      if (google::protobuf::util::MessageDifferencer::Equals(y1, y2)) {
+      model = f1(model);
+      fp_prev = fp_cur;
+      fp_cur = Fingerprint(model);
+      if (fp_cur == fp_prev) {
         if (converged) {
           *converged = true;
         }
-        return y1;
+        return model;
       }
-      y2 = f2(y1);
+      model = f2(model);
+      fp_prev = fp_cur;
+      fp_cur = Fingerprint(model);
     }
 
     if (converged) {
       *converged = false;
     }
-    return y2;
+    return model;
   };
 }
 

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -496,13 +496,12 @@ onnx::ModelProto EliminateUnusedInitializer(const onnx::ModelProto& model) {
   return result;
 }
 
-// Takes the model by value so a caller that no longer needs its copy can move
-// it in; ``onnx::shape_inference::InferShapes`` then mutates it in place, so no
-// extra ModelProto copy is made (the previous ``const&`` signature forced a
-// defensive ``CopyFrom`` because the input could not be mutated).
-onnx::ModelProto _InferShapes(onnx::ModelProto model) {
+// Mutates the model in place; ``onnx::shape_inference::InferShapes`` already
+// works in place, so no extra ModelProto copy is made (the previous ``const&``
+// signature forced a defensive ``CopyFrom`` because the input could not be
+// mutated).
+void _InferShapes(onnx::ModelProto& model) {
   onnx::shape_inference::InferShapes(model);
-  return model;
 }
 
 // Build a lookup from tensor name to its type, gathering shapes from every
@@ -779,40 +778,39 @@ ModelFingerprint Fingerprint(const onnx::ModelProto& model) {
 // applied function left the model unchanged -- while roughly halving the number
 // of full model copies held at once (which matters because these fixed points
 // nest).
-// The transforms take and return the model by value, so the working model is
-// moved from one to the next (``model = f(std::move(model))``) rather than
-// copied. A transform that mutates in place (e.g. ``_InferShapes``) then makes
-// no copy at all; one that must build a fresh model (e.g. ``Optimize``, whose
-// underlying ``OptimizeFixed`` returns a new proto) is no worse than before.
-// The returned function is likewise by-value so it composes when these fixed
-// points nest.
+// The transforms mutate the model in place (``std::function<void(T&)>``), so a
+// transform that already works in place (e.g. ``_InferShapes``) makes no copy
+// at all, and one that must build a fresh model (e.g. ``Optimize``, whose
+// underlying ``OptimizeFixed`` returns a new proto) move-assigns it back. The
+// returned function likewise mutates in place, so it composes when these fixed
+// points nest and a single ModelProto is threaded through the whole thing.
 template <typename T>
-std::function<T(T)> FixedPointFn(const std::function<T(T)>& f1,
-                                 const std::function<T(T)>& f2,
-                                 size_t max_iters, bool* converged) {
-  return [f1, f2, max_iters, converged](T model) -> T {
+std::function<void(T&)> FixedPointFn(const std::function<void(T&)>& f1,
+                                     const std::function<void(T&)>& f2,
+                                     size_t max_iters, bool* converged) {
+  return [f1, f2, max_iters, converged](T& model) -> void {
     size_t _max_iters = max_iters;
-    model = f1(std::move(model));
+    f1(model);
     ModelFingerprint fp_prev = Fingerprint(model);
-    model = f2(std::move(model));
+    f2(model);
     ModelFingerprint fp_cur = Fingerprint(model);
     while (_max_iters-- > 0) {
       if (fp_cur == fp_prev) {
         if (converged) {
           *converged = true;
         }
-        return model;
+        return;
       }
-      model = f1(std::move(model));
+      f1(model);
       fp_prev = fp_cur;
       fp_cur = Fingerprint(model);
       if (fp_cur == fp_prev) {
         if (converged) {
           *converged = true;
         }
-        return model;
+        return;
       }
-      model = f2(std::move(model));
+      f2(model);
       fp_prev = fp_cur;
       fp_cur = Fingerprint(model);
     }
@@ -820,20 +818,19 @@ std::function<T(T)> FixedPointFn(const std::function<T(T)>& f1,
     if (converged) {
       *converged = false;
     }
-    return model;
   };
 }
 
 template <typename T>
-std::function<T(T)> FixedPointFn(const std::function<T(T)>& f1,
-                                 const std::function<T(T)>& f2,
-                                 size_t max_iters) {
+std::function<void(T&)> FixedPointFn(const std::function<void(T&)>& f1,
+                                     const std::function<void(T&)>& f2,
+                                     size_t max_iters) {
   return FixedPointFn(f1, f2, max_iters, nullptr);
 }
 
-// By value (matching ``_InferShapes``) so it can move the model straight
-// through without copying when the caller passes an rvalue.
-onnx::ModelProto Identity(onnx::ModelProto model) { return model; }
+// A no-op in-place transform (mutates nothing), used when shape inference or
+// constant folding is disabled.
+void Identity(onnx::ModelProto&) {}
 
 // Recursively collect the op types of operators that live in ONNX's *default*
 // domain but have no registered schema. These are custom operators -- most
@@ -949,35 +946,39 @@ onnx::ModelProto Simplify(
     config.optimizer_passes = passes;
   }
 
-  std::function<onnx::ModelProto(onnx::ModelProto)> FoldConstant;
+  // Every transform mutates the model in place.
+  using ModelFn = std::function<void(onnx::ModelProto&)>;
+  ModelFn FoldConstant;
   if (constant_folding) {
-    FoldConstant = [&executor](const onnx::ModelProto& model) {
+    FoldConstant = [&executor](onnx::ModelProto& model) {
       // Partial shape evaluation (issue #139) turns Shape/Gather-on-shape into
       // constants that the ordinary constant folder can then propagate.
-      return _FoldConstant(executor, _EvalPartialShape(model));
+      model = _FoldConstant(executor, _EvalPartialShape(model));
     };
   } else {
     FoldConstant = Identity;
   }
-  auto InferShapes = shape_inference ? _InferShapes : Identity;
+  ModelFn InferShapes = shape_inference ? _InferShapes : Identity;
+  // ``Optimize`` builds a fresh model (``OptimizeFixed`` returns a new proto),
+  // so wrap it as an in-place transform that move-assigns the result back.
+  ModelFn OptimizeInPlace = [](onnx::ModelProto& model) {
+    model = Optimize(model);
+  };
 
   int fixed_point_iters =
       std::getenv("ONNXSIM_FIXED_POINT_ITERS")
           ? std::atoi(std::getenv("ONNXSIM_FIXED_POINT_ITERS"))
           : 50;
 
-  // ``Optimize`` takes ``const ModelProto&`` while the others take the model by
-  // value, so pin every transform to the same ``ModelProto(ModelProto)`` type
-  // (a by-value arg binds fine to ``Optimize``'s ``const&`` parameter) for the
-  // by-value FixedPointFn.
-  using ModelFn = std::function<onnx::ModelProto(onnx::ModelProto)>;
-  auto OptAndShape = FixedPointFn(ModelFn{InferShapes}, ModelFn{Optimize},
-                                  fixed_point_iters);
+  ModelFn OptAndShape =
+      FixedPointFn(InferShapes, OptimizeInPlace, fixed_point_iters);
   bool converged = false;
-  auto OptAndShapeAndFold =
-      FixedPointFn(ModelFn{OptAndShape}, ModelFn{FoldConstant},
-                   fixed_point_iters, &converged);
-  auto sim_model = OptAndShapeAndFold(model);
+  ModelFn OptAndShapeAndFold =
+      FixedPointFn(OptAndShape, FoldConstant, fixed_point_iters, &converged);
+  // The fixed points mutate in place, so make one working copy of the (const)
+  // input model and simplify it in place.
+  onnx::ModelProto sim_model = model;
+  OptAndShapeAndFold(sim_model);
   Check(sim_model);
   if (!converged) {
     std::cout << "WARNING: the simplification stopped because of timeout. "

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -435,11 +435,13 @@ GetConstantNodes(const onnx::ModelProto& model) {
   return {const_nodes, non_const_nodes};
 }
 
-onnx::ModelProto _InferShapes(const onnx::ModelProto& model) {
-  onnx::ModelProto result;
-  result.CopyFrom(model);
-  onnx::shape_inference::InferShapes(result);
-  return result;
+// Takes the model by value so a caller that no longer needs its copy can move
+// it in; ``onnx::shape_inference::InferShapes`` then mutates it in place, so no
+// extra ModelProto copy is made (the previous ``const&`` signature forced a
+// defensive ``CopyFrom`` because the input could not be mutated).
+onnx::ModelProto _InferShapes(onnx::ModelProto model) {
+  onnx::shape_inference::InferShapes(model);
+  return model;
 }
 
 // Build a lookup from tensor name to its type, gathering shapes from every
@@ -714,15 +716,22 @@ ModelFingerprint Fingerprint(const onnx::ModelProto& model) {
 // applied function left the model unchanged -- while roughly halving the number
 // of full model copies held at once (which matters because these fixed points
 // nest).
+// The transforms take and return the model by value, so the working model is
+// moved from one to the next (``model = f(std::move(model))``) rather than
+// copied. A transform that mutates in place (e.g. ``_InferShapes``) then makes
+// no copy at all; one that must build a fresh model (e.g. ``Optimize``, whose
+// underlying ``OptimizeFixed`` returns a new proto) is no worse than before.
+// The returned function is likewise by-value so it composes when these fixed
+// points nest.
 template <typename T>
-std::function<T(const T&)> FixedPointFn(const std::function<T(const T&)>& f1,
-                                        const std::function<T(const T&)>& f2,
-                                        size_t max_iters, bool* converged) {
-  return [f1, f2, max_iters, converged](const T& x) -> T {
+std::function<T(T)> FixedPointFn(const std::function<T(T)>& f1,
+                                 const std::function<T(T)>& f2,
+                                 size_t max_iters, bool* converged) {
+  return [f1, f2, max_iters, converged](T model) -> T {
     size_t _max_iters = max_iters;
-    T model = f1(x);
+    model = f1(std::move(model));
     ModelFingerprint fp_prev = Fingerprint(model);
-    model = f2(model);
+    model = f2(std::move(model));
     ModelFingerprint fp_cur = Fingerprint(model);
     while (_max_iters-- > 0) {
       if (fp_cur == fp_prev) {
@@ -731,7 +740,7 @@ std::function<T(const T&)> FixedPointFn(const std::function<T(const T&)>& f1,
         }
         return model;
       }
-      model = f1(model);
+      model = f1(std::move(model));
       fp_prev = fp_cur;
       fp_cur = Fingerprint(model);
       if (fp_cur == fp_prev) {
@@ -740,7 +749,7 @@ std::function<T(const T&)> FixedPointFn(const std::function<T(const T&)>& f1,
         }
         return model;
       }
-      model = f2(model);
+      model = f2(std::move(model));
       fp_prev = fp_cur;
       fp_cur = Fingerprint(model);
     }
@@ -753,13 +762,15 @@ std::function<T(const T&)> FixedPointFn(const std::function<T(const T&)>& f1,
 }
 
 template <typename T>
-std::function<T(const T&)> FixedPointFn(const std::function<T(const T&)>& f1,
-                                        const std::function<T(const T&)>& f2,
-                                        size_t max_iters) {
+std::function<T(T)> FixedPointFn(const std::function<T(T)>& f1,
+                                 const std::function<T(T)>& f2,
+                                 size_t max_iters) {
   return FixedPointFn(f1, f2, max_iters, nullptr);
 }
 
-onnx::ModelProto Identity(const onnx::ModelProto& model) { return model; }
+// By value (matching ``_InferShapes``) so it can move the model straight
+// through without copying when the caller passes an rvalue.
+onnx::ModelProto Identity(onnx::ModelProto model) { return model; }
 
 void Check(const onnx::ModelProto& model) { onnx::checker::check_model(model); }
 
@@ -789,7 +800,7 @@ onnx::ModelProto Simplify(
     config.optimizer_passes = passes;
   }
 
-  std::function<onnx::ModelProto(const onnx::ModelProto&)> FoldConstant;
+  std::function<onnx::ModelProto(onnx::ModelProto)> FoldConstant;
   if (constant_folding) {
     FoldConstant = [&executor](const onnx::ModelProto& model) {
       // Partial shape evaluation (issue #139) turns Shape/Gather-on-shape into
@@ -806,11 +817,16 @@ onnx::ModelProto Simplify(
           ? std::atoi(std::getenv("ONNXSIM_FIXED_POINT_ITERS"))
           : 50;
 
-  auto OptAndShape = FixedPointFn(std::function{InferShapes},
-                                  std::function{Optimize}, fixed_point_iters);
+  // ``Optimize`` takes ``const ModelProto&`` while the others take the model by
+  // value, so pin every transform to the same ``ModelProto(ModelProto)`` type
+  // (a by-value arg binds fine to ``Optimize``'s ``const&`` parameter) for the
+  // by-value FixedPointFn.
+  using ModelFn = std::function<onnx::ModelProto(onnx::ModelProto)>;
+  auto OptAndShape = FixedPointFn(ModelFn{InferShapes}, ModelFn{Optimize},
+                                  fixed_point_iters);
   bool converged = false;
   auto OptAndShapeAndFold =
-      FixedPointFn(std::function{OptAndShape}, std::function{FoldConstant},
+      FixedPointFn(ModelFn{OptAndShape}, ModelFn{FoldConstant},
                    fixed_point_iters, &converged);
   auto sim_model = OptAndShapeAndFold(model);
   Check(sim_model);


### PR DESCRIPTION
## Summary
This change reduces peak memory consumption during ONNX model simplification by releasing intermediate model representations as soon as they are no longer needed, rather than holding them in memory throughout the deserialization process.

## Key Changes
- **Delete serialized original model bytes** after the C++ simplifier consumes them, since the fallback path re-serializes from the in-memory model rather than reusing these bytes
- **Release the original model object** before deserializing the simplified result when `check_n == 0` (no model checking needed), since the original won't be read again
- **Add safety check** in the exception handler to prevent crashes when the model has been released due to the optimization above

## Implementation Details
- The original model is only released when `model_owned` is True, ensuring we don't invalidate caller-provided `ModelProto` references
- The model release happens after the ">2GB optimized model" check, so the large-model fallback can still re-simplify from the original if needed
- Exception handling was updated to detect when the model has been freed and raise the exception directly rather than attempting the external data fallback with a None model

https://claude.ai/code/session_016FP5RVkW8x3GBcePPLRJVF