### PR TITLE
Add "Expand" op to tensor size threshold warning message

### DIFF
--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -662,10 +662,10 @@ def main():
 
     if args.tensor_size_threshold == DEFAULT_TENSOR_SIZE_THRESHOLDHOLD:
         for node in model.graph.node:
-            if node.op_type in ["Tile", "ConstantOfShape"]:
+            if node.op_type in ["Tile", "ConstantOfShape", "Expand"]:
                 print(
                     Text(
-                        'Your model contains "Tile" ops or/and "ConstantOfShape" ops. Folding these ops can make the simplified model much larger. If it is not expected, please specify "--no-large-tensor" (which will lose some optimization chances)',
+                        'Your model contains "Tile" ops or/and "ConstantOfShape" ops or/and "Expand" ops. Folding these ops can make the simplified model much larger. If it is not expected, please specify "--no-large-tensor" (which will lose some optimization chances)',
                         style="bold magenta",
                     )
                 )


### PR DESCRIPTION
## Summary
Updated the tensor size threshold warning logic to include the "Expand" operator alongside "Tile" and "ConstantOfShape" operators when detecting ops that can produce large tensors during folding.

## Changes
- Added "Expand" to the list of operators checked in the tensor size threshold condition
- Updated the warning message to mention "Expand" ops as a potential source of large tensors during model simplification
- The warning now informs users that folding "Tile", "ConstantOfShape", or "Expand" ops can significantly increase the simplified model size

## Details
This change ensures that users are properly warned when their model contains "Expand" operations, which like "Tile" and "ConstantOfShape", can produce unexpectedly large tensors when folded during the simplification process. Users can use the `--no-large-tensor` flag to prevent folding these operations if the model size increase is undesirable.

fixes https://github.com/onnxsim/onnxsim/issues/100

https://claude.ai/code/session_01DDsitt38eRKWvVVvQLYYfY