### PR TITLE
Assign unique names to nameless nodes after simplification

### DIFF
--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -931,6 +931,65 @@ void RegisterCustomDefaultDomainOpSchemas(const onnx::ModelProto& model) {
   }
 }
 
+// Collect the names of every node in `graph`, descending into subgraphs held in
+// node attributes (If/Loop/Scan bodies). Used to de-duplicate the names later
+// assigned to nameless nodes.
+void CollectNodeNames(const onnx::GraphProto& graph,
+                      std::set<std::string>& names) {
+  for (const auto& node : graph.node()) {
+    if (!node.name().empty()) {
+      names.insert(node.name());
+    }
+    for (const auto& attr : node.attribute()) {
+      if (attr.has_g()) {
+        CollectNodeNames(attr.g(), names);
+      }
+      for (const auto& subgraph : attr.graphs()) {
+        CollectNodeNames(subgraph, names);
+      }
+    }
+  }
+}
+
+// Give a unique, deterministic name to every node that has none. Nodes without
+// a name survive simplification unnamed -- either because they were nameless in
+// the input model or because an onnx-optimizer pass created a replacement node
+// without setting a name -- which trips up downstream tooling that keys on node
+// names (issue #269). Each generated name is derived from the op type plus a
+// running counter and de-duplicated against every name already present in the
+// graph (including names generated earlier in this pass). Subgraphs are handled
+// recursively so nodes inside If/Loop/Scan bodies are named too.
+void AssignMissingNodeNames(onnx::GraphProto& graph,
+                            std::set<std::string>& used_names,
+                            size_t& counter) {
+  for (auto& node : *graph.mutable_node()) {
+    if (node.name().empty()) {
+      std::string name;
+      do {
+        name = node.op_type() + "_" + std::to_string(counter++);
+      } while (used_names.count(name) > 0);
+      used_names.insert(name);
+      node.set_name(name);
+    }
+    for (auto& attr : *node.mutable_attribute()) {
+      if (attr.has_g()) {
+        AssignMissingNodeNames(*attr.mutable_g(), used_names, counter);
+      }
+      for (auto& subgraph : *attr.mutable_graphs()) {
+        AssignMissingNodeNames(subgraph, used_names, counter);
+      }
+    }
+  }
+}
+
+// Assign names to any nodes left nameless after simplification (issue #269).
+void AssignMissingNodeNames(onnx::ModelProto& model) {
+  std::set<std::string> used_names;
+  CollectNodeNames(model.graph(), used_names);
+  size_t counter = 0;
+  AssignMissingNodeNames(*model.mutable_graph(), used_names, counter);
+}
+
 void Check(const onnx::ModelProto& model) { onnx::checker::check_model(model); }
 
 onnx::ModelProto Simplify(
@@ -997,6 +1056,10 @@ onnx::ModelProto Simplify(
   // input model and simplify it in place.
   onnx::ModelProto sim_model = model;
   OptAndShapeAndFold(sim_model);
+  // Simplification (and some onnx-optimizer passes) can leave nodes without a
+  // name; assign unique names to them so downstream tools that key on node
+  // names keep working (issue #269).
+  AssignMissingNodeNames(sim_model);
   Check(sim_model);
   if (!converged) {
     std::cout << "WARNING: the simplification stopped because of timeout. "

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -702,6 +702,36 @@ def test_custom_trt_op_does_not_block_surrounding_simplification():
     assert op_types.count("BatchedNMS_TRT") == 1
 
 
+def test_nameless_nodes_get_names():
+    # Regression test for GitHub issue #269. Nodes that have no name in the input
+    # model (and nodes left nameless by onnx-optimizer passes) must be assigned
+    # unique names during simplification, otherwise downstream tools that key on
+    # node names break.
+    x = onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1, 4])
+    y = onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1, 4])
+    # Both nodes are created without a name (the `name` argument is omitted) and
+    # operate on the non-constant graph input, so they survive simplification.
+    nodes = [
+        onnx.helper.make_node("Abs", ["X"], ["t"]),
+        onnx.helper.make_node("Relu", ["t"], ["Y"]),
+    ]
+    graph_def = onnx.helper.make_graph(nodes, "test_nameless_nodes", [x], [y])
+    model = onnx.helper.make_model(
+        graph_def, opset_imports=[onnx.helper.make_opsetid("", 13)]
+    )
+    # Sanity check: the input model really has nameless nodes.
+    assert all(node.name == "" for node in model.graph.node)
+
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    assert len(sim_model.graph.node) == 2
+
+    names = [node.name for node in sim_model.graph.node]
+    # Every surviving node has a non-empty, unique name.
+    assert all(name != "" for name in names)
+    assert len(set(names)) == len(names)
+
+
 def test_perform_optimization_false():
     def _create_dummy_model():
         class MockModel(torch.nn.Module):


### PR DESCRIPTION
## Summary
This PR fixes #269 by ensuring that all nodes in the simplified ONNX model have unique, non-empty names. Nodes that lack names in the input model or are left nameless by onnx-optimizer passes are now assigned deterministic names based on their op type and a counter, which prevents downstream tools that key on node names from breaking.

## Key Changes
- Added `CollectNodeNames()` function to recursively collect all existing node names in a graph, including names in subgraphs (If/Loop/Scan bodies)
- Added `AssignMissingNodeNames()` functions (two overloads) to:
  - Recursively traverse the model graph and all subgraphs
  - Assign unique names to any nodes without a name
  - Generate names using the pattern `{op_type}_{counter}` with de-duplication against existing names
- Integrated the naming pass into the `Simplify()` function to run after optimization and before model validation
- Added regression test `test_nameless_nodes_get_names()` to verify that nameless nodes are properly named after simplification

## Implementation Details
- The naming algorithm uses a set to track all used names and a counter to ensure uniqueness
- Names are generated deterministically based on op type and counter value, making the output reproducible
- The implementation handles nested subgraphs recursively, ensuring nodes in If/Loop/Scan bodies are also named
- The pass runs after `OptAndShapeAndFold()` to catch both originally nameless nodes and those created by optimizer passes

https://claude.ai/code/session_01A1YY5h52JjjHvH4qy5XbNy