### PR TITLE
Strip debug symbols from released Linux wheels

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,6 +22,12 @@ jobs:
       CIBW_TEST_COMMAND: pytest -v --durations=10 {project}/tests && onnxsim -h && onnxsim --list-default-optimizers
       # Only build on Python 3 and skip 32-bit or musl builds
       CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
+      # The extension is built RelWithDebInfo (see setup.py) so the sanitizer
+      # job gets symbolized traces, but GCC embeds that DWARF straight into the
+      # Linux .so, bloating each manylinux wheel ~18x (~3 MB -> ~51 MB). Strip
+      # the debug symbols when repairing the released wheels; the sanitizer
+      # workflow builds separately and keeps its symbols.
+      CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} --strip"
       CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF" CMAKE_GENERATOR=Ninja CMAKE_CXX_COMPILER_LAUNCHER=sccache CMAKE_LINKER_TYPE=LLD
       SCCACHE_GHA_ENABLED: on
       ACTIONS_CACHE_SERVICE_V2: on


### PR DESCRIPTION
## Problem

Linux wheels ballooned ~18× starting with `0.6.5.dev18`, while macOS, Windows, and the sdist stayed the same size:

| Wheel | before (`dev2`) | after (`dev18`) |
|---|---|---|
| `manylinux` x86_64 | 2.9 MB | **51.8 MB** |
| `manylinux` aarch64 | 2.6 MB | **50.7 MB** |
| macOS arm64 | 1.9 MB | 2.6 MB |
| Windows amd64 | 1.8 MB | 1.8 MB |

This is a major contributor to the TestPyPI project hitting its 10 GB storage cap.

## Root cause

Commit `bd6e93a` (PR #436) changed the CMake build type in `setup.py` from `Release` to `RelWithDebInfo` (except on Windows, which stays `Release`) so the AddressSanitizer job gets symbolized stack traces. On Linux, GCC embeds that `-g` DWARF debug info directly into `onnxsim_cpp2py_export*.so`, and nothing strips it — so each manylinux wheel carries ~48 MB of debug symbols.

The asymmetry lines up exactly:
- **Windows** — explicitly forced back to `Release`, so it stayed small.
- **macOS** — clang keeps DWARF in external object/`.dSYM` files rather than embedding it in the linked `.so`.
- **Linux** — GCC embeds the DWARF in the `.so`, causing the blow-up.

## Fix

Add `--strip` to cibuildwheel's Linux wheel-repair command so the distributed wheels ship without debug symbols (back to ~3 MB). The build still uses `RelWithDebInfo`, and the `sanitizer.yml` workflow builds separately, so it keeps its symbols for debugging — only the packaged release wheels are stripped.

```yaml
CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} --strip"
```

Expected saving: ~48 MB per Linux wheel × ~10 Linux wheels per release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011kad71wtUnWazwV44ri4dC)_