### PR TITLE
Handle dynamic input shapes and warn about leftover Shape ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,31 @@ during simplification, so the custom operator's output shapes are inferred too.
 Custom operators without an inference function are still imported; shape
 inference simply flows past them.
 
+## Dynamic input shapes
+
+onnxsim removes `Shape`, `Reshape` and similar shape-manipulation ops by
+constant-folding them, which only works when the dimensions they read are
+statically known. When a model keeps a **dynamic** input dimension (a symbolic
+axis such as `batch`/`height`/`width`, or a `-1`/`0` "unknown" size), the
+`Shape` ops that read those dimensions genuinely depend on runtime values and
+therefore cannot be folded away — so they remain in the simplified model. This
+is expected, but it breaks downstream converters that do not support dynamic
+shapes, for example ncnn's `onnx2ncnn` (`Shape not supported yet!`, see issue
+[#314](https://github.com/onnxsim/onnxsim/issues/314)).
+
+If you need a fully static model, give onnxsim a fixed input shape so those ops
+become foldable:
+
+```
+onnxsim input.onnx output.onnx --overwrite-input-shape x:1,3,48,320
+```
+
+(replace the numbers with the shape you actually want, and use
+`name:d0,d1,...` for each input when the model has more than one). When a
+simplified model still contains `Shape` ops caused by a dynamic input, onnxsim
+now prints a hint telling you which input dimensions are dynamic and how to fix
+them with `--overwrite-input-shape`.
+
 ## Projects Using ONNX Simplifier
 
 * [MXNet](https://mxnet.apache.org/versions/1.9.1/api/python/docs/tutorials/deploy/export/onnx.html#Simplify-the-exported-ONNX-model)

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -41,6 +41,90 @@ def get_output_names(model: onnx.ModelProto) -> List[str]:
     return output_names
 
 
+def get_dynamic_input_dims(model: onnx.ModelProto) -> Dict[str, List[int]]:
+    """Return, for each real graph input, the axis indices that are dynamic.
+
+    A dimension is *dynamic* when its size is not a fixed positive integer --
+    i.e. it carries a symbolic ``dim_param`` (such as "batch" or "width") or a
+    non-positive ``dim_value`` (0 or -1, which some exporters use to mean
+    "unknown"). Initializers that also appear in ``graph.input`` are skipped:
+    they are constants, not inputs. Only inputs with at least one dynamic axis
+    appear in the returned mapping.
+    """
+    initializer_names = {x.name for x in model.graph.initializer}
+    dynamic: Dict[str, List[int]] = {}
+    for ipt in model.graph.input:
+        if ipt.name in initializer_names:
+            continue
+        tensor_type = ipt.type.tensor_type
+        if not tensor_type.HasField("shape"):
+            continue
+        axes = [
+            i
+            for i, dim in enumerate(tensor_type.shape.dim)
+            if not (dim.HasField("dim_value") and dim.dim_value > 0)
+        ]
+        if axes:
+            dynamic[ipt.name] = axes
+    return dynamic
+
+
+def _format_input_shape_hint(
+    model: onnx.ModelProto, name: str, dynamic_axes: Sequence[int]
+) -> str:
+    """Render an input's shape as an ``--overwrite-input-shape`` suggestion.
+
+    Static axes keep their concrete size; dynamic axes show their symbolic name
+    (or ``?`` when anonymous) as a placeholder the user must replace with a
+    concrete size, e.g. ``x:batch,3,H,W``.
+    """
+    for ipt in model.graph.input:
+        if ipt.name == name:
+            dims = []
+            for i, dim in enumerate(ipt.type.tensor_type.shape.dim):
+                if i in dynamic_axes:
+                    dims.append(dim.dim_param or "?")
+                else:
+                    dims.append(str(dim.dim_value))
+            return "{}:{}".format(name, ",".join(dims))
+    return name
+
+
+def _warn_if_shape_ops_remain(model_opt: onnx.ModelProto) -> None:
+    """Explain leftover ``Shape`` ops caused by dynamic input dimensions.
+
+    onnxsim removes shape-related ops (``Shape``, ``Reshape``, ...) by
+    constant-folding them, which is only possible when the dimensions they read
+    are statically known. When an input keeps a dynamic dimension, the ``Shape``
+    ops that read it genuinely depend on runtime values and cannot be folded, so
+    they remain in the output -- which then breaks converters that do not support
+    dynamic shapes (e.g. ncnn's ``onnx2ncnn``, see GitHub issue #314). Point the
+    user at ``--overwrite-input-shape`` so they can make the model fully static.
+    """
+    remaining_shape_ops = sum(
+        1 for node in model_opt.graph.node if node.op_type == "Shape"
+    )
+    dynamic_inputs = get_dynamic_input_dims(model_opt)
+    if not remaining_shape_ops or not dynamic_inputs:
+        return
+    hints = " ".join(
+        '"{}"'.format(_format_input_shape_hint(model_opt, name, axes))
+        for name, axes in dynamic_inputs.items()
+    )
+    print(
+        Text(
+            f'The simplified model still contains {remaining_shape_ops} "Shape" '
+            "op(s). They read input dimensions that are dynamic "
+            f"({', '.join(dynamic_inputs)}), so onnxsim cannot constant-fold "
+            "them away. If you need a fully static model (for example for "
+            "converters like onnx2ncnn that do not support dynamic shapes), "
+            "re-run with a fixed input shape, e.g. --overwrite-input-shape "
+            f"{hints} (replace each symbolic/? dimension with a concrete size).",
+            style="bold magenta",
+        )
+    )
+
+
 def remove_unused_output(
     model: onnx.ModelProto, unused_output: Sequence[str]
 ) -> onnx.ModelProto:
@@ -518,6 +602,7 @@ def simplify(
             )
             model_opt = onnx.load(os.path.join(tmpdirname, 'opt.onnx'))
     _restore_doc_strings(model_opt, doc_strings)
+    _warn_if_shape_ops_remain(model_opt)
     return model_opt, check_ok
 
 

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -931,3 +931,103 @@ def test_perform_optimization_false():
     simple_model, _ = onnxsim.simplify(onnx_model, perform_optimization=False, skip_shape_inference=True)
     assert simple_model is not None
 
+
+
+def _value_info(name, elem_type, shape):
+    return onnx.helper.make_tensor_value_info(name, elem_type, shape)
+
+
+def test_get_dynamic_input_dims():
+    from onnxsim.onnx_simplifier import get_dynamic_input_dims
+
+    # x has symbolic batch/height/width; y is fully static; z uses the
+    # non-positive "unknown" convention some exporters emit.
+    x = _value_info("x", onnx.TensorProto.FLOAT, ["batch", 3, "H", "W"])
+    y = _value_info("y", onnx.TensorProto.FLOAT, [1, 3, 224, 224])
+    z = _value_info("z", onnx.TensorProto.FLOAT, [0, 3])
+    graph = onnx.helper.make_graph([], "g", [x, y, z], [])
+    model = onnx.helper.make_model(graph)
+
+    assert get_dynamic_input_dims(model) == {"x": [0, 2, 3], "z": [0]}
+
+
+def test_get_dynamic_input_dims_ignores_initializer_inputs():
+    from onnxsim.onnx_simplifier import get_dynamic_input_dims
+
+    # An initializer that is also listed as an input is a constant, not a real
+    # dynamic input, so it must be ignored even if its shape looks dynamic.
+    w = _value_info("w", onnx.TensorProto.FLOAT, ["k"])
+    init = onnx.numpy_helper.from_array(np.zeros((2,), dtype=np.float32), name="w")
+    graph = onnx.helper.make_graph([], "g", [w], [], initializer=[init])
+    model = onnx.helper.make_model(graph)
+
+    assert get_dynamic_input_dims(model) == {}
+
+
+def test_warn_if_shape_ops_remain_hints_overwrite(capsys):
+    from onnxsim.onnx_simplifier import _warn_if_shape_ops_remain
+
+    # A model with a dynamic input and a leftover Shape op should trigger the
+    # actionable hint pointing at --overwrite-input-shape (GitHub issue #314).
+    x = _value_info("x", onnx.TensorProto.FLOAT, ["batch", 3, "H", "W"])
+    shape_out = _value_info("s", onnx.TensorProto.INT64, [4])
+    node = onnx.helper.make_node("Shape", ["x"], ["s"])
+    graph = onnx.helper.make_graph([node], "g", [x], [shape_out])
+    model = onnx.helper.make_model(graph)
+
+    _warn_if_shape_ops_remain(model)
+    out = capsys.readouterr().out
+    assert "--overwrite-input-shape" in out
+    assert "x:batch,3,H,W" in out
+
+
+def test_warn_if_shape_ops_remain_silent_when_static(capsys):
+    from onnxsim.onnx_simplifier import _warn_if_shape_ops_remain
+
+    # No warning when the input is fully static, even with a Shape op present.
+    x = _value_info("x", onnx.TensorProto.FLOAT, [1, 3, 4, 5])
+    shape_out = _value_info("s", onnx.TensorProto.INT64, [4])
+    node = onnx.helper.make_node("Shape", ["x"], ["s"])
+    graph = onnx.helper.make_graph([node], "g", [x], [shape_out])
+    model = onnx.helper.make_model(graph)
+
+    _warn_if_shape_ops_remain(model)
+    assert "--overwrite-input-shape" not in capsys.readouterr().out
+
+
+def test_dynamic_reshape_shape_ops_removed_by_overwrite(capsys):
+    # Reproduces the shape of GitHub issue #314: a reshape whose target depends
+    # on the (dynamic) input dimensions keeps Shape ops that onnxsim cannot fold
+    # away -- until the input shape is fixed via overwrite_input_shapes.
+    class DynReshape(torch.nn.Module):
+        def forward(self, x):
+            n, c, h, w = x.shape
+            return x.reshape(n, c, h * w)
+
+    net = DynReshape()
+    dummy = torch.randn(1, 3, 4, 5)
+    buf = io.BytesIO()
+    torch.onnx.export(
+        net,
+        dummy,
+        buf,
+        input_names=["x"],
+        output_names=["y"],
+        dynamic_axes={"x": {0: "n", 2: "h", 3: "w"}},
+        do_constant_folding=False,
+        dynamo=False,
+    )
+    model = onnx.load_from_string(buf.getvalue())
+
+    # Dynamic input: Shape ops survive and the user is told how to fix it.
+    sim, ok = onnxsim.simplify(model)
+    assert ok
+    assert any(n.op_type == "Shape" for n in sim.graph.node)
+    assert "--overwrite-input-shape" in capsys.readouterr().out
+
+    # Fixing every input dimension lets constant folding remove the Shape ops.
+    sim_static, ok_static = onnxsim.simplify(
+        model, overwrite_input_shapes={"x": [1, 3, 4, 5]}
+    )
+    assert ok_static
+    assert all(n.op_type != "Shape" for n in sim_static.graph.node)


### PR DESCRIPTION
## Summary
This PR adds support for detecting and handling dynamic input dimensions in ONNX models, and provides users with actionable guidance when `Shape` operations cannot be eliminated due to dynamic inputs.

Relates to https://github.com/onnxsim/onnxsim/issues/314

## Key Changes

- **New `get_dynamic_input_dims()` function**: Identifies which input dimensions are dynamic (symbolic or non-positive values) by analyzing the model's graph inputs. Correctly excludes initializers that are also listed as inputs, treating them as constants rather than dynamic inputs.

- **New `_format_input_shape_hint()` function**: Generates user-friendly `--overwrite-input-shape` suggestions by rendering input shapes with symbolic names for dynamic axes and concrete values for static axes (e.g., `x:batch,3,H,W`).

- **New `_warn_if_shape_ops_remain()` function**: Detects when simplified models still contain `Shape` operations due to dynamic input dimensions and prints an informative message explaining why they couldn't be folded away and how to fix it using `--overwrite-input-shape`.

- **Integration into simplify pipeline**: The warning function is now called at the end of the `simplify()` function to alert users when dynamic inputs prevent complete shape operation elimination.

- **Comprehensive test coverage**: Added 5 new tests covering:
  - Basic dynamic dimension detection
  - Proper handling of initializer inputs
  - Warning generation for models with dynamic inputs and Shape ops
  - Silent behavior when inputs are fully static
  - End-to-end scenario with PyTorch-exported models demonstrating how `--overwrite-input-shape` enables Shape op removal

- **Documentation**: Updated README with a new "Dynamic input shapes" section explaining the behavior, why it occurs, and how users can resolve it.

## Implementation Details

The solution recognizes that `Shape` operations reading dynamic dimensions cannot be constant-folded (they genuinely depend on runtime values), which is expected behavior but breaks downstream converters that don't support dynamic shapes. Rather than silently leaving these ops in place, the implementation now provides clear, actionable guidance pointing users to the `--overwrite-input-shape` option with concrete examples of how to use it.

https://claude.ai/code/session_01SrSMirgaks6zA7yEhHazyM