### PR TITLE
Suppress CMake developer warnings in Windows wheel build

### DIFF
--- a/scripts/cross/build_windows_wheel.sh
+++ b/scripts/cross/build_windows_wheel.sh
@@ -303,7 +303,10 @@ python_args=(
 # warns it fell back to STATIC because this cross toolchain reports no dynamic
 # linking. That fallback is correct here (an import lib is what we want) and the
 # warning comes from CMake modules, not onnxsim, so there is nothing else to fix.
-cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -G Ninja -Wno-dev \
+# -Wno-dev also disables deprecation warnings by default; pair it with
+# -Wdeprecated so those stay visible (e.g. a future deprecation in onnxsim's own
+# CMakeLists), keeping the suppression scoped to just the author/dev warning.
+cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -G Ninja -Wno-dev -Wdeprecated \
   "${TOOLCHAIN_ARGS[@]}" \
   "${SCCACHE_ARGS[@]}" \
   -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="${REPO_ROOT}/scripts/cross/find_python_early.cmake" \

--- a/scripts/cross/build_windows_wheel.sh
+++ b/scripts/cross/build_windows_wheel.sh
@@ -298,7 +298,12 @@ python_args=(
   -DPython3_SABI_LIBRARY="${WINPY_SABI_LIB}"
 )
 
-cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -G Ninja \
+# -Wno-dev quiets CMake's own developer/author warning from FindPython, which
+# creates the Python SABI import library with ADD_LIBRARY(... SHARED) and then
+# warns it fell back to STATIC because this cross toolchain reports no dynamic
+# linking. That fallback is correct here (an import lib is what we want) and the
+# warning comes from CMake modules, not onnxsim, so there is nothing else to fix.
+cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -G Ninja -Wno-dev \
   "${TOOLCHAIN_ARGS[@]}" \
   "${SCCACHE_ARGS[@]}" \
   -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="${REPO_ROOT}/scripts/cross/find_python_early.cmake" \
@@ -310,7 +315,6 @@ cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -G Ninja \
   -DONNX_USE_LITE_PROTO=OFF \
   -DONNX_USE_PROTOBUF_SHARED_LIBS=OFF \
   -DONNX_CUSTOM_PROTOC_EXECUTABLE="${HOST_PROTOC}" \
-  -DProtobuf_PROTOC_EXECUTABLE="${HOST_PROTOC}" \
   -DCMAKE_PREFIX_PATH="${DEPS_TARGET};${NANOBIND_CMAKE_DIR}" \
   -Dnanobind_DIR="${NANOBIND_CMAKE_DIR}" \
   "${python_args[@]}"


### PR DESCRIPTION
## Summary
This change suppresses CMake developer warnings during the Windows wheel cross-compilation build process and removes a redundant Protobuf configuration option.

## Key Changes
- Added `-Wno-dev` flag to the CMake invocation to suppress developer/author warnings from CMake modules
- Removed the redundant `-DProtobuf_PROTOC_EXECUTABLE` argument (the same executable is already specified via `-DONNX_CUSTOM_PROTOC_EXECUTABLE`)
- Added detailed comment explaining why the `-Wno-dev` flag is necessary: CMake's FindPython module creates a Python SABI import library with `ADD_LIBRARY(... SHARED)` and then warns about falling back to STATIC due to the cross-toolchain's dynamic linking configuration. This fallback behavior is correct and expected for import libraries, and the warning originates from CMake's own modules rather than onnxsim code.

## Implementation Details
The `-Wno-dev` flag is a standard CMake option that suppresses warnings intended for CMake module authors/developers. In this case, it eliminates noise from the build output without masking any actual issues with the onnxsim build configuration itself.

https://claude.ai/code/session_01NdK54bKnwDMKjCbuvR6bwz