### PR TITLE
Defer loading external tensor data to reduce memory usage

### DIFF
--- a/onnxsim/model_info.py
+++ b/onnxsim/model_info.py
@@ -1,13 +1,49 @@
 from collections import defaultdict
-from typing import Callable, Any, Optional, Tuple, Dict
+from typing import Callable, Any, Iterable, Optional, Dict
 
 import onnx
+from onnx.external_data_helper import ExternalDataInfo, uses_external_data
 from rich.table import Table
 from rich.text import Text
 from rich import print
 
 
 __all__ = ['ModelInfo', 'print_simplifying_info']
+
+
+def _iter_graph_tensors(graph: onnx.GraphProto) -> Iterable[onnx.TensorProto]:
+    """Yield every ``TensorProto`` stored in ``graph``, recursing into subgraphs.
+
+    Covers initializers as well as tensors carried in node attributes (e.g. the
+    ``value`` of a ``Constant``), matching every place a model may hold tensor
+    data.
+    """
+    for initializer in graph.initializer:
+        yield initializer
+    for node in graph.node:
+        for attr in node.attribute:
+            if attr.HasField("t"):
+                yield attr.t
+            for tensor in attr.tensors:
+                yield tensor
+            if attr.HasField("g"):
+                yield from _iter_graph_tensors(attr.g)
+            for subgraph in attr.graphs:
+                yield from _iter_graph_tensors(subgraph)
+
+
+def _external_data_size(graph: onnx.GraphProto) -> int:
+    """Total bytes of tensor data held in external files, from metadata alone.
+
+    ``ExternalDataInfo(tensor).length`` reads the ``length`` entry of a tensor's
+    ``external_data`` record, so this never loads the data itself: the size of a
+    model whose weights live on disk can be reported without materializing them.
+    """
+    total = 0
+    for tensor in _iter_graph_tensors(graph):
+        if uses_external_data(tensor):
+            total += ExternalDataInfo(tensor).length or 0
+    return total
 
 
 def human_readable_size(num, suffix="B"):
@@ -31,27 +67,32 @@ class ModelInfo:
     4、compute density
     """
 
-    def get_info(self, graph: onnx.GraphProto) -> Tuple[Dict[str, int], int]:
+    def get_info(self, graph: onnx.GraphProto) -> Dict[str, int]:
         op_nums = defaultdict(int)
-        model_size = 0
         for node in graph.node:
             op_nums[node.op_type] += 1
             for attr in node.attribute:
                 sub_graphs = []
-                if attr.g is not None:
+                if attr.HasField("g"):
                     sub_graphs.append(attr.g)
-                if attr.graphs is not None:
-                    sub_graphs.extend(attr.graphs)
+                sub_graphs.extend(attr.graphs)
                 for sub_graph in sub_graphs:
-                    sub_op_nums, sub_model_size = self.get_info(sub_graph)
+                    sub_op_nums = self.get_info(sub_graph)
                     op_nums = defaultdict(int, {k: op_nums[k] + sub_op_nums[k] for k in set(op_nums) | set(sub_op_nums)})
-                    model_size += sub_model_size
         op_nums["Constant"] += len(graph.initializer)
-        model_size += graph.ByteSize()
-        return op_nums, model_size
+        return op_nums
 
     def __init__(self, model: onnx.ModelProto):
-        self.op_nums, self.model_size = self.get_info(model.graph)
+        self.op_nums = self.get_info(model.graph)
+        # ``graph.ByteSize()`` is the serialized size of the whole graph -- nested
+        # subgraphs and inline tensor data included -- so it is taken once at the
+        # top rather than summed per subgraph (which double-counted nested
+        # graphs). Tensors kept as external data contribute nothing to ByteSize
+        # (their ``raw_data`` is empty), so their on-disk lengths are added from
+        # metadata. The size is therefore correct whether or not the external
+        # data has been loaded, so callers need not materialize multi-GB weights
+        # just to measure the model.
+        self.model_size = model.graph.ByteSize() + _external_data_size(model.graph)
 
 
 def print_simplifying_info(model_ori: onnx.ModelProto, model_opt: onnx.ModelProto) -> None:

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -794,9 +794,20 @@ def main():
         sess_options.optimized_model_filepath = tmp_file.name
         _ = rt.InferenceSession(args.input_model, sess_options, providers=["CPUExecutionProvider"])
 
-        model = onnx.load(tmp_file.name)
+        # ``tmp_file`` stays referenced (and thus on disk) until ``main`` returns,
+        # so ``simplify`` can load it below.
+        model_path = tmp_file.name
     else:
-        model = onnx.load(args.input_model)
+        model_path = args.input_model
+
+    # Load only the graph structure here, deferring the (potentially multi-GB)
+    # external tensor data. The CLI needs this model just for the pre-flight
+    # warnings below and the size/op diff printed at the end -- none of which read
+    # raw tensor bytes: op counts come from graph structure and the reported size
+    # is computed from external-data metadata (see ``model_info``). ``simplify``
+    # is handed the *path* (not this ModelProto) so it owns its copy and performs
+    # its own deferred load, keeping the weights out of memory here entirely.
+    model = onnx.load(model_path, load_external_data=False)
 
     if args.tensor_size_threshold == DEFAULT_TENSOR_SIZE_THRESHOLDHOLD:
         for node in model.graph.node:
@@ -831,7 +842,7 @@ def main():
     print("Simplifying...")
 
     model_opt, check_ok = simplify(
-        model,
+        model_path,
         args.check_n,
         perform_optimization,
         False,

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -376,8 +376,19 @@ def simplify(
     # defensive copy). When the caller passes their own ``ModelProto`` we must
     # not mutate it.
     model_owned = isinstance(model, str)
+    # When the caller passes a file path, defer loading the (potentially
+    # multi-GB) external tensor data until it is actually needed -- right before
+    # the model is serialized for the C++ simplifier. Every graph transformation
+    # in between (input-shape overwrite, unused-output/initializer pruning,
+    # unhashable-tensor detection, doc-string snapshotting) reads only tensor
+    # *metadata* -- names, shapes, element types -- never the raw bytes, so
+    # keeping the weights on disk through these phases lowers active memory use
+    # and avoids loading them at all when an earlier phase raises. The directory
+    # is remembered so the external data can be resolved later.
+    external_data_dir: Optional[str] = None
     if model_owned:
-        model = onnx.load(model)
+        external_data_dir = os.path.dirname(os.path.abspath(model))
+        model = onnx.load(model, load_external_data=False)
     if overwrite_input_shapes is None:
         overwrite_input_shapes = {}
     overwrite_input_shapes = check_and_update_input_shapes(
@@ -441,6 +452,13 @@ def simplify(
     tensor_size_threshold = parse_size(tensor_size_threshold)
     if tensor_size_threshold > 2**31 - 9999:
         raise ValueError("tensor_size_threshold should be less than 2GB")
+
+    # Materialize the external tensor data now that the metadata-only phases are
+    # over and the full model is about to be serialized for the C++ simplifier.
+    # This is a no-op unless we loaded from a path above (and therefore deferred
+    # it); a caller-provided ``ModelProto`` already carries its data inline.
+    if external_data_dir is not None:
+        onnx.load_external_data_for_model(model, external_data_dir)
 
     try:
         model_bytes = model.SerializeToString()

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -910,6 +910,51 @@ def test_nameless_nodes_get_names():
     assert len(set(names)) == len(names)
 
 
+def test_simplify_path_with_external_data():
+    # When ``simplify`` is given a *file path* to a model whose weights live in a
+    # separate external-data file, it defers loading that (potentially huge)
+    # external data until right before the model is serialized for the C++
+    # simplifier -- every graph-metadata phase in between runs without the
+    # weights resident. This regression test makes sure that deferral still
+    # produces a correct result: the external tensor data must be materialized so
+    # the constant fold below can happen and the values are preserved.
+    a = np.random.rand(64, 64).astype(np.float32)
+    b = np.random.rand(64, 64).astype(np.float32)
+    initializers = [
+        onnx.numpy_helper.from_array(a, "a"),
+        onnx.numpy_helper.from_array(b, "b"),
+    ]
+    node = onnx.helper.make_node("Add", ["a", "b"], ["y"])
+    out = onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, (64, 64))
+    graph_def = onnx.helper.make_graph(
+        [node], "test_simplify_path_with_external_data", [], [out],
+        initializer=initializers)
+    model = onnx.helper.make_model(
+        graph_def, opset_imports=[onnx.helper.make_opsetid("", 14)], ir_version=10)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_path = os.path.join(tmpdir, "model.onnx")
+        onnx.save(
+            model,
+            model_path,
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location="model.data",
+        )
+        # The .onnx file itself carries no raw tensor data -- it is all in the
+        # external .data file, so this really exercises the deferred-load path.
+        assert os.path.exists(os.path.join(tmpdir, "model.data"))
+
+        sim_model, check_ok = onnxsim.simplify(model_path, check_n=1)
+
+    assert check_ok
+    # Add of two constants is folded into a single initializer holding a + b.
+    assert len(sim_model.graph.node) == 0
+    assert len(sim_model.graph.initializer) == 1
+    folded = onnx.numpy_helper.to_array(sim_model.graph.initializer[0])
+    np.testing.assert_allclose(folded, a + b, rtol=1e-5, atol=1e-6)
+
+
 def test_perform_optimization_false():
     def _create_dummy_model():
         class MockModel(torch.nn.Module):

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -955,6 +955,67 @@ def test_simplify_path_with_external_data():
     np.testing.assert_allclose(folded, a + b, rtol=1e-5, atol=1e-6)
 
 
+def test_model_info_size_counts_external_data_without_loading():
+    # ModelInfo must report a model's size from external-data metadata, so a
+    # model whose weights live on disk can be measured without loading them --
+    # and the number must match what a fully-loaded model reports.
+    from onnxsim import model_info
+
+    w = np.random.rand(256, 256).astype(np.float32)  # 256 KiB of weights
+    initializer = onnx.numpy_helper.from_array(w, "w")
+    node = onnx.helper.make_node("Identity", ["w"], ["y"])
+    out = onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, (256, 256))
+    graph_def = onnx.helper.make_graph([node], "g", [], [out], initializer=[initializer])
+    model = onnx.helper.make_model(
+        graph_def, opset_imports=[onnx.helper.make_opsetid("", 14)], ir_version=10)
+
+    full_size = model_info.ModelInfo(model).model_size
+    # The weights dominate the reported size.
+    assert full_size >= w.nbytes
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_path = os.path.join(tmpdir, "model.onnx")
+        onnx.save(
+            model, model_path, save_as_external_data=True,
+            all_tensors_to_one_file=True, location="model.data")
+        meta_only = onnx.load(model_path, load_external_data=False)
+
+    # The metadata-only model carries no raw tensor bytes...
+    assert len(meta_only.graph.initializer[0].raw_data) == 0
+    meta_size = model_info.ModelInfo(meta_only).model_size
+    # ...yet its reported size still counts the external weights and matches the
+    # fully-loaded size (to within the few bytes of external-data bookkeeping).
+    assert meta_size >= w.nbytes
+    assert abs(meta_size - full_size) < 1024
+
+
+def test_model_info_size_does_not_double_count_subgraphs():
+    # graph.ByteSize() already includes nested subgraphs, so the size must be
+    # taken once at the top -- not summed per subgraph (which double-counted).
+    from onnxsim import model_info
+
+    def _branch(name, out_name):
+        c = onnx.numpy_helper.from_array(np.zeros(1024, dtype=np.float32), name + "_c")
+        n = onnx.helper.make_node("Identity", [name + "_c"], [out_name])
+        return onnx.helper.make_graph(
+            [n], name, [], [onnx.helper.make_tensor_value_info(
+                out_name, onnx.TensorProto.FLOAT, (1024,))], initializer=[c])
+
+    if_node = onnx.helper.make_node(
+        "If", ["cond"], ["y"],
+        then_branch=_branch("then", "ty"), else_branch=_branch("else", "ey"))
+    graph_def = onnx.helper.make_graph(
+        [if_node], "g",
+        [onnx.helper.make_tensor_value_info("cond", onnx.TensorProto.BOOL, [])],
+        [onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, (1024,))])
+    model = onnx.helper.make_model(
+        graph_def, opset_imports=[onnx.helper.make_opsetid("", 14)], ir_version=10)
+
+    # With no external data, the reported size is exactly the graph's serialized
+    # size -- the subgraph bytes are counted once, not twice.
+    assert model_info.ModelInfo(model).model_size == model.graph.ByteSize()
+
+
 def test_perform_optimization_false():
     def _create_dummy_model():
         class MockModel(torch.nn.Module):


### PR DESCRIPTION
## Summary
This PR optimizes memory usage when simplifying ONNX models with external tensor data by deferring the loading of weights until they are actually needed. This allows graph transformations and metadata operations to run without materializing potentially multi-gigabyte weight files.

## Key Changes

- **Deferred external data loading in `simplify()`**: When a file path is provided, the model is now loaded with `load_external_data=False`, keeping weights on disk through all metadata-only phases (shape overwriting, pruning, etc.). The external data is materialized only right before C++ serialization.

- **Fixed `ModelInfo.model_size` calculation**: 
  - Refactored `get_info()` to return only operation counts, removing the recursive size accumulation that was double-counting nested subgraphs
  - Model size is now computed once at the top level using `graph.ByteSize()` plus external data sizes from metadata
  - Added `_external_data_size()` helper that reads tensor lengths from external-data metadata without loading the actual files

- **Added tensor iteration utility**: New `_iter_graph_tensors()` function recursively yields all tensors in a graph, including those in node attributes and subgraphs, enabling comprehensive external data accounting.

- **Updated CLI to pass file path to `simplify()`**: The command-line interface now passes the model path (rather than a loaded `ModelProto`) to `simplify()`, allowing it to benefit from deferred loading.

## Notable Implementation Details

- External data directory is tracked when loading from a path and used later to resolve external files when materializing data
- The `ModelInfo` size calculation works correctly whether external data is loaded or not, since it reads lengths from metadata rather than raw bytes
- All graph transformation phases (input shape overwriting, pruning, etc.) operate on metadata only and never require the raw tensor data
- Three new regression tests verify: constant folding with external data, size reporting without loading, and correct subgraph size accounting

https://claude.ai/code/session_01KDDzZVX2MSxt6c46LHxs3P