### PR TITLE
Use SPDX string for project.license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta:__legacy__"
 
 [project]
@@ -7,7 +7,7 @@ name = "onnxsim"
 dynamic = ["version"]
 description = "Simplify your ONNX model"
 readme = "README.md"
-license = {text = "MIT AND (Apache-2.0 OR BSD-2-Clause)"}
+license = "MIT AND (Apache-2.0 OR BSD-2-Clause)"
 requires-python = ">=3.10"
 dependencies = [
     "onnx",


### PR DESCRIPTION
## Summary
Silences a setuptools deprecation warning that shows up in the build logs, with a hard removal deadline.

## Problem
During the sdist/wheel build, setuptools warns (seen in the "Build and test" job logs):

```
SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
Please use a simple string containing a SPDX expression for `project.license`.
By 2027-Feb-18, you need to update your project and remove deprecated calls
or your builds will no longer be supported.
```

This is the only CI warning with an actual sunset date.

## Change
- `pyproject.toml`: `license = {text = "MIT AND (Apache-2.0 OR BSD-2-Clause)"}` → `license = "MIT AND (Apache-2.0 OR BSD-2-Clause)"` (PEP 639 SPDX-expression string). The value was already a valid SPDX expression, so this is a pure format change.
- Bump the build requirement to `setuptools>=77`, the first release that accepts a string SPDX license.

## Risk
Low — no behavior change; only the metadata format and the build-time setuptools floor change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdK54bKnwDMKjCbuvR6bwz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdK54bKnwDMKjCbuvR6bwz)_