### PR TITLE
Declare the extension free-threading-safe (FREE_THREADED)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,11 @@ if (ONNXSIM_PYTHON)
     Python 3.10
     COMPONENTS Interpreter Development.Module REQUIRED
     OPTIONAL_COMPONENTS Development.SABIModule)
-  nanobind_add_module(onnxsim_cpp2py_export onnxsim/cpp2py_export.cc STABLE_ABI)
+  # FREE_THREADED marks the module Py_MOD_GIL_NOT_USED so free-threaded
+  # interpreters (e.g. the cp314t wheel) keep the GIL disabled instead of
+  # re-enabling it at import. nanobind ignores STABLE_ABI on free-threaded
+  # builds (the limited API is unavailable there), so the two keywords coexist:
+  # STABLE_ABI applies on regular interpreters, FREE_THREADED on cp314t.
+  nanobind_add_module(onnxsim_cpp2py_export onnxsim/cpp2py_export.cc STABLE_ABI FREE_THREADED)
   target_link_libraries(onnxsim_cpp2py_export PRIVATE onnxsim)
 endif()

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -1,0 +1,37 @@
+"""Free-threading (no-GIL) regression tests.
+
+These only do something on a free-threaded CPython build (the ``cp*t`` wheels,
+e.g. cp314t). On a regular GIL build they are skipped.
+"""
+import subprocess
+import sys
+import sysconfig
+
+import pytest
+
+FREE_THREADED = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+
+
+@pytest.mark.skipif(
+    not FREE_THREADED,
+    reason="only meaningful on a free-threaded (Py_GIL_DISABLED) build",
+)
+def test_extension_keeps_gil_disabled():
+    """Importing the compiled extension must not re-enable the GIL.
+
+    The nanobind module is built with ``FREE_THREADED`` (see CMakeLists.txt), so
+    it is tagged ``Py_MOD_GIL_NOT_USED`` and a free-threaded interpreter keeps
+    the GIL disabled on import. Without that declaration CPython silently
+    re-enables the GIL and emits a RuntimeWarning, defeating the free-threaded
+    wheel. This guards against that regression.
+
+    Run in a fresh subprocess importing *only* the extension: other test
+    dependencies (torch, numpy) imported in-process might not declare
+    free-threading support and would re-enable the GIL themselves, masking what
+    we are checking here.
+    """
+    code = (
+        "import sys, onnxsim.onnxsim_cpp2py_export\n"
+        "assert sys._is_gil_enabled() is False, 'importing onnxsim re-enabled the GIL'\n"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)


### PR DESCRIPTION
## Summary
Makes the free-threaded (cp314t) wheel actually run without the GIL, instead of silently re-enabling it at import.

## Problem
On import under free-threaded Python 3.14, the cp314t wheel emits (seen in the "Build wheel cp314t" job logs):

```
RuntimeWarning: The global interpreter lock (GIL) has been enabled to load
module 'onnxsim.onnxsim_cpp2py_export', which has not declared that it can
run safely without the GIL.
```

Because the nanobind module never declared free-threading support, Python force-re-enables the GIL — so the free-threaded wheel we ship does not actually run GIL-free.

## Change
- `CMakeLists.txt`: add `FREE_THREADED` to `nanobind_add_module(...)` so the module is tagged `Py_MOD_GIL_NOT_USED`. nanobind automatically disables `STABLE_ABI` on free-threaded builds, so both keywords coexist (STABLE_ABI on regular interpreters, FREE_THREADED on cp314t).

## Risk / caveat
⚠️ `FREE_THREADED` is a **correctness assertion**: it tells Python the C++ (the ORT + onnx-optimizer wrappers) is safe to run without the GIL. This is *declared*, not verified. If any wrapped path is not thread-safe, free-threaded callers could hit data races. A thread-safety review of the wrapped code is a reasonable follow-up before relying on it. (The alternative — dropping cp314t from the wheel matrix — was considered and not taken.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdK54bKnwDMKjCbuvR6bwz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdK54bKnwDMKjCbuvR6bwz)_