### PR TITLE
Stop shipping C++ sources in wheels and silence packaging warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -267,6 +267,15 @@ ext_modules = [
 ]
 
 packages = setuptools.find_packages()
+# onnxsim/bin and onnxsim/capi hold C++ build inputs, not importable Python.
+# MANIFEST.in's `recursive-include onnxsim ...` sweeps their sources into the
+# sdist, and because they are identifier-named subdirectories of the onnxsim
+# package, setuptools both warns ("Package 'onnxsim.bin' is absent from the
+# `packages` configuration") and ships the raw .cpp/.h inside every wheel.
+# Declare them as packages to silence the warning, then exclude their contents
+# (below) so the built wheel carries no stray C++ sources -- they stay in the
+# sdist for source builds.
+packages += ['onnxsim.bin', 'onnxsim.capi']
 
 version_str = VersionInfo.version
 
@@ -283,5 +292,6 @@ setuptools.setup(
     cmdclass=cmdclass,
     packages=packages,
     include_package_data=True,
+    exclude_package_data={'onnxsim.bin': ['*'], 'onnxsim.capi': ['*']},
     options=setup_opts,
 )


### PR DESCRIPTION
## Summary
Removes stray C++ source files from the built wheels and silences two setuptools packaging warnings.

## Problem
During the build, setuptools warns (seen in the "Build and test" job logs):

```
_Warning: Package 'onnxsim.bin' is absent from the `packages` configuration.
_Warning: Package 'onnxsim.capi' is absent from the `packages` configuration.
```

`onnxsim/bin` and `onnxsim/capi` contain only C++ build inputs. `MANIFEST.in`'s `recursive-include onnxsim ...` pulls their sources into the manifest, and because they are identifier-named subdirectories of the `onnxsim` package, `include_package_data` treats them as undeclared sub-packages — hence the warning, **and** it copies the raw `.cpp`/`.h` into every wheel. Verified: current wheels contain `onnxsim/bin/onnxsim_bin.cpp` and `onnxsim/capi/onnxsim_c_api.cpp`.

## Change
- `setup.py`: declare `onnxsim.bin` and `onnxsim.capi` as packages (silences the warning), then add `exclude_package_data` for them so the built wheel carries **no** C++ sources. The sdist still includes them (via `MANIFEST.in`) for source builds.

## Verification
Reproduced before/after in a minimal sandbox against setuptools 68.1.2: absent-package warnings drop from 2 → 0, and no `.cpp` is copied into `build/lib`. CI uses a newer setuptools, so the next wheel build log is the real confirmation.

## Note
The three `MANIFEST.in` "no previously-included files" warnings are intentionally left as-is — I tested `global-exclude`/`prune` and they warn identically, so there is no warning-free way to keep those defensive `recursive-exclude` lines. Kept the safety net rather than trade it for a cosmetic log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdK54bKnwDMKjCbuvR6bwz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdK54bKnwDMKjCbuvR6bwz)_