### PR TITLE
Bump actions/cache v4 -> v6 in the Rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
       # ONNX Runtime source is not a git submodule; onnxsim-sys downloads it on
       # demand. Cache it so it is fetched at most once per version.
       - name: Cache ONNX Runtime source
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: third_party/onnxruntime-1.27.1
           key: onnxruntime-src-1.27.1


### PR DESCRIPTION
## Summary
Clears a Node 20 deprecation warning emitted on every run of the Rust wrapper workflow.

## Problem
`rust.yml` pinned `actions/cache@v4`, which targets Node 20. The runner force-runs it on Node 24 and warns (seen in the "build + smoke test (native)" job logs):

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are
being forced to run on Node.js 24: actions/cache@v4.
```

## Change
- `.github/workflows/rust.yml`: `actions/cache@v4` → `@v6`.

`static.yml` was already on `@v6`; this aligns the Rust workflow to match. Latest release is v6.1.0; pinned to the major tag `@v6` (consistent with `static.yml`) so it tracks patch releases.

## Risk
Low — cache action major bump only; no cache key/path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdK54bKnwDMKjCbuvR6bwz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdK54bKnwDMKjCbuvR6bwz)_