### PR TITLE
Add target opset version conversion during simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,33 @@ during simplification, so the custom operator's output shapes are inferred too.
 Custom operators without an inference function are still imported; shape
 inference simply flows past them.
 
+## Changing the opset version
+
+You can upgrade (or downgrade) the model's opset version while simplifying. Pass
+`target_opset_version` to `simplify` (CLI: `--target-opset`) and onnxsim converts
+the default ONNX domain to that opset — using onnx's own version converter —
+before running the simplification, so any redundant nodes the conversion
+introduces get cleaned up too.
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load(filename)
+
+# Convert the model to opset 18 and simplify it.
+model_simp, check = onnxsim.simplify(model, target_opset_version=18)
+```
+
+On the command line:
+
+```
+onnxsim input_onnx_model output_onnx_model --target-opset 18
+```
+
+When `target_opset_version` is left unset (the default), the model's opset
+version is preserved.
+
 ## Projects Using ONNX Simplifier
 
 * [MXNet](https://mxnet.apache.org/versions/1.9.1/api/python/docs/tutorials/deploy/export/onnx.html#Simplify-the-exported-ONNX-model)

--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ onnxsim input_onnx_model output_onnx_model --target-opset 18
 When `target_opset_version` is left unset (the default), the model's opset
 version is preserved.
 
+The conversion runs inside onnxsim's C++ core, so every binding shares it —
+the Python package, the C API and its Rust wrapper (`Options::target_opset_version`),
+the standalone `onnxsim` binary (`--target-opset`), and the
+[web version](https://onnxsim.github.io/onnxsim/) (the "target opset version"
+field).
+
 ## Projects Using ONNX Simplifier
 
 * [MXNet](https://mxnet.apache.org/versions/1.9.1/api/python/docs/tutorials/deploy/export/onnx.html#Simplify-the-exported-ONNX-model)

--- a/onnxsim/bin/onnxsim_bin.cpp
+++ b/onnxsim/bin/onnxsim_bin.cpp
@@ -11,6 +11,7 @@ int main(int argc, char** argv) {
   bool no_opt = option.Get<bool>("no-opt");
   bool no_sim = option.Get<bool>("no-sim");
   bool no_shape_inference = option.Get<bool>("no-shape-inference");
+  int target_opset = option.Get<int>("target-opset");
   auto input_model_filename = option.Get<std::string>("input-model");
   auto output_model_filename = option.Get<std::string>("output-model");
 
@@ -20,7 +21,9 @@ int main(int argc, char** argv) {
   model = Simplify(
       *GetBuiltinModelExecutor(), model,
       no_opt ? std::nullopt : std::make_optional<std::vector<std::string>>({}),
-      !no_sim, !no_shape_inference, SIZE_MAX);
+      !no_sim, !no_shape_inference, SIZE_MAX,
+      // A target opset of <= 0 means "leave the opset version unchanged".
+      target_opset > 0 ? std::make_optional(target_opset) : std::nullopt);
 
   std::ofstream ofs(output_model_filename,
                     std::ios::out | std::ios::trunc | std::ios::binary);

--- a/onnxsim/bin/onnxsim_option.cpp
+++ b/onnxsim/bin/onnxsim_option.cpp
@@ -12,6 +12,7 @@ void OnnxsimOption::Parse(int argc, char** argv) {
   ("no-opt",              "No optimization",             cxxopts::value<bool>()->default_value("false"))
   ("no-sim",              "No simplification",           cxxopts::value<bool>()->default_value("false"))
   ("no-shape-inference",  "No shape inference",          cxxopts::value<bool>()->default_value("false"))
+  ("target-opset",        "Convert the model to this opset version (of the default ONNX domain) before simplifying. 0 keeps the current version.", cxxopts::value<int>()->default_value("0"))
   ;
   // clang-format on
 

--- a/onnxsim/capi/onnxsim_c_api.cpp
+++ b/onnxsim/capi/onnxsim_c_api.cpp
@@ -56,6 +56,14 @@ std::optional<std::vector<std::string>> BuildSkipOptimizers(
   return passes;
 }
 
+// A target opset version of <= 0 means "leave the opset version unchanged".
+std::optional<int> BuildTargetOpsetVersion(int target_opset_version) {
+  if (target_opset_version <= 0) {
+    return std::nullopt;
+  }
+  return target_opset_version;
+}
+
 }  // namespace
 
 extern "C" {
@@ -65,8 +73,8 @@ OnnxsimStatus onnxsim_simplify(const void* model_data, size_t model_size,
                                size_t num_skip_optimizers,
                                int skip_optimizers_is_null, int constant_folding,
                                int shape_inference, size_t tensor_size_threshold,
-                               void** out_data, size_t* out_size,
-                               char** out_error) {
+                               int target_opset_version, void** out_data,
+                               size_t* out_size, char** out_error) {
   if (out_data != nullptr) {
     *out_data = nullptr;
   }
@@ -93,7 +101,8 @@ OnnxsimStatus onnxsim_simplify(const void* model_data, size_t model_size,
         *GetBuiltinModelExecutor(), model,
         BuildSkipOptimizers(skip_optimizers, num_skip_optimizers,
                             skip_optimizers_is_null),
-        constant_folding != 0, shape_inference != 0, tensor_size_threshold);
+        constant_folding != 0, shape_inference != 0, tensor_size_threshold,
+        BuildTargetOpsetVersion(target_opset_version));
 
     std::string out;
     if (!result.SerializeToString(&out)) {
@@ -126,6 +135,7 @@ OnnxsimStatus onnxsim_simplify_path(const char* in_path, const char* out_path,
                                     int skip_optimizers_is_null,
                                     int constant_folding, int shape_inference,
                                     size_t tensor_size_threshold,
+                                    int target_opset_version,
                                     char** out_error) {
   if (out_error != nullptr) {
     *out_error = nullptr;
@@ -140,7 +150,8 @@ OnnxsimStatus onnxsim_simplify_path(const char* in_path, const char* out_path,
                  BuildSkipOptimizers(skip_optimizers, num_skip_optimizers,
                                     skip_optimizers_is_null),
                  constant_folding != 0, shape_inference != 0,
-                 tensor_size_threshold);
+                 tensor_size_threshold,
+                 BuildTargetOpsetVersion(target_opset_version));
     return ONNXSIM_OK;
   } catch (const std::exception& e) {
     SetError(out_error, e.what());

--- a/onnxsim/capi/onnxsim_c_api.h
+++ b/onnxsim/capi/onnxsim_c_api.h
@@ -47,6 +47,10 @@ typedef enum OnnxsimStatus {
  * tensor_size_threshold bounds the byte size of tensors produced by constant
  * folding that are kept as initializers.
  *
+ * target_opset_version, when > 0, converts the model to that opset version of
+ * the default ONNX domain (using onnx's version converter) before simplifying;
+ * a value <= 0 leaves the opset version unchanged.
+ *
  * On ONNXSIM_OK, *out_data / *out_size receive a newly allocated buffer holding
  * the serialized simplified ModelProto; release it with onnxsim_free_buffer.
  * On ONNXSIM_ERROR, *out_error receives a newly allocated, NUL-terminated
@@ -57,8 +61,8 @@ ONNXSIM_C_API OnnxsimStatus onnxsim_simplify(
     const void* model_data, size_t model_size,
     const char* const* skip_optimizers, size_t num_skip_optimizers,
     int skip_optimizers_is_null, int constant_folding, int shape_inference,
-    size_t tensor_size_threshold, void** out_data, size_t* out_size,
-    char** out_error);
+    size_t tensor_size_threshold, int target_opset_version, void** out_data,
+    size_t* out_size, char** out_error);
 
 /*
  * Same as onnxsim_simplify, but reads the input model from `in_path` and writes
@@ -69,7 +73,7 @@ ONNXSIM_C_API OnnxsimStatus onnxsim_simplify_path(
     const char* in_path, const char* out_path,
     const char* const* skip_optimizers, size_t num_skip_optimizers,
     int skip_optimizers_is_null, int constant_folding, int shape_inference,
-    size_t tensor_size_threshold, char** out_error);
+    size_t tensor_size_threshold, int target_opset_version, char** out_error);
 
 /*
  * Return the names of all available fuse/elimination optimizer passes as a

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -262,35 +262,40 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
            const py::bytes& model_proto_bytes,
            std::optional<std::vector<std::string>> skip_optimizers,
            bool constant_folding, bool shape_inference,
-           size_t tensor_size_threshold) -> py::bytes {
+           size_t tensor_size_threshold,
+           std::optional<int> target_opset_version) -> py::bytes {
           // force env initialization to register opset
           InitEnv();
           ONNX_NAMESPACE::ModelProto model;
           ParseProtoFromBytes(&model, model_proto_bytes.c_str(), model_proto_bytes.size());
           auto const result = Simplify(*executor, model, skip_optimizers,
                                        constant_folding, shape_inference,
-                                       tensor_size_threshold);
+                                       tensor_size_threshold,
+                                       target_opset_version);
           std::string out;
           result.SerializeToString(&out);
           return py::bytes(out.data(), out.size());
         }, "executor"_a, "model_bytes"_a, "skip_optimizers"_a.none(),
-        "constant_folding"_a = true, "shape_inference"_a = true, "tensor_size_threshold"_a)
+        "constant_folding"_a = true, "shape_inference"_a = true, "tensor_size_threshold"_a,
+        "target_opset_version"_a.none())
       .def("simplify_path",
            [](std::shared_ptr<PyModelExecutor> executor,
               const std::string& in_path, const std::string& out_path,
               std::optional<std::vector<std::string>> skip_optimizers,
               bool constant_folding, bool shape_inference,
-              size_t tensor_size_threshold) -> bool {
+              size_t tensor_size_threshold,
+              std::optional<int> target_opset_version) -> bool {
              // force env initialization to register opset
              InitEnv();
              SimplifyPath(*executor, in_path, out_path, skip_optimizers,
                           constant_folding, shape_inference,
-                          tensor_size_threshold);
+                          tensor_size_threshold, target_opset_version);
              return true;
            }, "executor"_a, "in_path"_a, "out_path"_a,
            "skip_optimizers"_a.none(),
            "constant_folding"_a = true, "shape_inference"_a = true,
-           "tensor_size_threshold"_a)
+           "tensor_size_threshold"_a,
+           "target_opset_version"_a.none())
       .def("_list_optimizers",
            []() {
             py::list ret;

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -16,7 +16,6 @@ import onnx.checker  # type: ignore
 import onnx.helper  # type: ignore
 import onnx.shape_inference  # type: ignore
 import onnx.numpy_helper  # type: ignore
-import onnx.version_converter  # type: ignore
 import onnxsim.onnxsim_cpp2py_export as C
 from . import backend
 from . import model_info
@@ -293,35 +292,6 @@ def _restore_doc_strings(model: onnx.ModelProto, snapshot: dict) -> None:
             opt.doc_string = snapshot["outputs"][opt.name]
 
 
-def _get_default_opset_version(model: onnx.ModelProto) -> Optional[int]:
-    """Return the opset version the model imports for the default ONNX domain.
-
-    The default domain is represented as either the empty string ``""`` or the
-    equivalent ``"ai.onnx"``. Returns ``None`` when the model does not import the
-    default domain at all (a model made purely of custom-domain operators).
-    """
-    for opset in model.opset_import:
-        if opset.domain in ("", "ai.onnx"):
-            return opset.version
-    return None
-
-
-def _convert_opset_version(
-    model: onnx.ModelProto, target_opset_version: int
-) -> onnx.ModelProto:
-    """Convert ``model`` to ``target_opset_version`` for the default ONNX domain.
-
-    Uses onnx's own version converter. Only the default ONNX domain opset is
-    changed; custom/other-domain opset imports are left untouched. If the model
-    is already at the requested version (or does not import the default domain)
-    the model is returned unchanged.
-    """
-    current = _get_default_opset_version(model)
-    if current is None or current == target_opset_version:
-        return model
-    return onnx.version_converter.convert_version(model, target_opset_version)
-
-
 def simplify(
     model: Union[str, onnx.ModelProto],
     check_n: int = 0,
@@ -367,9 +337,9 @@ def simplify(
             registry untouched.
     :param input_shapes: Deprecated. Please use `overwrite_input_shapes` and/or `test_input_shapes` instead.
     :param target_opset_version: Convert the model to this opset version (of the default ONNX domain)
-            before simplifying, using onnx's version converter. This can be used to upgrade (or
-            downgrade) the model's opset during simplification. When None (the default), the opset
-            version is left unchanged.
+            before simplifying, using onnx's version converter (run inside the C++ core so every
+            binding shares the behavior). This can be used to upgrade (or downgrade) the model's
+            opset during simplification. When None (the default), the opset version is left unchanged.
     :return: A tuple (simplified model, success(True) or failed(False))
     """
     if dynamic_input_shape:
@@ -495,12 +465,6 @@ def simplify(
     if external_data_dir is not None:
         onnx.load_external_data_for_model(model, external_data_dir)
 
-    # Optionally convert the model to a different opset version (of the default
-    # ONNX domain) before simplifying. Running the conversion first lets the
-    # simplifier clean up any redundant nodes the version converter introduces.
-    if target_opset_version is not None:
-        model = _convert_opset_version(model, target_opset_version)
-
     try:
         model_bytes = model.SerializeToString()
         if len(model_bytes) >= 2 * 1024 * 1024 * 1024:
@@ -513,6 +477,7 @@ def simplify(
             not skip_constant_folding,
             not skip_shape_inference,
             tensor_size_threshold,
+            target_opset_version,
         )
         # The serialized original (~1x model) is not needed once the C++
         # simplifier has consumed it -- the large-model fallback below
@@ -569,6 +534,7 @@ def simplify(
                 not skip_constant_folding,
                 not skip_shape_inference,
                 tensor_size_threshold,
+                target_opset_version,
             )
             check_ok = model_checking.compare(
                 os.path.join(tmpdirname, 'opt.onnx'),

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -16,6 +16,7 @@ import onnx.checker  # type: ignore
 import onnx.helper  # type: ignore
 import onnx.shape_inference  # type: ignore
 import onnx.numpy_helper  # type: ignore
+import onnx.version_converter  # type: ignore
 import onnxsim.onnxsim_cpp2py_export as C
 from . import backend
 from . import model_info
@@ -292,6 +293,35 @@ def _restore_doc_strings(model: onnx.ModelProto, snapshot: dict) -> None:
             opt.doc_string = snapshot["outputs"][opt.name]
 
 
+def _get_default_opset_version(model: onnx.ModelProto) -> Optional[int]:
+    """Return the opset version the model imports for the default ONNX domain.
+
+    The default domain is represented as either the empty string ``""`` or the
+    equivalent ``"ai.onnx"``. Returns ``None`` when the model does not import the
+    default domain at all (a model made purely of custom-domain operators).
+    """
+    for opset in model.opset_import:
+        if opset.domain in ("", "ai.onnx"):
+            return opset.version
+    return None
+
+
+def _convert_opset_version(
+    model: onnx.ModelProto, target_opset_version: int
+) -> onnx.ModelProto:
+    """Convert ``model`` to ``target_opset_version`` for the default ONNX domain.
+
+    Uses onnx's own version converter. Only the default ONNX domain opset is
+    changed; custom/other-domain opset imports are left untouched. If the model
+    is already at the requested version (or does not import the default domain)
+    the model is returned unchanged.
+    """
+    current = _get_default_opset_version(model)
+    if current is None or current == target_opset_version:
+        return model
+    return onnx.version_converter.convert_version(model, target_opset_version)
+
+
 def simplify(
     model: Union[str, onnx.ModelProto],
     check_n: int = 0,
@@ -312,6 +342,7 @@ def simplify(
     *,
     import_custom_schemas: bool = True,
     input_shapes=None,
+    target_opset_version: Optional[int] = None,
 ) -> Tuple[onnx.ModelProto, bool]:
     """
     :param model: onnx ModelProto object or file path
@@ -335,6 +366,10 @@ def simplify(
             custom operators pass validation. Set to False to disable this and leave onnxsim's
             registry untouched.
     :param input_shapes: Deprecated. Please use `overwrite_input_shapes` and/or `test_input_shapes` instead.
+    :param target_opset_version: Convert the model to this opset version (of the default ONNX domain)
+            before simplifying, using onnx's version converter. This can be used to upgrade (or
+            downgrade) the model's opset during simplification. When None (the default), the opset
+            version is left unchanged.
     :return: A tuple (simplified model, success(True) or failed(False))
     """
     if dynamic_input_shape:
@@ -459,6 +494,12 @@ def simplify(
     # it); a caller-provided ``ModelProto`` already carries its data inline.
     if external_data_dir is not None:
         onnx.load_external_data_for_model(model, external_data_dir)
+
+    # Optionally convert the model to a different opset version (of the default
+    # ONNX domain) before simplifying. Running the conversion first lets the
+    # simplifier clean up any redundant nodes the version converter introduces.
+    if target_opset_version is not None:
+        model = _convert_opset_version(model, target_opset_version)
 
     try:
         model_bytes = model.SerializeToString()
@@ -698,6 +739,12 @@ def main():
         help="By default onnxsim imports operator schemas registered in the Python 'onnx' module (e.g. via onnx.defs.register_schema) into its own registry so models with custom operators pass validation. Specify this flag to disable that import.",
         action="store_true",
         )
+    parser.add_argument(
+        "--target-opset",
+        help="Convert the model to this opset version (of the default ONNX domain) before simplifying, for example '--target-opset 18'. Can be used to upgrade (or downgrade) the model's opset during simplification.",
+        type=int,
+        default=None,
+        )
     parser.add_argument('-v', '--version', action='version', version='onnxsim ' + version.version)
 
     class ListOptimizers(argparse.Action):
@@ -859,6 +906,7 @@ def main():
         args.tensor_size_threshold,
         args.mutable_initializer,
         import_custom_schemas=not args.skip_schema_import,
+        target_opset_version=args.target_opset,
     )
 
     try:

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -20,6 +20,7 @@
 #include "onnx/defs/printer.h"
 #include "onnx/defs/schema.h"
 #include "onnx/shape_inference/implementation.h"
+#include "onnx/version_converter/convert.h"
 #include "onnxoptimizer/model_util.h"
 #include "onnxoptimizer/optimize.h"
 #include "onnxoptimizer/passes/logging.h"
@@ -1203,10 +1204,38 @@ void AssignMissingNodeNames(onnx::ModelProto& model) {
 
 void Check(const onnx::ModelProto& model) { onnx::checker::check_model(model); }
 
+// Return the opset version the model imports for the default ONNX domain
+// (represented as either the empty string or "ai.onnx"), or std::nullopt when
+// the model does not import the default domain at all (a model made purely of
+// custom-domain operators).
+std::optional<int> DefaultOpsetVersion(const onnx::ModelProto& model) {
+  for (const auto& opset : model.opset_import()) {
+    if (opset.domain().empty() || opset.domain() == "ai.onnx") {
+      return static_cast<int>(opset.version());
+    }
+  }
+  return std::nullopt;
+}
+
+// Convert the default ONNX domain of the model to target_version using onnx's
+// own version converter. Only the default ONNX domain opset is changed;
+// custom/other-domain opset imports are left untouched. Returns the model
+// unchanged when it is already at the requested version or does not import the
+// default domain.
+onnx::ModelProto ConvertOpsetVersion(const onnx::ModelProto& model,
+                                     int target_version) {
+  const auto current = DefaultOpsetVersion(model);
+  if (!current || *current == target_version) {
+    return model;
+  }
+  return onnx::version_conversion::ConvertVersion(model, target_version);
+}
+
 onnx::ModelProto Simplify(
     const ModelExecutor& executor, const onnx::ModelProto& model,
     std::optional<std::vector<std::string>> skip_optimizers,
-    bool constant_folding, bool shape_inference, size_t tensor_size_threshold) {
+    bool constant_folding, bool shape_inference, size_t tensor_size_threshold,
+    std::optional<int> target_opset_version) {
   // Make shape inference aware of ONNX Runtime's quantized contrib operators
   // (QLinearAdd and friends) so shape deduction does not stop at them.
   onnxsim::RegisterContribOpSchemas();
@@ -1276,6 +1305,12 @@ onnx::ModelProto Simplify(
   // The fixed points mutate in place, so make one working copy of the (const)
   // input model and simplify it in place.
   onnx::ModelProto sim_model = model;
+  // Optionally convert the model to a different opset version (of the default
+  // ONNX domain) first, so the simplification below can clean up any redundant
+  // nodes the version converter introduces.
+  if (target_opset_version) {
+    sim_model = ConvertOpsetVersion(sim_model, *target_opset_version);
+  }
   OptAndShapeAndFold(sim_model);
   // Simplification (and some onnx-optimizer passes) can leave nodes without a
   // name; assign unique names to them so downstream tools that key on node
@@ -1296,12 +1331,14 @@ void SimplifyPath(const ModelExecutor& executor, const std::string& in_path,
                   const std::string& out_path,
                   std::optional<std::vector<std::string>> skip_optimizers,
                   bool constant_folding, bool shape_inference,
-                  size_t tensor_size_threshold) {
+                  size_t tensor_size_threshold,
+                  std::optional<int> target_opset_version) {
   onnx::ModelProto model;
   onnx::optimization::loadModel(&model, in_path, true);
 
   model = Simplify(executor, model, skip_optimizers, constant_folding,
-                   shape_inference, tensor_size_threshold);
+                   shape_inference, tensor_size_threshold,
+                   target_opset_version);
 
   onnx::optimization::saveModel(&model, out_path, true, "");
 }

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -23,13 +23,19 @@ void InitEnv();
 std::shared_ptr<const ModelExecutor> GetBuiltinModelExecutor();
 #endif
 
+// ``target_opset_version``, when set, converts the model to that opset version
+// of the default ONNX domain (using onnx's version converter) before
+// simplifying, so the simplifier can clean up any redundant nodes the
+// conversion introduces. std::nullopt leaves the opset version unchanged.
 onnx::ModelProto Simplify(
     const ModelExecutor& executor, const onnx::ModelProto& model,
     std::optional<std::vector<std::string>> skip_optimizers,
-    bool constant_folding, bool shape_inference, size_t tensor_size_threshold);
+    bool constant_folding, bool shape_inference, size_t tensor_size_threshold,
+    std::optional<int> target_opset_version = std::nullopt);
 
 void SimplifyPath(const ModelExecutor& executor, const std::string& in_path,
                   const std::string& out_path,
                   std::optional<std::vector<std::string>> skip_optimizers,
                   bool constant_folding, bool shape_inference,
-                  size_t tensor_size_threshold);
+                  size_t tensor_size_threshold,
+                  std::optional<int> target_opset_version = std::nullopt);

--- a/rust/onnxsim-sys/src/lib.rs
+++ b/rust/onnxsim-sys/src/lib.rs
@@ -41,6 +41,7 @@ extern "C" {
         constant_folding: c_int,
         shape_inference: c_int,
         tensor_size_threshold: usize,
+        target_opset_version: c_int,
         out_data: *mut *mut c_void,
         out_size: *mut usize,
         out_error: *mut *mut c_char,
@@ -60,6 +61,7 @@ extern "C" {
         constant_folding: c_int,
         shape_inference: c_int,
         tensor_size_threshold: usize,
+        target_opset_version: c_int,
         out_error: *mut *mut c_char,
     ) -> c_int;
 

--- a/rust/onnxsim/src/lib.rs
+++ b/rust/onnxsim/src/lib.rs
@@ -93,6 +93,9 @@ pub struct Options {
     constant_folding: bool,
     shape_inference: bool,
     tensor_size_threshold: usize,
+    /// Target opset version (of the default ONNX domain) to convert the model
+    /// to before simplifying. `None` leaves the opset version unchanged.
+    target_opset_version: Option<i32>,
 }
 
 impl Default for Options {
@@ -102,6 +105,7 @@ impl Default for Options {
             constant_folding: true,
             shape_inference: true,
             tensor_size_threshold: DEFAULT_TENSOR_SIZE_THRESHOLD,
+            target_opset_version: None,
         }
     }
 }
@@ -131,6 +135,15 @@ impl Options {
     /// as an initializer (default: [`DEFAULT_TENSOR_SIZE_THRESHOLD`]).
     pub fn tensor_size_threshold(mut self, bytes: usize) -> Self {
         self.tensor_size_threshold = bytes;
+        self
+    }
+
+    /// Convert the model to `version` (the opset version of the default ONNX
+    /// domain) before simplifying, using onnx's version converter. Can be used
+    /// to upgrade or downgrade the model's opset during simplification (default:
+    /// leave the opset version unchanged).
+    pub fn target_opset_version(mut self, version: i32) -> Self {
+        self.target_opset_version = Some(version);
         self
     }
 
@@ -192,6 +205,7 @@ pub fn simplify_with(model_bytes: &[u8], options: &Options) -> Result<Vec<u8>, E
             bool_to_c(options.constant_folding),
             bool_to_c(options.shape_inference),
             options.tensor_size_threshold,
+            target_opset_to_c(options.target_opset_version),
             &mut out_data,
             &mut out_size,
             &mut out_error,
@@ -240,6 +254,7 @@ pub fn simplify_path_with<P: AsRef<Path>, Q: AsRef<Path>>(
             bool_to_c(options.constant_folding),
             bool_to_c(options.shape_inference),
             options.tensor_size_threshold,
+            target_opset_to_c(options.target_opset_version),
             &mut out_error,
         )
     };
@@ -332,6 +347,12 @@ fn bool_to_c(value: bool) -> c_int {
     }
 }
 
+/// Encode the optional target opset version for the C ABI: `None` (leave the
+/// opset unchanged) maps to 0, which the C API treats as "no change".
+fn target_opset_to_c(version: Option<i32>) -> c_int {
+    version.unwrap_or(0) as c_int
+}
+
 /// Consume a C-owned error string, returning a Rust `Error` and freeing the
 /// original allocation.
 fn take_error(out_error: *mut c_char) -> Error {
@@ -377,6 +398,16 @@ mod tests {
         assert!(opts.shape_inference);
         assert_eq!(opts.skip_optimizers, Some(Vec::new()));
         assert_eq!(opts.tensor_size_threshold, DEFAULT_TENSOR_SIZE_THRESHOLD);
+        assert_eq!(opts.target_opset_version, None);
+    }
+
+    #[test]
+    fn target_opset_version_setter() {
+        let opts = Options::new().target_opset_version(18);
+        assert_eq!(opts.target_opset_version, Some(18));
+        // None encodes to 0 (the C API's "no change" sentinel); Some passes through.
+        assert_eq!(target_opset_to_c(None), 0);
+        assert_eq!(target_opset_to_c(Some(18)), 18);
     }
 
     #[test]

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -75,7 +75,9 @@
                     const constant_fold = document.getElementById("id_simplify_constant_fold").checked;
                     const shape_inference = document.getElementById("id_simplify_shape_inference").checked;
                     const tensor_size_threshold = parseInt(document.getElementById("id_simplify_tensor_size_threshold").value);
-                    worker.postMessage([optimizer, buf, passes, constant_fold, shape_inference, tensor_size_threshold], [buf]);
+                    // An empty / non-positive value means "keep the current opset version".
+                    const target_opset_version = parseInt(document.getElementById("id_simplify_target_opset").value) || 0;
+                    worker.postMessage([optimizer, buf, passes, constant_fold, shape_inference, tensor_size_threshold, target_opset_version], [buf]);
                 });
             };
         </script>
@@ -107,6 +109,9 @@
             <br/>
             <label>tensor size threshold (simplify only)</label>
             <input type="number" name="simplify_tensor_size_threshold" id="id_simplify_tensor_size_threshold" value="1000000000">
+            <br/>
+            <label>target opset version (simplify only, 0 = keep)</label>
+            <input type="number" name="simplify_target_opset" id="id_simplify_target_opset" value="0">
             <br/>
         </div>
         <h2>Console outputs:</h2>

--- a/scripts/convertmodel/interface.cpp
+++ b/scripts/convertmodel/interface.cpp
@@ -7,7 +7,7 @@
 
 namespace em = emscripten;
 
-em::val onnxsimplify_export(const std::string& data, em::val skip_optimizers, bool constant_folding, bool shape_inference, size_t tensor_size_threshold) {
+em::val onnxsimplify_export(const std::string& data, em::val skip_optimizers, bool constant_folding, bool shape_inference, size_t tensor_size_threshold, int target_opset_version) {
     InitEnv();
 
     std::cerr << "LOG_THRESHOLD: " << std::getenv("LOG_THRESHOLD") << std::endl;
@@ -27,7 +27,11 @@ em::val onnxsimplify_export(const std::string& data, em::val skip_optimizers, bo
             em::vecFromJSArray<std::string>(skip_optimizers),
             constant_folding,
             shape_inference,
-            tensor_size_threshold
+            tensor_size_threshold,
+            // A target opset version of <= 0 means "leave the opset unchanged".
+            target_opset_version > 0
+                ? std::make_optional(target_opset_version)
+                : std::nullopt
         );
     } catch (const std::exception& e) {
         std::cerr << "simplify error: " << e.what() << std::endl;

--- a/scripts/convertmodel/worker.js
+++ b/scripts/convertmodel/worker.js
@@ -25,6 +25,7 @@ create_onnxsim({
                     e.data[3], // constant folding
                     e.data[4], // shape inference
                     e.data[5], // tensor size threshold
+                    e.data[6], // target opset version (<= 0 means keep)
                 );
                 break;
             case "optimize":

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -1171,6 +1171,45 @@ def test_keep_nonzero_lstm_initial_state():
     assert "Tile" in [node.op_type for node in sim_model.graph.node]
 
 
+def test_target_opset_version_upgrades_model():
+    # ``target_opset_version`` must upgrade the model's default-domain opset
+    # during simplification, using onnx's version converter.
+    x = onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1, 4])
+    y = onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1, 4])
+    node = onnx.helper.make_node("Relu", ["X"], ["Y"])
+    graph_def = onnx.helper.make_graph([node], "g", [x], [y])
+    model = onnx.helper.make_model(
+        graph_def, opset_imports=[onnx.helper.make_opsetid("", 11)]
+    )
+
+    def _default_opset(m):
+        return next(o.version for o in m.opset_import if o.domain in ("", "ai.onnx"))
+
+    assert _default_opset(model) == 11
+
+    sim_model, check_ok = onnxsim.simplify(model, target_opset_version=18)
+    assert check_ok
+    assert _default_opset(sim_model) == 18
+
+
+def test_target_opset_version_none_keeps_opset():
+    # The default (None) must leave the model's opset version untouched.
+    x = onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1, 4])
+    y = onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1, 4])
+    node = onnx.helper.make_node("Relu", ["X"], ["Y"])
+    graph_def = onnx.helper.make_graph([node], "g", [x], [y])
+    model = onnx.helper.make_model(
+        graph_def, opset_imports=[onnx.helper.make_opsetid("", 11)]
+    )
+
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    default_opset = next(
+        o.version for o in sim_model.opset_import if o.domain in ("", "ai.onnx")
+    )
+    assert default_opset == 11
+
+
 def test_perform_optimization_false():
     def _create_dummy_model():
         class MockModel(torch.nn.Module):


### PR DESCRIPTION
## Summary
This PR adds support for converting ONNX models to a target opset version during simplification. Users can now specify a target opset version, and onnxsim will convert the model's default ONNX domain to that version before running simplification, allowing redundant nodes introduced by the conversion to be cleaned up.

## Key Changes

- **Core C++ Implementation**: Added `DefaultOpsetVersion()` and `ConvertOpsetVersion()` functions in `onnxsim.cpp` that leverage ONNX's built-in version converter to upgrade/downgrade the default domain opset before simplification.

- **API Updates**: Extended the `Simplify()` and `SimplifyPath()` functions to accept an optional `target_opset_version` parameter (defaults to `std::nullopt` to preserve existing behavior).

- **C API**: Updated `onnxsim_simplify()` and `onnxsim_simplify_path()` to accept `target_opset_version` parameter, using a convention where values ≤ 0 mean "leave unchanged".

- **Python Bindings**: 
  - Added `target_opset_version` parameter to the `simplify()` function
  - Added `--target-opset` CLI argument to the command-line tool
  - Updated C++ to Python export bindings in `cpp2py_export.cc`

- **Rust Bindings**: Added `target_opset_version()` builder method to `Options` struct with proper encoding for the C ABI.

- **Web Interface**: Added "target opset version" input field to the HTML UI and updated worker.js to pass the parameter through.

- **CLI Tool**: Updated `onnxsim_bin.cpp` and `onnxsim_option.cpp` to support `--target-opset` command-line flag.

- **Tests**: Added two new Python tests verifying that:
  - `target_opset_version` parameter correctly upgrades the model's opset
  - Default behavior (None) preserves the original opset version

- **Documentation**: Updated README.md with usage examples for both Python API and CLI.

## Implementation Details

- The conversion happens inside the C++ core before simplification, ensuring all language bindings (Python, Rust, C API, web) share consistent behavior.
- Only the default ONNX domain opset is modified; custom/other-domain opset imports remain untouched.
- The implementation gracefully handles models that don't import the default domain (custom-only operators).
- Uses ONNX's own `version_conversion::ConvertVersion()` for reliable, standards-compliant conversion.

https://claude.ai/code/session_0159iqx6AG6NfrYh1zi9uThq