### PR TITLE
Add memory metrics: access traffic, peak footprint, compute density

### DIFF
--- a/onnxsim/model_info.py
+++ b/onnxsim/model_info.py
@@ -60,6 +60,10 @@ def _external_data_size(graph: onnx.GraphProto) -> int:
 
 
 def human_readable_size(num, suffix="B"):
+    # A symbolic byte count (dynamic shapes + sympy) is printed as the formula
+    # itself, matching human_readable_num.
+    if _is_symbolic(num):
+        return str(sympy.factor(num))
     for unit in ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"]:
         if abs(num) < 1024.0:
             return f"{num:3.1f}{unit}{suffix}"
@@ -79,12 +83,23 @@ def human_readable_num(num, suffix=""):
     return f"{num:.1f}Z{suffix}"
 
 
+def human_readable_density(num, suffix=" FLOP/Byte"):
+    # Arithmetic intensity is a small ratio; print it plainly. When symbolic
+    # (dynamic shapes cancel unevenly) fall back to the factored formula.
+    if _is_symbolic(num):
+        return f"{sympy.factor(num)}{suffix}"
+    return f"{float(num):.2f}{suffix}"
+
+
 # A dimension is a concrete int, a symbolic size (a sympy Symbol standing in for
 # a ``dim_param`` such as "batch"), or None when the size is entirely unknown.
 Dim = Union[int, "sympy.Expr", None]
 # A MAC count is an int, or a sympy expression once any symbolic dim is involved.
 Macs = Union[int, "sympy.Expr"]
 ShapeMap = Dict[str, List[Dim]]
+# Bytes-per-element for each tensor, keyed like ShapeMap. Drives the memory
+# metrics (access traffic, peak footprint) alongside the shapes.
+DTypeMap = Dict[str, int]
 
 
 def _dim_symbol(name: str) -> "sympy.Expr":
@@ -134,6 +149,13 @@ def _representative_number(value: Macs) -> int:
     return int(value)
 
 
+def _max_macs(a: Macs, b: Macs) -> Macs:
+    # Larger of two possibly-symbolic values, chosen by representative magnitude
+    # (all free dims -> 1). The winner is returned intact, so a symbolic peak is
+    # reported as its formula while the comparison itself stays decidable.
+    return a if _representative_number(a) >= _representative_number(b) else b
+
+
 def _collect_shapes(graph: onnx.GraphProto, inherited: ShapeMap) -> ShapeMap:
     shapes: ShapeMap = dict(inherited)
     for value_info in list(graph.input) + list(graph.output) + list(graph.value_info):
@@ -143,6 +165,59 @@ def _collect_shapes(graph: onnx.GraphProto, inherited: ShapeMap) -> ShapeMap:
     for initializer in graph.initializer:
         shapes[initializer.name] = list(initializer.dims)
     return shapes
+
+
+def _elem_size(elem_type: int) -> Optional[int]:
+    """Bytes per element of an ONNX tensor element type, or None if it has no
+    fixed width (e.g. STRING) or is unmapped. Unknown widths disable the memory
+    metrics for the tensor rather than guessing.
+    """
+    try:
+        dtype = helper.tensor_dtype_to_np_dtype(elem_type)
+    except Exception:
+        return None
+    if dtype.kind in ("O", "U", "S", "V"):  # object / string / void: no fixed size
+        return None
+    return int(dtype.itemsize)
+
+
+def _collect_dtypes(graph: onnx.GraphProto, inherited: DTypeMap) -> DTypeMap:
+    dtypes: DTypeMap = dict(inherited)
+    for value_info in list(graph.input) + list(graph.output) + list(graph.value_info):
+        esize = _elem_size(value_info.type.tensor_type.elem_type)
+        if esize is not None:
+            dtypes[value_info.name] = esize
+    for initializer in graph.initializer:
+        esize = _elem_size(initializer.data_type)
+        if esize is not None:
+            dtypes[initializer.name] = esize
+    return dtypes
+
+
+def _tensor_bytes(name: str, shapes: ShapeMap, dtypes: DTypeMap) -> Optional[Macs]:
+    """Size in bytes of a named tensor, or None when its shape or element size is
+    unknown. May be symbolic when a dimension is a ``dim_param``.
+    """
+    shape = shapes.get(name)
+    esize = dtypes.get(name)
+    if not _known(shape) or esize is None:
+        return None
+    return _prod(shape) * esize
+
+
+def _node_memory_access(node: onnx.NodeProto, shapes: ShapeMap, dtypes: DTypeMap) -> Macs:
+    """Bytes a node moves in a forward pass: every input read plus every output
+    written. Weights read from memory count as reads. Tensors with unknown size
+    contribute 0 (best-effort, matching the MAC counters).
+    """
+    total: Macs = 0
+    for name in list(node.input) + list(node.output):
+        if not name:  # optional/omitted operand
+            continue
+        nbytes = _tensor_bytes(name, shapes, dtypes)
+        if nbytes is not None:
+            total += nbytes
+    return total
 
 
 def _attr_int(node: onnx.NodeProto, name: str, default: int) -> int:
@@ -374,19 +449,34 @@ class ModelInfo:
        functions (and nested ones) are inlined, and schema-registered function
        ops without a bespoke counter fall back to their context-dependent body
        (best-effort).
-    TODO:
-    Based on onnx runtime, get
-    1、forward memory footprint
-    2、memory access
-    3、compute density
+    4. Memory metrics, derived statically from the same inferred shapes (no
+       runtime execution needed):
+       - ``mem_access``: total bytes read and written across a forward pass --
+         every node's inputs (weights included) plus its outputs.
+       - ``memory_footprint``: peak bytes resident at once, from a liveness pass
+         over the topologically-ordered nodes -- weights stay resident while each
+         activation lives only from where it is produced to its last use.
+       - ``compute_density``: arithmetic intensity, ``flops / mem_access``
+         (FLOP per byte), the roofline ratio.
+       Tensors whose shape or element size is unknown contribute 0, so these are
+       best-effort lower bounds; with dynamic dims they may be symbolic too.
     """
 
-    def get_info(self, graph: onnx.GraphProto, inherited_shapes: Optional[ShapeMap] = None) -> Tuple[Dict[str, int], Macs]:
+    def get_info(
+        self,
+        graph: onnx.GraphProto,
+        inherited_shapes: Optional[ShapeMap] = None,
+        inherited_dtypes: Optional[DTypeMap] = None,
+    ) -> Tuple[Dict[str, int], Macs, Macs]:
         if inherited_shapes is None:
             inherited_shapes = {}
+        if inherited_dtypes is None:
+            inherited_dtypes = {}
         shapes = _collect_shapes(graph, inherited_shapes)
+        dtypes = _collect_dtypes(graph, inherited_dtypes)
         op_nums = defaultdict(int)
         macs = 0
+        mem_access = 0
         for node in graph.node:
             op_nums[node.op_type] += 1
             counter = _MAC_COUNTERS.get(node.op_type)
@@ -399,23 +489,25 @@ class ModelInfo:
                         f"'{node.name}' ({e}); it is excluded from the total.",
                         stacklevel=2,
                     )
+            mem_access += _node_memory_access(node, shapes, dtypes)
             for attr in node.attribute:
                 sub_graphs = []
                 if attr.HasField("g"):
                     sub_graphs.append(attr.g)
                 sub_graphs.extend(attr.graphs)
                 for sub_graph in sub_graphs:
-                    sub_op_nums, sub_macs = self.get_info(sub_graph, shapes)
+                    sub_op_nums, sub_macs, sub_mem = self.get_info(sub_graph, shapes, dtypes)
                     op_nums = defaultdict(int, {k: op_nums[k] + sub_op_nums[k] for k in set(op_nums) | set(sub_op_nums)})
                     macs += sub_macs
+                    mem_access += sub_mem
         op_nums["Constant"] += len(graph.initializer)
-        return op_nums, macs
+        return op_nums, macs, mem_access
 
     def __init__(self, model: onnx.ModelProto):
         inferred = self._infer_shapes(model)
         # Op counts describe the model as authored, so a function op (e.g. a
         # fused block) is reported as a single op.
-        self.op_nums, macs = self.get_info(inferred.graph)
+        self.op_nums, macs, mem_access = self.get_info(inferred.graph)
         # ``graph.ByteSize()`` is the serialized size of the whole graph -- nested
         # subgraphs and inline tensor data included -- so it is taken once at the
         # top rather than summed per subgraph (which double-counted nested
@@ -425,13 +517,18 @@ class ModelInfo:
         # data has been loaded, so callers need not materialize multi-GB weights
         # just to measure the model.
         self.model_size = model.graph.ByteSize() + _external_data_size(model.graph)
-        # A function op's compute lives in its body, so for MACs we expose
-        # function bodies and recount -- the primitive counters then see the
+        # A function op's compute lives in its body, so for MACs (and the memory
+        # metrics, which must pair with those FLOPs) we expose function bodies and
+        # recount on the expanded graph -- the primitive counters then see the
         # MatMuls, Convs, etc. inside every function instance.
-        macs_graph = self._expanded_macs_graph(model)
-        if macs_graph is not None:
-            _, macs = self.get_info(macs_graph)
+        compute_graph = self._expanded_macs_graph(model)
+        if compute_graph is not None:
+            _, macs, mem_access = self.get_info(compute_graph)
+        else:
+            compute_graph = inferred.graph
         self.macs = macs
+        self.mem_access = mem_access
+        self.memory_footprint = self._peak_memory_footprint(compute_graph)
 
     @staticmethod
     def _expanded_macs_graph(model: onnx.ModelProto) -> Optional[onnx.GraphProto]:
@@ -475,9 +572,88 @@ class ModelInfo:
             )
             return model
 
+    def _peak_memory_footprint(
+        self,
+        graph: onnx.GraphProto,
+        inherited_shapes: Optional[ShapeMap] = None,
+        inherited_dtypes: Optional[DTypeMap] = None,
+    ) -> Macs:
+        """Peak bytes resident during a forward pass of ``graph``.
+
+        A simple liveness pass over the topologically-ordered nodes (ONNX
+        requires that order): weights (initializers) stay resident throughout,
+        while every other tensor lives from where it is produced until its last
+        consumer -- graph outputs live to the end. The peak is the largest total
+        of resident-weights + live-activations at any node. Control-flow
+        subgraphs add their own recursive peak on top of the live set at the
+        owning node (a conservative bound, since captured tensors are counted in
+        both). Unknown-size tensors contribute 0.
+        """
+        shapes = _collect_shapes(graph, inherited_shapes or {})
+        dtypes = _collect_dtypes(graph, inherited_dtypes or {})
+
+        def nbytes(name: str) -> Macs:
+            size = _tensor_bytes(name, shapes, dtypes)
+            return size if size is not None else 0
+
+        weight_names = {init.name for init in graph.initializer}
+        resident: Macs = 0
+        for name in weight_names:
+            resident += nbytes(name)
+
+        # Last node index that consumes each tensor; graph outputs are "consumed"
+        # at the end so they stay live for the whole pass.
+        last_use: Dict[str, int] = {}
+        for i, node in enumerate(graph.node):
+            for name in node.input:
+                if name:
+                    last_use[name] = i
+        end = len(graph.node)
+        for out in graph.output:
+            last_use[out.name] = end
+
+        def live_bytes(live: set) -> Macs:
+            total: Macs = resident
+            for name in live:
+                total += nbytes(name)
+            return total
+
+        # Graph inputs (non-weight) are available from the start.
+        live = {inp.name for inp in graph.input if inp.name not in weight_names}
+        peak = live_bytes(live)
+        for i, node in enumerate(graph.node):
+            for name in node.output:
+                if name and name not in weight_names:
+                    live.add(name)
+            current = live_bytes(live)
+            # Nested subgraphs run while this node's live set is held.
+            for attr in node.attribute:
+                sub_graphs = []
+                if attr.HasField("g"):
+                    sub_graphs.append(attr.g)
+                sub_graphs.extend(attr.graphs)
+                for sub_graph in sub_graphs:
+                    sub_peak = self._peak_memory_footprint(sub_graph, shapes, dtypes)
+                    current = current + sub_peak
+            peak = _max_macs(peak, current)
+            for name in [n for n in live if last_use.get(n) == i]:
+                live.discard(name)
+        return peak
+
     @property
     def flops(self) -> int:
         return self.macs * 2
+
+    @property
+    def compute_density(self) -> Macs:
+        """Arithmetic intensity: FLOPs per byte of memory traffic (roofline).
+
+        0 when no traffic is known. Symbolic when the dynamic dimensions do not
+        cancel between FLOPs and bytes.
+        """
+        if _representative_number(self.mem_access) == 0:
+            return 0
+        return self.flops / self.mem_access
 
 
 def print_simplifying_info(model_ori: onnx.ModelProto, model_opt: onnx.ModelProto) -> None:
@@ -522,4 +698,12 @@ def print_simplifying_info(model_ori: onnx.ModelProto, model_opt: onnx.ModelProt
         table, 'MACs', ori_info.macs, opt_info.macs, macs_improved, postprocess=human_readable_num)
     add_row(
         table, 'FLOPs', ori_info.flops, opt_info.flops, macs_improved, postprocess=human_readable_num)
+    add_row(
+        table, 'Memory Access', ori_info.mem_access, opt_info.mem_access, macs_improved, postprocess=human_readable_size)
+    add_row(
+        table, 'Memory Footprint', ori_info.memory_footprint, opt_info.memory_footprint, macs_improved, postprocess=human_readable_size)
+    # Compute density (FLOP/Byte): a change here isn't strictly "better or
+    # worse", so it is reported without highlighting.
+    add_row(
+        table, 'Compute Density', ori_info.compute_density, opt_info.compute_density, lambda opt, ori: False, postprocess=human_readable_density)
     print(table)

--- a/onnxsim/model_info.py
+++ b/onnxsim/model_info.py
@@ -21,7 +21,11 @@ except ImportError:  # onnx.inliner was added in onnx 1.14; see ModelInfo.__init
     onnx_inliner = None
 
 
-__all__ = ['ModelInfo', 'print_simplifying_info']
+__all__ = ['ModelInfo', 'print_simplifying_info', 'annotate_metadata', 'METADATA_PREFIX']
+
+# metadata_props keys written by ``annotate_metadata`` are namespaced with this
+# prefix (e.g. "onnxsim.macs") so they never collide with other producers.
+METADATA_PREFIX = "onnxsim."
 
 
 def _iter_graph_tensors(graph: onnx.GraphProto) -> Iterable[onnx.TensorProto]:
@@ -707,3 +711,135 @@ def print_simplifying_info(model_ori: onnx.ModelProto, model_opt: onnx.ModelProt
     add_row(
         table, 'Compute Density', ori_info.compute_density, opt_info.compute_density, lambda opt, ori: False, postprocess=human_readable_density)
     print(table)
+
+
+def _metric_str(value: Macs) -> str:
+    # A metadata value is always a string. A symbolic metric is stored as its
+    # factored formula (e.g. "512*batch"); a concrete one as its plain number.
+    if _is_symbolic(value):
+        return str(sympy.factor(value))
+    return str(value)
+
+
+def _supports_metadata(proto) -> bool:
+    # metadata_props on Node/Graph/ValueInfo/Tensor was added in newer onnx
+    # releases; skip the level cleanly on older ones instead of crashing.
+    return any(f.name == "metadata_props" for f in proto.DESCRIPTOR.fields)
+
+
+def _set_metadata(proto, key: str, value: str) -> None:
+    """Set ``key`` -> ``value`` in ``proto.metadata_props``, overwriting any
+    existing entry with that key. No-op if the proto has no metadata_props.
+    """
+    if not _supports_metadata(proto):
+        return
+    for entry in proto.metadata_props:
+        if entry.key == key:
+            entry.value = value
+            return
+    entry = proto.metadata_props.add()
+    entry.key = key
+    entry.value = value
+
+
+def _annotate_graph(
+    graph: onnx.GraphProto,
+    prefix: str,
+    inherited_shapes: ShapeMap,
+    inherited_dtypes: DTypeMap,
+) -> Tuple[Macs, Macs]:
+    """Write per-node and per-value metrics onto ``graph`` in place and return
+    the graph's ``(macs, mem_access)`` subtotal.
+
+    Per-value tensors (inputs, outputs, value_info and initializers) get a
+    ``<prefix>bytes`` entry; each node gets ``macs`` / ``flops`` / ``mem_access``;
+    the graph itself gets its own aggregate of those three. Values come from the
+    graph as authored, so a function-op node counts only what a bespoke counter
+    knows (0 otherwise) -- the model-level totals additionally include function
+    bodies (see ``annotate_metadata``).
+    """
+    shapes = _collect_shapes(graph, inherited_shapes)
+    dtypes = _collect_dtypes(graph, inherited_dtypes)
+
+    for value_info in list(graph.input) + list(graph.output) + list(graph.value_info):
+        nbytes = _tensor_bytes(value_info.name, shapes, dtypes)
+        if nbytes is not None:
+            _set_metadata(value_info, prefix + "bytes", _metric_str(nbytes))
+    for initializer in graph.initializer:
+        nbytes = _tensor_bytes(initializer.name, shapes, dtypes)
+        if nbytes is not None:
+            _set_metadata(initializer, prefix + "bytes", _metric_str(nbytes))
+
+    macs: Macs = 0
+    mem_access: Macs = 0
+    for node in graph.node:
+        counter = _MAC_COUNTERS.get(node.op_type)
+        node_macs: Macs = 0
+        if counter is not None:
+            try:
+                node_macs = counter(node, shapes)
+            except Exception:
+                node_macs = 0
+        node_mem = _node_memory_access(node, shapes, dtypes)
+        _set_metadata(node, prefix + "macs", _metric_str(node_macs))
+        _set_metadata(node, prefix + "flops", _metric_str(node_macs * 2))
+        _set_metadata(node, prefix + "mem_access", _metric_str(node_mem))
+        macs += node_macs
+        mem_access += node_mem
+        for attr in node.attribute:
+            sub_graphs = []
+            if attr.HasField("g"):
+                sub_graphs.append(attr.g)
+            sub_graphs.extend(attr.graphs)
+            for sub_graph in sub_graphs:
+                sub_macs, sub_mem = _annotate_graph(sub_graph, prefix, shapes, dtypes)
+                macs += sub_macs
+                mem_access += sub_mem
+
+    _set_metadata(graph, prefix + "macs", _metric_str(macs))
+    _set_metadata(graph, prefix + "flops", _metric_str(macs * 2))
+    _set_metadata(graph, prefix + "mem_access", _metric_str(mem_access))
+    return macs, mem_access
+
+
+def annotate_metadata(model: onnx.ModelProto, prefix: str = METADATA_PREFIX) -> onnx.ModelProto:
+    """Return a shape-inferred copy of ``model`` with the computed metrics stored
+    in ``metadata_props`` at three levels, so downstream tools can read them back:
+
+    - **Model** (and every graph): ``<prefix>macs``, ``flops``, ``mem_access``.
+      The model additionally carries ``memory_footprint``, ``compute_density``
+      and ``model_size``. Model-level totals come from :class:`ModelInfo`, so
+      they include the compute inside inlined function bodies; a graph's own
+      entries are the sum over the nodes it literally contains.
+    - **Node**: ``<prefix>macs`` / ``flops`` / ``mem_access`` for that node.
+    - **Value** (inputs, outputs, value_info, initializers): ``<prefix>bytes``.
+
+    Values are strings (a symbolic metric is its formula, e.g. ``"512*batch"``).
+    Tensors of unknown shape/dtype are simply left unannotated. The input model
+    is never mutated; the returned copy is shape-inferred so intermediate values
+    carry the shapes the per-value/per-node metrics are derived from.
+    """
+    info = ModelInfo(model)
+    # Work on an inferred copy: infer_shapes returns a fresh model on success,
+    # but the original object on failure -- deep-copy first so the caller's model
+    # is never touched and the annotations land on populated value_info.
+    work = ModelInfo._infer_shapes(copy.deepcopy(model))
+
+    _annotate_graph(work.graph, prefix, {}, {})
+
+    totals = {
+        "macs": info.macs,
+        "flops": info.flops,
+        "mem_access": info.mem_access,
+        "memory_footprint": info.memory_footprint,
+        "compute_density": info.compute_density,
+        "model_size": info.model_size,
+    }
+    for key, value in totals.items():
+        _set_metadata(work, prefix + key, _metric_str(value))
+    # Overwrite the top graph's authored-node aggregates with the model totals so
+    # graph- and model-level macs/flops/mem_access agree (they differ only when
+    # function bodies contribute compute the authored nodes don't show).
+    for key in ("macs", "flops", "mem_access"):
+        _set_metadata(work.graph, prefix + key, _metric_str(totals[key]))
+    return work

--- a/tests/test_model_info.py
+++ b/tests/test_model_info.py
@@ -12,7 +12,9 @@ import pytest
 
 from onnxsim import model_info
 from onnxsim.model_info import (
+    METADATA_PREFIX,
     ModelInfo,
+    annotate_metadata,
     human_readable_density,
     human_readable_num,
     human_readable_size,
@@ -408,6 +410,118 @@ def test_memory_metrics_reported_in_summary(capsys):
     assert "Memory Access" in out
     assert "Memory Footprint" in out
     assert "Compute Density" in out
+
+
+# --------------------------------------------------------------------------- #
+# Storing metrics into metadata_props
+# --------------------------------------------------------------------------- #
+def _meta(proto):
+    return {e.key: e.value for e in proto.metadata_props}
+
+
+def _gemm_model():
+    a = _vi("a", [5, 7])
+    b = _vi("b", [7, 3])
+    y = _vi("y", [5, 3])
+    return _model([helper.make_node("Gemm", ["a", "b"], ["y"], name="gemm0")], [a, b], [y])
+
+
+def test_annotate_metadata_model_level():
+    model = _gemm_model()
+    info = ModelInfo(model)
+    out = annotate_metadata(model)
+    meta = _meta(out)
+    p = METADATA_PREFIX
+    assert meta[p + "macs"] == str(info.macs)
+    assert meta[p + "flops"] == str(info.flops)
+    assert meta[p + "mem_access"] == str(info.mem_access)
+    assert meta[p + "memory_footprint"] == str(info.memory_footprint)
+    assert meta[p + "model_size"] == str(info.model_size)
+    assert p + "compute_density" in meta
+
+
+def test_annotate_metadata_node_level():
+    out = annotate_metadata(_gemm_model())
+    (node,) = out.graph.node
+    meta = _meta(node)
+    p = METADATA_PREFIX
+    assert meta[p + "macs"] == str(5 * 3 * 7)
+    assert meta[p + "flops"] == str(2 * 5 * 3 * 7)
+    assert meta[p + "mem_access"] == str((5 * 7 + 7 * 3 + 5 * 3) * 4)
+
+
+def test_annotate_metadata_value_level():
+    out = annotate_metadata(_gemm_model())
+    by_name = {vi.name: _meta(vi) for vi in list(out.graph.input) + list(out.graph.output)}
+    p = METADATA_PREFIX
+    assert by_name["a"][p + "bytes"] == str(5 * 7 * 4)
+    assert by_name["b"][p + "bytes"] == str(7 * 3 * 4)
+    assert by_name["y"][p + "bytes"] == str(5 * 3 * 4)
+
+
+def test_annotate_metadata_annotates_initializers():
+    a = _vi("a", [4, 8])
+    b = _weight("b", [8, 16])
+    y = _vi("y", [4, 16])
+    model = _model([helper.make_node("MatMul", ["a", "b"], ["y"])], [a], [y], [b])
+    out = annotate_metadata(model)
+    (init,) = out.graph.initializer
+    assert _meta(init)[METADATA_PREFIX + "bytes"] == str(8 * 16 * 4)
+
+
+def test_annotate_metadata_does_not_mutate_input():
+    model = _gemm_model()
+    annotate_metadata(model)
+    assert len(model.metadata_props) == 0
+    assert all(len(n.metadata_props) == 0 for n in model.graph.node)
+    assert all(len(vi.metadata_props) == 0 for vi in model.graph.input)
+
+
+def test_annotate_metadata_output_passes_checker():
+    onnx.checker.check_model(annotate_metadata(_gemm_model()))
+
+
+def test_annotate_metadata_custom_prefix():
+    out = annotate_metadata(_gemm_model(), prefix="myprefix.")
+    assert "myprefix.macs" in _meta(out)
+    assert "myprefix.macs" in _meta(out.graph.node[0])
+
+
+def test_annotate_metadata_symbolic_stores_formula():
+    pytest.importorskip("sympy")
+    a = _vi("a", ["batch", 7])
+    b = _weight("b", [7, 3])
+    y = _vi("y", ["batch", 3])
+    model = _model([helper.make_node("MatMul", ["a", "b"], ["y"], name="mm")], [a], [y], [b])
+    out = annotate_metadata(model)
+    assert _meta(out.graph.node[0])[METADATA_PREFIX + "macs"] == "21*batch"
+    a_vi = next(vi for vi in out.graph.input if vi.name == "a")
+    assert _meta(a_vi)[METADATA_PREFIX + "bytes"] == "28*batch"
+
+
+def test_annotate_metadata_recurses_subgraphs():
+    # An If whose branches each hold a Gemm: the node inside a branch must be
+    # annotated, and the model total must include that branch's MACs.
+    cond = helper.make_tensor_value_info("cond", TensorProto.BOOL, [])
+    y = _vi("y", [5, 3])
+
+    def branch(name):
+        a = _weight("a_" + name, [5, 7])
+        b = _weight("b_" + name, [7, 3])
+        node = helper.make_node("Gemm", ["a_" + name, "b_" + name], ["y"], name="gemm_" + name)
+        return helper.make_graph([node], name, [], [_vi("y", [5, 3])], [a, b])
+
+    if_node = helper.make_node(
+        "If", ["cond"], ["y"], then_branch=branch("t"), else_branch=branch("e")
+    )
+    model = _model([if_node], [cond], [y])
+    out = annotate_metadata(model)
+    # Locate the Gemm inside the then-branch and check it carries metrics.
+    then_g = next(a.g for a in out.graph.node[0].attribute if a.name == "then_branch")
+    gemm = next(n for n in then_g.node if n.op_type == "Gemm")
+    assert _meta(gemm)[METADATA_PREFIX + "macs"] == str(5 * 3 * 7)
+    # Model total counts both branches' Gemms.
+    assert _meta(out)[METADATA_PREFIX + "macs"] == str(2 * 5 * 3 * 7)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_model_info.py
+++ b/tests/test_model_info.py
@@ -11,7 +11,12 @@ from onnx import TensorProto, helper
 import pytest
 
 from onnxsim import model_info
-from onnxsim.model_info import ModelInfo, human_readable_num, human_readable_size
+from onnxsim.model_info import (
+    ModelInfo,
+    human_readable_density,
+    human_readable_num,
+    human_readable_size,
+)
 
 
 def _model(nodes, inputs, outputs, initializers=None, opset=23):
@@ -270,6 +275,139 @@ def test_human_readable_num_units():
 def test_human_readable_size_units():
     assert human_readable_size(512) == "512.0B"
     assert human_readable_size(1024) == "1.0KiB"
+
+
+def test_human_readable_density_units():
+    assert human_readable_density(0) == "0.00 FLOP/Byte"
+    assert human_readable_density(2.5) == "2.50 FLOP/Byte"
+
+
+def test_human_readable_size_symbolic():
+    sympy = pytest.importorskip("sympy")
+    batch = sympy.Symbol("batch", positive=True, integer=True)
+    assert human_readable_size(512 * batch) == "512*batch"
+
+
+# --------------------------------------------------------------------------- #
+# Memory metrics: access traffic, peak footprint, compute density
+# --------------------------------------------------------------------------- #
+def _info(nodes, inputs, outputs, initializers=None, opset=23):
+    return ModelInfo(_model(nodes, inputs, outputs, initializers, opset))
+
+
+def test_memory_access_gemm():
+    # float32 tensors: reads a (5*7) + b (7*3), writes y (5*3), 4 bytes each.
+    a = _vi("a", [5, 7])
+    b = _vi("b", [7, 3])
+    y = _vi("y", [5, 3])
+    node = helper.make_node("Gemm", ["a", "b"], ["y"])
+    expected = (5 * 7 + 7 * 3 + 5 * 3) * 4
+    assert _info([node], [a, b], [y]).mem_access == expected
+
+
+def test_memory_access_counts_weights():
+    # A weight fed as an initializer is read from memory, so its bytes count.
+    a = _vi("a", [4, 8])
+    b = _weight("b", [8, 16])
+    y = _vi("y", [4, 16])
+    node = helper.make_node("MatMul", ["a", "b"], ["y"])
+    expected = (4 * 8 + 8 * 16 + 4 * 16) * 4
+    assert _info([node], [a], [y], [b]).mem_access == expected
+
+
+def test_memory_access_respects_dtype_size():
+    # float16 halves the bytes of the float32 case.
+    a = _vi("a", [5, 7], TensorProto.FLOAT16)
+    b = _vi("b", [7, 3], TensorProto.FLOAT16)
+    y = _vi("y", [5, 3], TensorProto.FLOAT16)
+    node = helper.make_node("Gemm", ["a", "b"], ["y"])
+    expected = (5 * 7 + 7 * 3 + 5 * 3) * 2
+    assert _info([node], [a, b], [y]).mem_access == expected
+
+
+def test_memory_access_unknown_shape_contributes_zero():
+    # An intermediate with no inferred shape simply drops out of the total; the
+    # known operands are still counted.
+    a = _vi("a", [5, 7])
+    b = _vi("b", [7, 3])
+    y = _vi("y", [5, 3])
+    node = helper.make_node("Gemm", ["a", "b"], ["y"])
+    assert model_info._node_memory_access(node, {}, {}) == 0
+
+
+def test_compute_density_is_flops_over_bytes():
+    a = _vi("a", [5, 7])
+    b = _vi("b", [7, 3])
+    y = _vi("y", [5, 3])
+    info = _info([helper.make_node("Gemm", ["a", "b"], ["y"])], [a, b], [y])
+    assert info.compute_density == info.flops / info.mem_access
+
+
+def test_compute_density_zero_when_no_traffic():
+    # A shapeless model has no measurable traffic, so density is 0 (not a crash).
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, None)
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, None)
+    info = _info([helper.make_node("Relu", ["x"], ["y"])], [x], [y])
+    assert info.mem_access == 0
+    assert info.compute_density == 0
+
+
+def test_memory_footprint_single_node():
+    # Gemm: inputs a, b live through the node and output y is produced -> peak is
+    # every tensor resident at once.
+    a = _vi("a", [5, 7])
+    b = _vi("b", [7, 3])
+    y = _vi("y", [5, 3])
+    info = _info([helper.make_node("Gemm", ["a", "b"], ["y"])], [a, b], [y])
+    assert info.memory_footprint == (5 * 7 + 7 * 3 + 5 * 3) * 4
+
+
+def test_memory_footprint_reuses_freed_activations():
+    # x -> Conv -> h -> Relu -> y. x is dead after Conv, so it is not resident
+    # during Relu; the peak is the larger of the two per-node working sets, not
+    # the sum of every tensor.
+    x = _vi("x", [1, 3, 8, 8])
+    w = _weight("w", [4, 3, 3, 3])
+    h = _vi("h", [1, 4, 8, 8])
+    y = _vi("y", [1, 4, 8, 8])
+    nodes = [
+        helper.make_node("Conv", ["x", "w"], ["h"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]),
+        helper.make_node("Relu", ["h"], ["y"]),
+    ]
+    info = _info(nodes, [x], [y], [w])
+    b = 4  # float32
+    weight_bytes = 4 * 3 * 3 * 3 * b
+    x_bytes = 1 * 3 * 8 * 8 * b
+    h_bytes = 1 * 4 * 8 * 8 * b
+    y_bytes = 1 * 4 * 8 * 8 * b
+    conv_peak = weight_bytes + x_bytes + h_bytes  # x still live, h produced
+    relu_peak = weight_bytes + h_bytes + y_bytes  # x freed, y produced
+    assert info.memory_footprint == max(conv_peak, relu_peak)
+    # ... and strictly less than holding every tensor at once.
+    assert info.memory_footprint < weight_bytes + x_bytes + h_bytes + y_bytes
+
+
+def test_memory_metrics_symbolic_dynamic_batch():
+    sympy = pytest.importorskip("sympy")
+    a = _vi("a", ["batch", 7])
+    b = _weight("b", [7, 3])
+    y = _vi("y", ["batch", 3])
+    info = _info([helper.make_node("MatMul", ["a", "b"], ["y"])], [a], [y], [b])
+    batch = sympy.Symbol("batch", positive=True, integer=True)
+    expected = (7 * batch + 3 * batch) * 4 + (7 * 3) * 4  # a + y scale with batch; b fixed
+    assert sympy.simplify(info.mem_access - expected) == 0
+
+
+def test_memory_metrics_reported_in_summary(capsys):
+    a = _vi("a", [5, 7])
+    b = _vi("b", [7, 3])
+    y = _vi("y", [5, 3])
+    model = _model([helper.make_node("Gemm", ["a", "b"], ["y"])], [a, b], [y])
+    model_info.print_simplifying_info(model, model)
+    out = capsys.readouterr().out
+    assert "Memory Access" in out
+    assert "Memory Footprint" in out
+    assert "Compute Density" in out
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
This PR adds comprehensive memory metrics to the ModelInfo class to complement the existing FLOP/MAC counters. These metrics enable analysis of memory-bound performance characteristics and roofline model analysis.

## Key Changes

- **Memory Access Tracking**: Added `mem_access` metric that counts total bytes read and written across a forward pass (all node inputs including weights, plus outputs)

- **Peak Memory Footprint**: Implemented `memory_footprint` metric via a liveness analysis pass that tracks which tensors are resident at each point in execution:
  - Weights (initializers) stay resident throughout
  - Activations live from production until last use
  - Graph outputs live until the end
  - Handles nested subgraphs conservatively

- **Compute Density**: Added `compute_density` property (arithmetic intensity) calculated as `flops / mem_access`, enabling roofline model analysis

- **Helper Functions**:
  - `_elem_size()`: Maps ONNX tensor types to bytes-per-element
  - `_collect_dtypes()`: Gathers element size information from graph tensors
  - `_tensor_bytes()`: Calculates tensor size in bytes (may be symbolic with dynamic dims)
  - `_node_memory_access()`: Computes memory traffic for individual nodes
  - `_max_macs()`: Compares possibly-symbolic values by representative magnitude
  - `human_readable_density()`: Formats compute density with proper units

- **Symbolic Support**: All memory metrics support symbolic expressions when dynamic dimensions are involved, matching the existing FLOP counter behavior

- **API Updates**:
  - `get_info()` now returns a 3-tuple including `mem_access`
  - Added optional `inherited_dtypes` parameter to propagate dtype info through subgraphs
  - `_peak_memory_footprint()` recursively handles nested control-flow subgraphs

- **Reporting**: Updated `print_simplifying_info()` to display memory metrics alongside existing MACs/FLOPs in the comparison table

## Implementation Details

- Unknown tensor shapes or element sizes contribute 0 bytes (best-effort lower bounds)
- Memory metrics are computed on the expanded graph (with inlined function bodies) to pair correctly with expanded FLOP counts
- The liveness pass is conservative for nested subgraphs, counting their peak footprint on top of the parent's live set
- Comprehensive test coverage including symbolic/dynamic shapes, dtype handling, and multi-node scenarios

https://claude.ai/code/session_01Gc4QL2ZBDr5E8J5qTskntd