### PR TITLE
Parallelize test dependency installation in CI workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,13 +44,22 @@ jobs:
         pip install cmake ninja "setuptools>=77" sccache
         pip install pytest pytest-cov gcovr
 
-    - name: Build instrumented extension (editable)
-      run: pip install --no-build-isolation -ve .
-
+    # Kick the network-heavy, build-independent test-dependency install off in
+    # the background so torch/torchvision (and the rest, all prebuilt wheels)
+    # download while the C++ extension below compiles, instead of waiting for the
+    # build to finish first. The `wait` before the test step guarantees they are
+    # installed before tests run.
     - name: Install test dependencies
+      id: test_deps
+      background: true
       run: |
         pip install torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cpu/
         pip install flake8 onnxruntime onnxscript==0.6.2 timm==1.0.26
+
+    - name: Build instrumented extension (editable)
+      run: pip install --no-build-isolation -ve .
+
+    - wait: test_deps
 
     - name: Run tests with combined coverage
       # COV_SKIP_BUILD=1: the extension was already built above.

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -32,13 +32,21 @@ jobs:
 
     - run: pip install cmake ninja setuptools sccache
 
-    - name: Build
-      run: pip install --no-build-isolation -ve .
-    
+    # Download/install the build-independent test dependencies (all prebuilt
+    # wheels) in the background so they fetch while the ASan build below compiles.
+    # The `wait` before the test step ensures they are ready first.
     - name: Install test dependencies
+      id: test_deps
+      background: true
       run: |
         pip install torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cpu/
         pip install pytest flake8 onnxruntime onnxscript==0.6.2 timm==1.0.26 sympy
+
+    - name: Build
+      run: pip install --no-build-isolation -ve .
+
+    - wait: test_deps
+
     - name: Test
       run: |
         LD_PRELOAD="/lib/x86_64-linux-gnu/libasan.so.8 /usr/lib/x86_64-linux-gnu/libstdc++.so.6" \


### PR DESCRIPTION
## Summary
Optimize CI workflow performance by running test dependency installation in the background while the C++ extension builds, rather than sequentially waiting for the build to complete first.

## Key Changes
- **coverage.yml**: Moved "Install test dependencies" step to run in background (before the build step) and added a `wait` step to ensure dependencies are ready before tests run
- **sanitizer.yml**: Applied the same optimization pattern - background test dependency installation with a `wait` step before the test execution

## Implementation Details
- Test dependencies (torch, torchvision, onnxruntime, etc.) are all prebuilt wheels that can be downloaded independently of the C++ extension build
- By running the dependency installation in parallel with the build (using `background: true`), network I/O and compilation happen concurrently instead of sequentially
- The `wait: test_deps` step ensures all dependencies are fully installed before the test step begins, maintaining correctness while improving overall workflow runtime
- Added clarifying comments explaining the optimization strategy in both workflows

https://claude.ai/code/session_01Pn6NMR9YpiH8S9nC5hy9vz