### PR TITLE
Disable eliminate_shape_gather pass to fix dynamic shape models

### DIFF
--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -1329,14 +1329,27 @@ onnx::ModelProto Simplify(
 
   config.tensor_size_threshold = tensor_size_threshold;
   config.optimizer_passes.clear();
+  // onnxsim already folds ``Gather`` on a ``Shape`` into constants on its own:
+  // ``_EvalPartialShape`` (above) plus data-propagating shape inference resolve
+  // the statically-known dimensions and leave the genuinely dynamic ones
+  // untouched. The onnx-optimizer ``eliminate_shape_gather`` pass is therefore
+  // redundant here, and it aborts the whole process on graphs where a Gather
+  // index cannot be statically resolved to an axis (common in dynamic-shape
+  // detection models such as FasterRCNN). Always drop it from the pass list.
+  static const std::vector<std::string> kAlwaysDisabledPasses = {
+      "eliminate_shape_gather"};
+  auto is_disabled = [](const std::vector<std::string>& list,
+                        const std::string& pass) {
+    return std::find(list.begin(), list.end(), pass) != list.end();
+  };
   // skip_optimizers == nullopt means skiping all optimizers, so
   // config.optimizer_passes is empty
   if (skip_optimizers) {
     std::vector<std::string> passes;
     const auto all_passes = onnx::optimization::GetFuseAndEliminationPass();
     for (const auto& pass : all_passes) {
-      if (std::find(skip_optimizers->begin(), skip_optimizers->end(), pass) ==
-          skip_optimizers->end()) {
+      if (!is_disabled(*skip_optimizers, pass) &&
+          !is_disabled(kAlwaysDisabledPasses, pass)) {
         passes.push_back(pass);
       }
     }


### PR DESCRIPTION
## Summary
This change prevents the `eliminate_shape_gather` optimizer pass from running in onnxsim, as it causes failures on dynamic-shape detection models like FasterRCNN where Gather indices cannot be statically resolved.

## Key Changes
- Added a `kAlwaysDisabledPasses` list containing `"eliminate_shape_gather"` that is unconditionally excluded from optimization
- Introduced an `is_disabled` helper function to check if a pass is in a disabled list
- Updated the pass filtering logic to exclude both user-specified skipped passes and always-disabled passes
- Added detailed comments explaining why `eliminate_shape_gather` is redundant and problematic:
  - onnxsim already handles Gather-on-Shape folding through `_EvalPartialShape` and shape inference
  - The onnx-optimizer pass aborts when it encounters Gather indices that cannot be statically resolved
  - This is common in dynamic-shape models

## Implementation Details
The change refactors the pass filtering to use a reusable `is_disabled` lambda function that checks membership in a disabled passes list, making the code more maintainable and allowing for future always-disabled passes if needed.

https://claude.ai/code/session_016qp5y8hZ8ktgPuAYKJtZZG