### PR TITLE
Add FunctionProto-based rewrite rules for cross-binding pattern matching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 # configure onnx-optimizer after onnxruntime, because they both depend on onnx and onnxruntime has its own flags for onnx
 add_subdirectory(third_party/onnx-optimizer EXCLUDE_FROM_ALL)
 
-add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/contrib_schemas.cpp)
+add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/contrib_schemas.cpp onnxsim/function_rewriter.cpp)
 if (ONNXSIM_BUILTIN_ORT)
   target_include_directories(onnxsim PRIVATE ${ONNXRUNTIME_INCLUDE_DIR})
 endif()

--- a/README.md
+++ b/README.md
@@ -369,6 +369,31 @@ pattern→replacement rules that translate directly into a FunctionProto pair li
 the one above; see `tests/test_function_rewriter_common_rules.py` for worked
 examples that check parity against the onnxscript rule itself.
 
+Instead of writing the ONNX text by hand you can author each side as an
+`onnxscript.script` function and call `.to_function_proto()` — a Python-typed
+attribute parameter (`alpha: float`) even compiles to the `@name` wildcard form:
+
+```python
+from onnxscript import script
+from onnxscript import opset18 as op
+
+@script()
+def matmul_add(a, b, c):
+    return op.Add(op.MatMul(a, b), c)
+
+@script()
+def gemm(a, b, c):
+    return op.Gemm(a, b, c)
+
+model_simp, check = onnxsim.simplify(
+    model,
+    function_rewrite_rules=[(matmul_add.to_function_proto(), gemm.to_function_proto())],
+)
+```
+
+See `tests/test_function_rewriter_onnxscript_script.py` for the `@script`
+approach, including the attribute-wildcard case.
+
 From C, call `onnxsim_simplify_with_rules` with the serialized FunctionProto
 pairs (see `onnxsim/capi/onnxsim_c_api.h`); from Rust, use
 `Options::function_rewrite_rule(pattern_bytes, replacement_bytes)`.

--- a/README.md
+++ b/README.md
@@ -392,7 +392,12 @@ model_simp, check = onnxsim.simplify(
 ```
 
 See `tests/test_function_rewriter_onnxscript_script.py` for the `@script`
-approach, including the attribute-wildcard case.
+approach, including the attribute-wildcard case. To reuse an *existing*
+`onnxscript` rule, its structural `pattern` method can be compiled to a
+FunctionProto through the same `@script` converter —
+`tests/test_function_rewriter_compile_rule.py` shows a small helper that does
+this (paired with a simple replacement), noting the boundary where a rewrite
+that derives attributes from the match can't be compiled that way.
 
 From C, call `onnxsim_simplify_with_rules` with the serialized FunctionProto
 pairs (see `onnxsim/capi/onnxsim_c_api.h`); from Rust, use

--- a/README.md
+++ b/README.md
@@ -362,6 +362,13 @@ wildcard: it binds the matched node's attribute and is substituted into the
 replacement. `function_rewrite_rules` is mutually exclusive with
 `custom_rewriter`.
 
+Many of onnxscript's ready-made
+[common rewrite rules](https://github.com/microsoft/onnxscript/tree/main/onnxscript/rewriter/rules/common)
+(e.g. `matmul_add_to_gemm_rule`, `reshape_reshape_rule`) are simple structural
+pattern→replacement rules that translate directly into a FunctionProto pair like
+the one above; see `tests/test_function_rewriter_common_rules.py` for worked
+examples that check parity against the onnxscript rule itself.
+
 From C, call `onnxsim_simplify_with_rules` with the serialized FunctionProto
 pairs (see `onnxsim/capi/onnxsim_c_api.h`); from Rust, use
 `Options::function_rewrite_rule(pattern_bytes, replacement_bytes)`.

--- a/README.md
+++ b/README.md
@@ -278,6 +278,76 @@ A few things to keep in mind:
   pass over `model.graph`, an [onnx-graphsurgeon](https://github.com/NVIDIA/TensorRT/tree/main/tools/onnx-graphsurgeon)
   edit, etc. — as long as it takes and returns a `ModelProto`.
 
+### FunctionProto rules (works in every binding)
+
+`custom_rewriter` takes a Python **callable**, so it only works from the Python
+binding. If instead you express a rule as **pure data** — a `(pattern,
+replacement)` pair of `onnx.FunctionProto` — onnxsim matches and applies it in
+its C++ core, so the *same* rule set also works from the C and Rust bindings
+with no dependency on onnxscript. The pattern's inputs are wildcards that bind
+to graph values, its body is the subgraph to match, and its outputs are rewired
+to the replacement's outputs. Build the FunctionProtos with
+`onnx.parser.parse_function`:
+
+```python
+import onnx
+import onnxsim
+from onnx import parser
+
+pattern = parser.parse_function("""
+<domain: "com.example", opset_import: ["" : 18]>
+matmul_add_pattern (x, w, b) => (y)
+{
+    t = MatMul(x, w)
+    y = Add(t, b)
+}
+""")
+replacement = parser.parse_function("""
+<domain: "com.example", opset_import: ["" : 18]>
+gemm_replacement (x, w, b) => (y)
+{
+    y = Gemm(x, w, b)
+}
+""")
+
+model = onnx.load("model.onnx")
+model_simp, check = onnxsim.simplify(
+    model, function_rewrite_rules=[(pattern, replacement)]
+)
+```
+
+This is enough to stand in for a hand-written onnxoptimizer pass: the rule above
+reproduces the built-in `fuse_matmul_add_bias_into_gemm` fusion. Skip the
+built-in pass and let the rule do it:
+
+```python
+model_simp, check = onnxsim.simplify(
+    model,
+    skipped_optimizers=["fuse_matmul_add_bias_into_gemm"],
+    function_rewrite_rules=[(pattern, replacement)],
+)
+```
+
+A node attribute written `@name` (an ONNX-text *ref attribute*) is an attribute
+wildcard: it binds the matched node's attribute and is substituted into the
+replacement. `function_rewrite_rules` is mutually exclusive with
+`custom_rewriter`.
+
+From C, call `onnxsim_simplify_with_rules` with the serialized FunctionProto
+pairs (see `onnxsim/capi/onnxsim_c_api.h`); from Rust, use
+`Options::function_rewrite_rule(pattern_bytes, replacement_bytes)`.
+
+**Capabilities and limits of the built-in matcher.** It matches arbitrary
+connected DAG patterns with one or more outputs, tries both operand orders for
+the commutative binary ops (`Add`, `Mul`, …), matches attributes exactly or as
+`@name` wildcards, matches a pattern `Constant` against a byte-equal
+initializer, and refuses a rewrite that would break a value consumed outside the
+match. It does **not** (in this version) traverse `If`/`Loop`/`Scan` subgraph
+bodies, handle variadic/optional-input arity mismatches, match >2-operand
+commutative permutations, or evaluate attribute *predicates* — for those, the
+Python-only `onnxscript.rewriter` via `custom_rewriter` remains the richer
+option.
+
 ## Projects Using ONNX Simplifier
 
 * [MXNet](https://mxnet.apache.org/versions/1.9.1/api/python/docs/tutorials/deploy/export/onnx.html#Simplify-the-exported-ONNX-model)

--- a/onnxsim/capi/onnxsim_c_api.cpp
+++ b/onnxsim/capi/onnxsim_c_api.cpp
@@ -8,9 +8,12 @@
 #include <cstring>
 #include <exception>
 #include <optional>
+#include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "function_rewriter.h"
 #include "onnx/proto_utils.h"
 #include "onnxoptimizer/optimize.h"
 #include "onnxsim.h"
@@ -66,17 +69,18 @@ std::optional<int> BuildTargetOpsetVersion(int target_opset_version) {
   return target_opset_version;
 }
 
-}  // namespace
-
-extern "C" {
-
-OnnxsimStatus onnxsim_simplify(const void* model_data, size_t model_size,
+// Shared body of onnxsim_simplify / onnxsim_simplify_with_rules: parse the
+// model, simplify it (optionally with `rewriter`), and hand back a freshly
+// malloc'd buffer of serialized bytes. All out-parameters follow the C API
+// contract documented in the header.
+OnnxsimStatus SimplifyToBuffer(const void* model_data, size_t model_size,
                                const char* const* skip_optimizers,
                                size_t num_skip_optimizers,
                                int skip_optimizers_is_null,
                                int constant_folding, int shape_inference,
                                size_t tensor_size_threshold,
-                               int target_opset_version, void** out_data,
+                               int target_opset_version,
+                               const GraphRewriter* rewriter, void** out_data,
                                size_t* out_size, char** out_error) {
   if (out_data != nullptr) {
     *out_data = nullptr;
@@ -105,7 +109,7 @@ OnnxsimStatus onnxsim_simplify(const void* model_data, size_t model_size,
         BuildSkipOptimizers(skip_optimizers, num_skip_optimizers,
                             skip_optimizers_is_null),
         constant_folding != 0, shape_inference != 0, tensor_size_threshold,
-        BuildTargetOpsetVersion(target_opset_version));
+        BuildTargetOpsetVersion(target_opset_version), rewriter);
 
     std::string out;
     if (!result.SerializeToString(&out)) {
@@ -129,6 +133,99 @@ OnnxsimStatus onnxsim_simplify(const void* model_data, size_t model_size,
     return ONNXSIM_ERROR;
   } catch (...) {
     SetError(out_error, "unknown error while simplifying the model");
+    return ONNXSIM_ERROR;
+  }
+}
+
+// Parse `num_rules` (pattern, replacement) FunctionProto pairs from the given
+// byte buffers into rewrite rules. Throws std::runtime_error on a parse
+// failure.
+std::vector<onnxsim::FunctionRewriteRule> BuildRewriteRules(
+    const void* const* pattern_data, const size_t* pattern_sizes,
+    const void* const* replacement_data, const size_t* replacement_sizes,
+    size_t num_rules) {
+  std::vector<onnxsim::FunctionRewriteRule> rules;
+  rules.reserve(num_rules);
+  for (size_t i = 0; i < num_rules; ++i) {
+    onnxsim::FunctionRewriteRule rule;
+    if (!ParseProtoFromBytes(&rule.pattern,
+                             static_cast<const char*>(pattern_data[i]),
+                             pattern_sizes[i])) {
+      throw std::runtime_error("failed to parse pattern FunctionProto");
+    }
+    if (!ParseProtoFromBytes(&rule.replacement,
+                             static_cast<const char*>(replacement_data[i]),
+                             replacement_sizes[i])) {
+      throw std::runtime_error("failed to parse replacement FunctionProto");
+    }
+    rules.push_back(std::move(rule));
+  }
+  return rules;
+}
+
+}  // namespace
+
+extern "C" {
+
+OnnxsimStatus onnxsim_simplify(const void* model_data, size_t model_size,
+                               const char* const* skip_optimizers,
+                               size_t num_skip_optimizers,
+                               int skip_optimizers_is_null,
+                               int constant_folding, int shape_inference,
+                               size_t tensor_size_threshold,
+                               int target_opset_version, void** out_data,
+                               size_t* out_size, char** out_error) {
+  return SimplifyToBuffer(model_data, model_size, skip_optimizers,
+                          num_skip_optimizers, skip_optimizers_is_null,
+                          constant_folding, shape_inference,
+                          tensor_size_threshold, target_opset_version,
+                          /*rewriter=*/nullptr, out_data, out_size, out_error);
+}
+
+OnnxsimStatus onnxsim_simplify_with_rules(
+    const void* model_data, size_t model_size,
+    const char* const* skip_optimizers, size_t num_skip_optimizers,
+    int skip_optimizers_is_null, int constant_folding, int shape_inference,
+    size_t tensor_size_threshold, int target_opset_version,
+    const void* const* pattern_data, const size_t* pattern_sizes,
+    const void* const* replacement_data, const size_t* replacement_sizes,
+    size_t num_rules, void** out_data, size_t* out_size, char** out_error) {
+  // With no rules this is just onnxsim_simplify.
+  if (num_rules == 0) {
+    return onnxsim_simplify(model_data, model_size, skip_optimizers,
+                            num_skip_optimizers, skip_optimizers_is_null,
+                            constant_folding, shape_inference,
+                            tensor_size_threshold, target_opset_version,
+                            out_data, out_size, out_error);
+  }
+  if (out_data != nullptr) {
+    *out_data = nullptr;
+  }
+  if (out_size != nullptr) {
+    *out_size = 0;
+  }
+  if (out_error != nullptr) {
+    *out_error = nullptr;
+  }
+  if (pattern_data == nullptr || pattern_sizes == nullptr ||
+      replacement_data == nullptr || replacement_sizes == nullptr) {
+    SetError(out_error, "onnxsim_simplify_with_rules: rule array is NULL");
+    return ONNXSIM_ERROR;
+  }
+  try {
+    onnxsim::FunctionProtoRewriter rewriter(
+        BuildRewriteRules(pattern_data, pattern_sizes, replacement_data,
+                          replacement_sizes, num_rules));
+    return SimplifyToBuffer(model_data, model_size, skip_optimizers,
+                            num_skip_optimizers, skip_optimizers_is_null,
+                            constant_folding, shape_inference,
+                            tensor_size_threshold, target_opset_version,
+                            &rewriter, out_data, out_size, out_error);
+  } catch (const std::exception& e) {
+    SetError(out_error, e.what());
+    return ONNXSIM_ERROR;
+  } catch (...) {
+    SetError(out_error, "unknown error while building rewrite rules");
     return ONNXSIM_ERROR;
   }
 }

--- a/onnxsim/capi/onnxsim_c_api.cpp
+++ b/onnxsim/capi/onnxsim_c_api.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <exception>
+#include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -213,14 +214,15 @@ OnnxsimStatus onnxsim_simplify_with_rules(
     return ONNXSIM_ERROR;
   }
   try {
-    onnxsim::FunctionProtoRewriter rewriter(
-        BuildRewriteRules(pattern_data, pattern_sizes, replacement_data,
-                          replacement_sizes, num_rules));
+    std::shared_ptr<GraphRewriter> rewriter =
+        onnxsim::MakeFunctionProtoRewriter(
+            BuildRewriteRules(pattern_data, pattern_sizes, replacement_data,
+                              replacement_sizes, num_rules));
     return SimplifyToBuffer(model_data, model_size, skip_optimizers,
                             num_skip_optimizers, skip_optimizers_is_null,
                             constant_folding, shape_inference,
                             tensor_size_threshold, target_opset_version,
-                            &rewriter, out_data, out_size, out_error);
+                            rewriter.get(), out_data, out_size, out_error);
   } catch (const std::exception& e) {
     SetError(out_error, e.what());
     return ONNXSIM_ERROR;

--- a/onnxsim/capi/onnxsim_c_api.h
+++ b/onnxsim/capi/onnxsim_c_api.h
@@ -65,6 +65,30 @@ ONNXSIM_C_API OnnxsimStatus onnxsim_simplify(
     size_t* out_size, char** out_error);
 
 /*
+ * Same as onnxsim_simplify, but also applies a set of data-driven rewrite rules
+ * inside the simplification fixed point. Each rule is a (pattern, replacement)
+ * pair of serialized ONNX FunctionProto: the pattern's inputs are wildcards
+ * binding to graph values, its body is the subgraph to match, and its outputs
+ * are rewired to the replacement's outputs. This is the same
+ * FunctionProto-based rewriter the Python and Rust bindings expose, so a rule
+ * set authored once (e.g. via onnx.parser.parse_function) works from any
+ * binding without depending on onnxscript.
+ *
+ * `pattern_data[i]`/`pattern_sizes[i]` and `replacement_data[i]`/
+ * `replacement_sizes[i]` describe rule `i`, for `i` in [0, num_rules). Passing
+ * num_rules == 0 behaves exactly like onnxsim_simplify. All other parameters
+ * match onnxsim_simplify.
+ */
+ONNXSIM_C_API OnnxsimStatus onnxsim_simplify_with_rules(
+    const void* model_data, size_t model_size,
+    const char* const* skip_optimizers, size_t num_skip_optimizers,
+    int skip_optimizers_is_null, int constant_folding, int shape_inference,
+    size_t tensor_size_threshold, int target_opset_version,
+    const void* const* pattern_data, const size_t* pattern_sizes,
+    const void* const* replacement_data, const size_t* replacement_sizes,
+    size_t num_rules, void** out_data, size_t* out_size, char** out_error);
+
+/*
  * Same as onnxsim_simplify, but reads the input model from `in_path` and writes
  * the simplified model to `out_path`. On failure, *out_error receives a message
  * (free with onnxsim_free_string).

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -470,21 +470,20 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       .def("Run", &PyGraphRewriter::_PyRun);
 
   // The data-driven rewriter: a list of (pattern, replacement) FunctionProto
-  // pairs. Being pure data, it works from every binding, not just Python.
-  py::class_<onnxsim::FunctionProtoRewriter, GraphRewriter>(
-      m, "FunctionProtoRewriter")
-      .def(
-          "__init__",
-          [](onnxsim::FunctionProtoRewriter* self,
-             std::vector<std::pair<onnx::FunctionProto, onnx::FunctionProto>>
-                 rules) {
-            std::vector<onnxsim::FunctionRewriteRule> converted;
-            converted.reserve(rules.size());
-            for (auto& pair : rules) {
-              converted.push_back(onnxsim::FunctionRewriteRule{
-                  std::move(pair.first), std::move(pair.second)});
-            }
-            new (self) onnxsim::FunctionProtoRewriter(std::move(converted));
-          },
-          "rules"_a);
+  // pairs. Being pure data, the same rules work from every binding, not just
+  // Python. Returned as the base ``GraphRewriter`` -- the concrete type stays
+  // private to the onnxsim core so this extension never references its vtable.
+  m.def(
+      "make_function_proto_rewriter",
+      [](std::vector<std::pair<onnx::FunctionProto, onnx::FunctionProto>> rules)
+          -> std::shared_ptr<GraphRewriter> {
+        std::vector<onnxsim::FunctionRewriteRule> converted;
+        converted.reserve(rules.size());
+        for (auto& pair : rules) {
+          converted.push_back(onnxsim::FunctionRewriteRule{
+              std::move(pair.first), std::move(pair.second)});
+        }
+        return onnxsim::MakeFunctionProtoRewriter(std::move(converted));
+      },
+      "rules"_a);
 }

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -4,6 +4,7 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/pair.h>
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
@@ -15,6 +16,7 @@
 #include <tuple>
 #include <vector>
 
+#include "function_rewriter.h"
 #include "onnx/defs/schema.h"
 #include "onnx/defs/shape_inference.h"
 #include "onnx/proto_utils.h"
@@ -69,6 +71,7 @@ ONNXSIM_PROTO_CASTER(AttributeProto, "onnx.AttributeProto")
 ONNXSIM_PROTO_CASTER(TypeProto, "onnx.TypeProto")
 ONNXSIM_PROTO_CASTER(NodeProto, "onnx.NodeProto")
 ONNXSIM_PROTO_CASTER(TensorProto, "onnx.TensorProto")
+ONNXSIM_PROTO_CASTER(FunctionProto, "onnx.FunctionProto")
 
 #undef ONNXSIM_PROTO_CASTER
 }  // namespace detail
@@ -303,7 +306,7 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
           std::optional<std::vector<std::string>> skip_optimizers,
           bool constant_folding, bool shape_inference,
           size_t tensor_size_threshold, std::optional<int> target_opset_version,
-          std::shared_ptr<PyGraphRewriter> rewriter) -> py::bytes {
+          std::shared_ptr<GraphRewriter> rewriter) -> py::bytes {
          // force env initialization to register opset
          InitEnv();
          ONNX_NAMESPACE::ModelProto model;
@@ -329,7 +332,7 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
              bool constant_folding, bool shape_inference,
              size_t tensor_size_threshold,
              std::optional<int> target_opset_version,
-             std::shared_ptr<PyGraphRewriter> rewriter) -> bool {
+             std::shared_ptr<GraphRewriter> rewriter) -> bool {
             // force env initialization to register opset
             InitEnv();
             SimplifyPath(*executor, in_path, out_path, skip_optimizers,
@@ -456,7 +459,32 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
       .def(py::init<>())
       .def("Run", &PyModelExecutor::_PyRun);
 
-  py::class_<PyGraphRewriter, PyGraphRewriterTrampoline>(m, "GraphRewriter")
+  // The abstract C++ base shared by every rewriter kind. It carries no Python
+  // constructor; ``simplify``/``simplify_path`` accept any subclass.
+  py::class_<GraphRewriter>(m, "_GraphRewriterBase");
+
+  // The Python-callable rewriter (an ``onnxscript.rewriter`` rule set, etc.).
+  py::class_<PyGraphRewriter, GraphRewriter, PyGraphRewriterTrampoline>(
+      m, "GraphRewriter")
       .def(py::init<>())
       .def("Run", &PyGraphRewriter::_PyRun);
+
+  // The data-driven rewriter: a list of (pattern, replacement) FunctionProto
+  // pairs. Being pure data, it works from every binding, not just Python.
+  py::class_<onnxsim::FunctionProtoRewriter, GraphRewriter>(
+      m, "FunctionProtoRewriter")
+      .def(
+          "__init__",
+          [](onnxsim::FunctionProtoRewriter* self,
+             std::vector<std::pair<onnx::FunctionProto, onnx::FunctionProto>>
+                 rules) {
+            std::vector<onnxsim::FunctionRewriteRule> converted;
+            converted.reserve(rules.size());
+            for (auto& pair : rules) {
+              converted.push_back(onnxsim::FunctionRewriteRule{
+                  std::move(pair.first), std::move(pair.second)});
+            }
+            new (self) onnxsim::FunctionProtoRewriter(std::move(converted));
+          },
+          "rules"_a);
 }

--- a/onnxsim/function_rewriter.cpp
+++ b/onnxsim/function_rewriter.cpp
@@ -1,0 +1,650 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * A data-driven, onnxscript.rewriter-style pattern rewriter that lives in the
+ * onnxsim C++ core so *every* binding (Python, the C ABI, Rust) can use it: a
+ * rule is a pair of ``onnx.FunctionProto`` (a pattern to match + a
+ * replacement), i.e. pure protobuf data, rather than a Python callback that
+ * cannot cross the FFI boundary.
+ *
+ * Supported (the "richer" matcher):
+ *   * pattern-function inputs as wildcards binding to host-graph values;
+ *   * arbitrary connected DAG patterns with one or more outputs;
+ *   * exact attribute matching, plus attribute *wildcards* via
+ * ``ref_attr_name`` (bound and substituted into the replacement);
+ *   * commutative reordering for the 2-input commutative ops (Add, Mul, ...);
+ *   * constant-value matching (a pattern ``Constant`` node matches a host
+ *     ``Constant`` node or an initializer with a byte-equal tensor);
+ *   * a safety rule: matched interior values must not be consumed outside the
+ *     match, so a rewrite never breaks unrelated parts of the graph.
+ *
+ * Documented limitations (first version):
+ *   * only the main graph is traversed -- patterns are not matched inside
+ *     If/Loop/Scan subgraph bodies;
+ *   * input arity must match exactly -- variadic / optional-input ops are not
+ *     specially handled, and commutative permutation is only tried for the
+ *     2-input case, not N-ary (>2) operands;
+ *   * attributes are matched by equality or bound as wildcards -- there is no
+ *     attribute *predicate* (e.g. "perm is a reverse");
+ *   * the replacement is spliced in at the position of the last matched node,
+ *     so a match whose outputs are consumed by an earlier node is rejected.
+ */
+#include "function_rewriter.h"
+
+#include <algorithm>
+#include <map>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace onnxsim {
+namespace {
+
+// The default ONNX domain is spelled either "" or "ai.onnx"; treat them as one.
+std::string NormDomain(const std::string& domain) {
+  return domain == "ai.onnx" ? std::string() : domain;
+}
+
+bool SameOp(const onnx::NodeProto& a, const onnx::NodeProto& b) {
+  return a.op_type() == b.op_type() &&
+         NormDomain(a.domain()) == NormDomain(b.domain());
+}
+
+const onnx::AttributeProto* FindAttr(const onnx::NodeProto& node,
+                                     const std::string& name) {
+  for (const auto& attr : node.attribute()) {
+    if (attr.name() == name) {
+      return &attr;
+    }
+  }
+  return nullptr;
+}
+
+// Structural attribute equality. onnxsim may be built against the protobuf lite
+// runtime (ONNX_USE_LITE_PROTO), where MessageDifferencer is unavailable, so
+// compare the deterministic wire encodings instead. Two AttributeProtos that
+// are field-for-field equal serialize identically.
+bool AttrEqual(const onnx::AttributeProto& a, const onnx::AttributeProto& b) {
+  return a.SerializeAsString() == b.SerializeAsString();
+}
+
+// Tensor value equality ignoring the (irrelevant) tensor name.
+bool TensorValueEqual(onnx::TensorProto a, onnx::TensorProto b) {
+  a.clear_name();
+  b.clear_name();
+  return a.SerializeAsString() == b.SerializeAsString();
+}
+
+// The commutative binary ops of the default ONNX domain whose two operands may
+// be matched in either order. (Variadic ops such as Sum/Max/Min are only
+// reordered when they happen to have exactly two inputs -- see the caller.)
+bool IsCommutative(const onnx::NodeProto& node) {
+  if (!NormDomain(node.domain()).empty()) {
+    return false;
+  }
+  static const std::set<std::string> kCommutative = {
+      "Add", "Mul", "And",  "Or",         "Xor",       "Max",
+      "Min", "Sum", "Mean", "BitwiseAnd", "BitwiseOr", "BitwiseXor"};
+  return kCommutative.count(node.op_type()) > 0;
+}
+
+// A read-only index over the host graph built once per rewrite scan.
+struct HostIndex {
+  // value name -> (node index producing it, output slot).
+  std::unordered_map<std::string, std::pair<int, int>> producer;
+  // value name -> indices of nodes consuming it.
+  std::unordered_map<std::string, std::vector<int>> consumers;
+  // initializer name -> tensor.
+  std::unordered_map<std::string, const onnx::TensorProto*> initializer;
+  std::unordered_set<std::string> graph_outputs;
+  std::unordered_set<std::string> value_names;  // every name in use anywhere.
+
+  explicit HostIndex(const onnx::GraphProto& graph) {
+    for (int i = 0; i < graph.node_size(); ++i) {
+      const auto& node = graph.node(i);
+      for (int s = 0; s < node.output_size(); ++s) {
+        const std::string& out = node.output(s);
+        if (!out.empty()) {
+          producer[out] = {i, s};
+          value_names.insert(out);
+        }
+      }
+      for (const auto& in : node.input()) {
+        if (!in.empty()) {
+          consumers[in].push_back(i);
+          value_names.insert(in);
+        }
+      }
+    }
+    for (const auto& init : graph.initializer()) {
+      initializer[init.name()] = &init;
+      value_names.insert(init.name());
+    }
+    for (const auto& vi : graph.input()) {
+      value_names.insert(vi.name());
+    }
+    for (const auto& vi : graph.output()) {
+      graph_outputs.insert(vi.name());
+      value_names.insert(vi.name());
+    }
+  }
+};
+
+// Precomputed view of a pattern FunctionProto.
+struct PatternIndex {
+  const onnx::FunctionProto* fn;
+  std::unordered_set<std::string> inputs;  // wildcard names.
+  // pattern value name -> (pattern node index, output slot).
+  std::unordered_map<std::string, std::pair<int, int>> producer;
+
+  explicit PatternIndex(const onnx::FunctionProto& f) : fn(&f) {
+    for (const auto& in : f.input()) {
+      inputs.insert(in);
+    }
+    for (int i = 0; i < f.node_size(); ++i) {
+      const auto& node = f.node(i);
+      for (int s = 0; s < node.output_size(); ++s) {
+        if (!node.output(s).empty()) {
+          producer[node.output(s)] = {i, s};
+        }
+      }
+    }
+  }
+};
+
+// The bindings accumulated while matching a single occurrence of a pattern.
+struct MatchState {
+  std::unordered_map<std::string, std::string>
+      vbind;  // wildcard -> host value.
+  std::unordered_map<std::string, onnx::AttributeProto> abind;  // ref -> value.
+  std::map<int, int> node_map;  // pattern node index -> host node index.
+};
+
+class Matcher {
+ public:
+  Matcher(const onnx::GraphProto& graph, const HostIndex& host,
+          const PatternIndex& pat)
+      : graph_(graph), host_(host), pat_(pat) {}
+
+  // Match a pattern value against a host value, extending ``state``.
+  bool MatchValue(const std::string& pval, const std::string& hval,
+                  MatchState& state) {
+    if (pat_.inputs.count(pval)) {
+      // Wildcard: bind consistently.
+      auto it = state.vbind.find(pval);
+      if (it != state.vbind.end()) {
+        return it->second == hval;
+      }
+      state.vbind[pval] = hval;
+      return true;
+    }
+    auto pit = pat_.producer.find(pval);
+    if (pit == pat_.producer.end()) {
+      // A pattern value that is neither an input nor produced by the body
+      // cannot be matched.
+      return false;
+    }
+    const int p_node = pit->second.first;
+    const int p_slot = pit->second.second;
+
+    auto hprod = host_.producer.find(hval);
+    if (hprod == host_.producer.end()) {
+      // Host value is a graph input or initializer. The only pattern node that
+      // can match it is a Constant whose tensor equals the initializer.
+      const onnx::NodeProto& pnode = pat_.fn->node(p_node);
+      if (pnode.op_type() == "Constant" && NormDomain(pnode.domain()).empty()) {
+        auto init = host_.initializer.find(hval);
+        const onnx::AttributeProto* value = FindAttr(pnode, "value");
+        if (init != host_.initializer.end() && value != nullptr &&
+            value->has_t() && TensorValueEqual(value->t(), *init->second)) {
+          return true;  // constant matched against an initializer.
+        }
+      }
+      return false;
+    }
+    if (hprod->second.second != p_slot) {
+      return false;  // produced at a different output slot.
+    }
+    return MatchNode(p_node, hprod->second.first, state);
+  }
+
+  // Match a pattern node against a host node, extending ``state``.
+  bool MatchNode(int p_idx, int h_idx, MatchState& state) {
+    auto existing = state.node_map.find(p_idx);
+    if (existing != state.node_map.end()) {
+      return existing->second == h_idx;  // shared subexpression: be consistent.
+    }
+    // A host node may fill at most one pattern role (injective mapping).
+    for (const auto& kv : state.node_map) {
+      if (kv.second == h_idx) {
+        return false;
+      }
+    }
+
+    const onnx::NodeProto& p = pat_.fn->node(p_idx);
+    const onnx::NodeProto& h = graph_.node(h_idx);
+    if (!SameOp(p, h) || p.input_size() != h.input_size()) {
+      return false;
+    }
+    if (!MatchAttributes(p, h, state)) {
+      return false;
+    }
+
+    state.node_map[p_idx] = h_idx;
+
+    // Try operand orders (identity, plus the swap for 2-input commutative ops).
+    std::vector<std::vector<int>> orders;
+    std::vector<int> identity(p.input_size());
+    for (int i = 0; i < p.input_size(); ++i) {
+      identity[i] = i;
+    }
+    orders.push_back(identity);
+    if (p.input_size() == 2 && IsCommutative(p)) {
+      orders.push_back({1, 0});
+    }
+
+    for (const auto& order : orders) {
+      MatchState trial = state;
+      bool ok = true;
+      for (int i = 0; i < p.input_size(); ++i) {
+        const std::string& pin = p.input(i);
+        const std::string& hin = h.input(order[i]);
+        if (pin.empty() || hin.empty()) {
+          ok =
+              (pin.empty() == hin.empty());  // optional-input slots must align.
+          if (!ok) break;
+          continue;
+        }
+        if (!MatchValue(pin, hin, trial)) {
+          ok = false;
+          break;
+        }
+      }
+      if (ok) {
+        state = trial;
+        return true;
+      }
+    }
+    return false;
+  }
+
+ private:
+  bool MatchAttributes(const onnx::NodeProto& p, const onnx::NodeProto& h,
+                       MatchState& state) {
+    for (const auto& pa : p.attribute()) {
+      if (!pa.ref_attr_name().empty()) {
+        // Attribute wildcard: bind the host node's attribute named pa.name().
+        const onnx::AttributeProto* ha = FindAttr(h, pa.name());
+        if (ha == nullptr) {
+          return false;
+        }
+        onnx::AttributeProto bound = *ha;
+        bound.clear_name();  // compare/store the value only.
+        auto it = state.abind.find(pa.ref_attr_name());
+        if (it != state.abind.end()) {
+          if (!AttrEqual(it->second, bound)) {
+            return false;
+          }
+        } else {
+          state.abind[pa.ref_attr_name()] = std::move(bound);
+        }
+      } else {
+        // Concrete attribute: the host must carry an equal one.
+        const onnx::AttributeProto* ha = FindAttr(h, pa.name());
+        if (ha == nullptr || !AttrEqual(pa, *ha)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  const onnx::GraphProto& graph_;
+  const HostIndex& host_;
+  const PatternIndex& pat_;
+};
+
+// Choose a value-name prefix that collides with nothing already in the graph,
+// so replacement interior values are guaranteed fresh.
+std::string FreshPrefix(const HostIndex& host,
+                        const std::vector<std::string>& interior_names) {
+  for (int k = 0;; ++k) {
+    std::string prefix = "onnxsim_fnrw" + std::to_string(k) + "_";
+    bool ok = true;
+    for (const auto& name : interior_names) {
+      if (host.value_names.count(prefix + name)) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) {
+      return prefix;
+    }
+  }
+}
+
+// Ensure ``model`` imports every operator-set domain the replacement nodes use.
+void EnsureOpsetImports(onnx::ModelProto& model,
+                        const onnx::FunctionProto& replacement) {
+  std::unordered_set<std::string> present;
+  for (const auto& imp : model.opset_import()) {
+    present.insert(NormDomain(imp.domain()));
+  }
+  for (const auto& node : replacement.node()) {
+    const std::string dom = NormDomain(node.domain());
+    if (present.count(dom)) {
+      continue;
+    }
+    int version = 0;
+    for (const auto& imp : replacement.opset_import()) {
+      if (NormDomain(imp.domain()) == dom) {
+        version = static_cast<int>(imp.version());
+        break;
+      }
+    }
+    if (version <= 0) {
+      version = 1;
+    }
+    auto* imp = model.add_opset_import();
+    imp->set_domain(dom);
+    imp->set_version(version);
+    present.insert(dom);
+  }
+}
+
+// Apply ``rule``'s replacement for a validated match: delete the matched nodes
+// and splice in the instantiated replacement at the last matched position.
+// Returns false (no change) if the replacement cannot be instantiated cleanly.
+bool ApplyReplacement(onnx::ModelProto& model, onnx::GraphProto& graph,
+                      const HostIndex& host, const FunctionRewriteRule& rule,
+                      const MatchState& state,
+                      const std::vector<std::string>& out_host,
+                      const std::set<int>& matched) {
+  const onnx::FunctionProto& rep = rule.replacement;
+  if (rep.output_size() != static_cast<int>(out_host.size())) {
+    return false;
+  }
+
+  std::unordered_set<std::string> rep_inputs(rep.input().begin(),
+                                             rep.input().end());
+  std::unordered_map<std::string, std::string> rep_outputs;
+  for (int i = 0; i < rep.output_size(); ++i) {
+    rep_outputs[rep.output(i)] = out_host[i];
+  }
+
+  // Collect the replacement's interior value names (neither input nor output).
+  std::vector<std::string> interior;
+  std::unordered_set<std::string> seen_interior;
+  auto note_interior = [&](const std::string& name) {
+    if (name.empty() || rep_inputs.count(name) || rep_outputs.count(name) ||
+        seen_interior.count(name)) {
+      return;
+    }
+    seen_interior.insert(name);
+    interior.push_back(name);
+  };
+  for (const auto& node : rep.node()) {
+    for (const auto& v : node.output()) note_interior(v);
+    for (const auto& v : node.input()) note_interior(v);
+  }
+  const std::string prefix = FreshPrefix(host, interior);
+
+  auto rename = [&](const std::string& name) -> std::string {
+    if (name.empty()) {
+      return name;
+    }
+    auto rin = rep_inputs.find(name);
+    if (rin != rep_inputs.end()) {
+      auto b = state.vbind.find(name);
+      // A replacement input must be a bound pattern wildcard.
+      return b != state.vbind.end() ? b->second : std::string();
+    }
+    auto rout = rep_outputs.find(name);
+    if (rout != rep_outputs.end()) {
+      return rout->second;
+    }
+    return prefix + name;
+  };
+
+  // Build the replacement nodes with renamed edges and bound attributes.
+  std::vector<onnx::NodeProto> new_nodes;
+  new_nodes.reserve(rep.node_size());
+  int node_counter = 0;
+  for (const auto& rnode : rep.node()) {
+    onnx::NodeProto n;
+    n.set_op_type(rnode.op_type());
+    if (!rnode.domain().empty()) {
+      n.set_domain(rnode.domain());
+    }
+    n.set_name(prefix + (rnode.name().empty()
+                             ? "node" + std::to_string(node_counter)
+                             : rnode.name()));
+    ++node_counter;
+    for (const auto& in : rnode.input()) {
+      const std::string mapped = rename(in);
+      if (!in.empty() && mapped.empty()) {
+        return false;  // an input referenced an unbound name.
+      }
+      n.add_input(mapped);
+    }
+    for (const auto& out : rnode.output()) {
+      n.add_output(rename(out));
+    }
+    for (const auto& a : rnode.attribute()) {
+      if (!a.ref_attr_name().empty()) {
+        auto it = state.abind.find(a.ref_attr_name());
+        if (it == state.abind.end()) {
+          return false;  // replacement references an unbound attribute.
+        }
+        onnx::AttributeProto filled = it->second;
+        filled.set_name(a.name());
+        filled.clear_ref_attr_name();
+        *n.add_attribute() = std::move(filled);
+      } else {
+        *n.add_attribute() = a;
+      }
+    }
+    new_nodes.push_back(std::move(n));
+  }
+
+  EnsureOpsetImports(model, rep);
+
+  // Rebuild the node list: drop matched nodes, and emit the replacement where
+  // the last matched node was (keeping topological order).
+  const int max_idx = *matched.rbegin();
+  std::vector<onnx::NodeProto> rebuilt;
+  rebuilt.reserve(graph.node_size() - matched.size() + new_nodes.size());
+  for (int i = 0; i < graph.node_size(); ++i) {
+    if (matched.count(i)) {
+      if (i == max_idx) {
+        for (auto& n : new_nodes) {
+          rebuilt.push_back(std::move(n));
+        }
+      }
+      continue;
+    }
+    rebuilt.push_back(graph.node(i));
+  }
+  graph.clear_node();
+  for (auto& n : rebuilt) {
+    *graph.add_node() = std::move(n);
+  }
+  return true;
+}
+
+// Try to match and rewrite ``rule`` at one location in ``graph``. Returns true
+// (and mutates ``model``/``graph``) on the first successful rewrite.
+bool ApplyRuleOnce(onnx::ModelProto& model, onnx::GraphProto& graph,
+                   const HostIndex& host, const FunctionRewriteRule& rule) {
+  const onnx::FunctionProto& pattern = rule.pattern;
+  if (pattern.output_size() == 0 || pattern.node_size() == 0) {
+    return false;
+  }
+  PatternIndex pat(pattern);
+
+  // Anchor on the node producing the pattern's first output.
+  auto root_it = pat.producer.find(pattern.output(0));
+  if (root_it == pat.producer.end()) {
+    return false;  // output(0) is a pass-through input -- nothing to match.
+  }
+  const int root_pat_node = root_it->second.first;
+  const onnx::NodeProto& root = pattern.node(root_pat_node);
+
+  for (int h = 0; h < graph.node_size(); ++h) {
+    if (!SameOp(root, graph.node(h))) {
+      continue;
+    }
+    Matcher matcher(graph, host, pat);
+    MatchState state;
+    if (!matcher.MatchNode(root_pat_node, h, state)) {
+      continue;
+    }
+
+    // Resolve every pattern output to a concrete host value.
+    std::vector<std::string> out_host;
+    out_host.reserve(pattern.output_size());
+    bool resolved = true;
+    for (const auto& pout : pattern.output()) {
+      if (pat.inputs.count(pout)) {
+        auto b = state.vbind.find(pout);
+        if (b == state.vbind.end()) {
+          resolved = false;
+          break;
+        }
+        out_host.push_back(b->second);
+        continue;
+      }
+      auto pit = pat.producer.find(pout);
+      if (pit == pat.producer.end() ||
+          !state.node_map.count(pit->second.first)) {
+        resolved = false;
+        break;
+      }
+      const onnx::NodeProto& hn =
+          graph.node(state.node_map.at(pit->second.first));
+      if (pit->second.second >= hn.output_size()) {
+        resolved = false;
+        break;
+      }
+      out_host.push_back(hn.output(pit->second.second));
+    }
+    if (!resolved) {
+      continue;
+    }
+
+    std::set<int> matched;
+    for (const auto& kv : state.node_map) {
+      matched.insert(kv.second);
+    }
+    if (matched.empty()) {
+      continue;
+    }
+    const int max_idx = *matched.rbegin();
+
+    std::unordered_set<std::string> out_set(out_host.begin(), out_host.end());
+
+    // Safety: an interior value (produced inside the match, not a pattern
+    // output) must be consumed only within the match and must not be a graph
+    // output -- otherwise the rewrite would break an outside consumer.
+    bool safe = true;
+    for (int idx : matched) {
+      for (const auto& v : graph.node(idx).output()) {
+        if (v.empty() || out_set.count(v)) {
+          continue;
+        }
+        if (host.graph_outputs.count(v)) {
+          safe = false;
+          break;
+        }
+        auto cit = host.consumers.find(v);
+        if (cit != host.consumers.end()) {
+          for (int c : cit->second) {
+            if (!matched.count(c)) {
+              safe = false;
+              break;
+            }
+          }
+        }
+        if (!safe) break;
+      }
+      if (!safe) break;
+    }
+    if (!safe) {
+      continue;
+    }
+
+    // Placement safety: every consumer of a (reproduced) pattern-output value
+    // must come after the splice point, and no replacement input may be
+    // produced by a matched (about-to-be-deleted) node.
+    for (const std::string& v : out_host) {
+      auto cit = host.consumers.find(v);
+      if (cit != host.consumers.end()) {
+        for (int c : cit->second) {
+          if (!matched.count(c) && c < max_idx) {
+            safe = false;
+            break;
+          }
+        }
+      }
+      if (!safe) break;
+    }
+    if (safe) {
+      for (const auto& kv : state.vbind) {
+        auto pit = host.producer.find(kv.second);
+        if (pit != host.producer.end() && matched.count(pit->second.first)) {
+          safe = false;  // a wildcard bound to a value we are about to delete.
+          break;
+        }
+      }
+    }
+    if (!safe) {
+      continue;
+    }
+
+    if (ApplyReplacement(model, graph, host, rule, state, out_host, matched)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+FunctionProtoRewriter::FunctionProtoRewriter(
+    std::vector<FunctionRewriteRule> rules)
+    : rules_(std::move(rules)) {}
+
+bool FunctionProtoRewriter::_Run(onnx::ModelProto& model) const {
+  if (rules_.empty() || !model.has_graph()) {
+    return false;
+  }
+  onnx::GraphProto& graph = *model.mutable_graph();
+  bool changed = false;
+  // Keep applying rules until a full pass over every rule changes nothing. Each
+  // successful rewrite invalidates the node indices, so rebuild the index and
+  // restart the scan. A generous iteration cap guards against a pathological
+  // rule whose replacement re-creates its own pattern (which would otherwise
+  // loop forever); normal rule sets converge far below it.
+  const long long kMaxRewrites =
+      static_cast<long long>(graph.node_size()) * 100 + 100000;
+  long long applied = 0;
+  bool progress = true;
+  while (progress && applied < kMaxRewrites) {
+    progress = false;
+    HostIndex host(graph);
+    for (const auto& rule : rules_) {
+      if (ApplyRuleOnce(model, graph, host, rule)) {
+        changed = true;
+        progress = true;
+        ++applied;
+        break;  // indices changed -- rebuild the index and rescan.
+      }
+    }
+  }
+  return changed;
+}
+
+}  // namespace onnxsim

--- a/onnxsim/function_rewriter.cpp
+++ b/onnxsim/function_rewriter.cpp
@@ -33,6 +33,7 @@
 
 #include <algorithm>
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -611,40 +612,54 @@ bool ApplyRuleOnce(onnx::ModelProto& model, onnx::GraphProto& graph,
   return false;
 }
 
-}  // namespace
+// A GraphRewriter that applies a fixed set of FunctionRewriteRules. Kept
+// private to this translation unit: callers obtain it only via
+// MakeFunctionProtoRewriter, as a base GraphRewriter pointer, so no other
+// shared object references this concrete type's vtable.
+class FunctionProtoRewriterImpl final : public GraphRewriter {
+ public:
+  explicit FunctionProtoRewriterImpl(std::vector<FunctionRewriteRule> rules)
+      : rules_(std::move(rules)) {}
 
-FunctionProtoRewriter::FunctionProtoRewriter(
-    std::vector<FunctionRewriteRule> rules)
-    : rules_(std::move(rules)) {}
-
-bool FunctionProtoRewriter::_Run(onnx::ModelProto& model) const {
-  if (rules_.empty() || !model.has_graph()) {
-    return false;
-  }
-  onnx::GraphProto& graph = *model.mutable_graph();
-  bool changed = false;
-  // Keep applying rules until a full pass over every rule changes nothing. Each
-  // successful rewrite invalidates the node indices, so rebuild the index and
-  // restart the scan. A generous iteration cap guards against a pathological
-  // rule whose replacement re-creates its own pattern (which would otherwise
-  // loop forever); normal rule sets converge far below it.
-  const long long kMaxRewrites =
-      static_cast<long long>(graph.node_size()) * 100 + 100000;
-  long long applied = 0;
-  bool progress = true;
-  while (progress && applied < kMaxRewrites) {
-    progress = false;
-    HostIndex host(graph);
-    for (const auto& rule : rules_) {
-      if (ApplyRuleOnce(model, graph, host, rule)) {
-        changed = true;
-        progress = true;
-        ++applied;
-        break;  // indices changed -- rebuild the index and rescan.
+  bool _Run(onnx::ModelProto& model) const override {
+    if (rules_.empty() || !model.has_graph()) {
+      return false;
+    }
+    onnx::GraphProto& graph = *model.mutable_graph();
+    bool changed = false;
+    // Keep applying rules until a full pass over every rule changes nothing.
+    // Each successful rewrite invalidates the node indices, so rebuild the
+    // index and restart the scan. A generous iteration cap guards against a
+    // pathological rule whose replacement re-creates its own pattern (which
+    // would otherwise loop forever); normal rule sets converge far below it.
+    const long long kMaxRewrites =
+        static_cast<long long>(graph.node_size()) * 100 + 100000;
+    long long applied = 0;
+    bool progress = true;
+    while (progress && applied < kMaxRewrites) {
+      progress = false;
+      HostIndex host(graph);
+      for (const auto& rule : rules_) {
+        if (ApplyRuleOnce(model, graph, host, rule)) {
+          changed = true;
+          progress = true;
+          ++applied;
+          break;  // indices changed -- rebuild the index and rescan.
+        }
       }
     }
+    return changed;
   }
-  return changed;
+
+ private:
+  std::vector<FunctionRewriteRule> rules_;
+};
+
+}  // namespace
+
+std::shared_ptr<GraphRewriter> MakeFunctionProtoRewriter(
+    std::vector<FunctionRewriteRule> rules) {
+  return std::make_shared<FunctionProtoRewriterImpl>(std::move(rules));
 }
 
 }  // namespace onnxsim

--- a/onnxsim/function_rewriter.h
+++ b/onnxsim/function_rewriter.h
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ONNXSIM_FUNCTION_REWRITER_H_
+#define ONNXSIM_FUNCTION_REWRITER_H_
+
+#include <onnx/onnx_pb.h>
+
+#include <vector>
+
+#include "onnxsim.h"
+
+namespace onnxsim {
+
+// A single data-driven rewrite rule expressed entirely as ONNX protobuf:
+// ``pattern`` describes the subgraph to match and ``replacement`` what to put
+// in its place. Both are ``FunctionProto``s, so a rule is *pure data* that can
+// cross any binding boundary (Python, the C ABI, Rust) as serialized bytes --
+// unlike the ``PyGraphRewriter`` Python callable, which only the Python binding
+// can carry.
+//
+// Semantics (see function_rewriter.cpp for the details and limitations):
+//   * ``pattern.input``  -- wildcards; each binds to a host-graph value.
+//   * ``pattern.node``   -- the DAG of ops to match.
+//   * ``pattern.output`` -- the values whose consumers are rewired to the
+//                           replacement's outputs.
+// A node attribute carrying a ``ref_attr_name`` (the onnx text ``@name`` form)
+// is an attribute wildcard: it binds to the host node's attribute and is
+// substituted into the replacement. A concrete attribute must match exactly.
+struct FunctionRewriteRule {
+  onnx::FunctionProto pattern;
+  onnx::FunctionProto replacement;
+};
+
+// A ``GraphRewriter`` that applies a fixed set of ``FunctionRewriteRule``s. It
+// plugs into ``Simplify`` exactly like any other rewriter and therefore runs
+// inside onnxsim's simplification fixed point, so a fusion it performs can
+// unlock further optimizer/folding passes and vice versa.
+class FunctionProtoRewriter final : public GraphRewriter {
+ public:
+  explicit FunctionProtoRewriter(std::vector<FunctionRewriteRule> rules);
+
+  // Repeatedly applies the rules to ``model``'s main graph until no rule fires.
+  // Returns true if the model was changed and false if it was left untouched;
+  // the "unchanged" answer lets onnxsim skip re-copying the model, matching the
+  // rest of the ``GraphRewriter`` contract.
+  bool _Run(onnx::ModelProto& model) const override;
+
+ private:
+  std::vector<FunctionRewriteRule> rules_;
+};
+
+}  // namespace onnxsim
+
+#endif  // ONNXSIM_FUNCTION_REWRITER_H_

--- a/onnxsim/function_rewriter.h
+++ b/onnxsim/function_rewriter.h
@@ -6,6 +6,7 @@
 
 #include <onnx/onnx_pb.h>
 
+#include <memory>
 #include <vector>
 
 #include "onnxsim.h"
@@ -32,23 +33,22 @@ struct FunctionRewriteRule {
   onnx::FunctionProto replacement;
 };
 
-// A ``GraphRewriter`` that applies a fixed set of ``FunctionRewriteRule``s. It
-// plugs into ``Simplify`` exactly like any other rewriter and therefore runs
-// inside onnxsim's simplification fixed point, so a fusion it performs can
-// unlock further optimizer/folding passes and vice versa.
-class FunctionProtoRewriter final : public GraphRewriter {
- public:
-  explicit FunctionProtoRewriter(std::vector<FunctionRewriteRule> rules);
-
-  // Repeatedly applies the rules to ``model``'s main graph until no rule fires.
-  // Returns true if the model was changed and false if it was left untouched;
-  // the "unchanged" answer lets onnxsim skip re-copying the model, matching the
-  // rest of the ``GraphRewriter`` contract.
-  bool _Run(onnx::ModelProto& model) const override;
-
- private:
-  std::vector<FunctionRewriteRule> rules_;
-};
+// Build a ``GraphRewriter`` that applies ``rules``. It plugs into ``Simplify``
+// like any other rewriter and runs inside onnxsim's simplification fixed point,
+// so a fusion it performs can unlock further optimizer/folding passes and vice
+// versa.
+//
+// The concrete rewriter type is kept private to function_rewriter.cpp and only
+// a base ``GraphRewriter`` pointer is returned. onnxsim is built as a shared
+// library under a hidden default-visibility preset, and its callers (the C ABI
+// and the Python extension) live in *other* shared objects; returning the base
+// keeps them from referencing the concrete subclass's vtable across the
+// library boundary (which the linker cannot resolve). The returned
+// ``shared_ptr`` type-erases its deleter, so destruction still dispatches to
+// the concrete type. This is a plain free function, exported exactly like the
+// rest of onnxsim's public API (e.g. ``Simplify``).
+std::shared_ptr<GraphRewriter> MakeFunctionProtoRewriter(
+    std::vector<FunctionRewriteRule> rules);
 
 }  // namespace onnxsim
 

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -419,7 +419,7 @@ def simplify(
             "pass only one."
         )
     if function_rewrite_rules:
-        rewriter = C.FunctionProtoRewriter(
+        rewriter = C.make_function_proto_rewriter(
             [(pattern, replacement) for pattern, replacement in function_rewrite_rules]
         )
     elif custom_rewriter is not None:

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -29,6 +29,13 @@ TensorShapesWithOptionalKey = Dict[Optional[str], TensorShape]
 # ``False`` reports that nothing was rewritten, which lets onnxsim skip copying
 # an unchanged model back through the C++ core (see ``_GraphRewriterAdapter``).
 ModelRewriter = Callable[[onnx.ModelProto], Union[onnx.ModelProto, bool, None]]
+# A data-driven rewrite rule: a ``(pattern, replacement)`` pair of
+# ``onnx.FunctionProto``. The pattern's inputs are wildcards binding to graph
+# values, its body is the subgraph to match, and its outputs are the values
+# rewired to the replacement's outputs. Unlike ``ModelRewriter`` (a Python
+# callable), a rule is pure data, so the same rules work from the C and Rust
+# bindings too. Build one with ``onnx.parser.parse_function`` (see the README).
+FunctionRewriteRule = Tuple[onnx.FunctionProto, onnx.FunctionProto]
 Unit = Literal["B", "KB", "MB", "GB", "TB"]
 
 UNIT_MAP: dict[Unit, int] = {
@@ -328,6 +335,7 @@ def simplify(
     input_shapes=None,
     target_opset_version: Optional[int] = None,
     custom_rewriter: Optional[ModelRewriter] = None,
+    function_rewrite_rules: Optional[Sequence[FunctionRewriteRule]] = None,
 ) -> Tuple[onnx.ModelProto, bool]:
     """
     :param model: onnx ModelProto object or file path
@@ -364,6 +372,15 @@ def simplify(
             to report that it rewrote nothing. Returning ``False`` when no rewrite happened (for example
             when an ``onnxscript.rewriter`` pass reports ``PassResult.modified`` is ``False``) lets onnxsim
             skip copying an unchanged model back through the C++ core on that fixed-point round.
+    :param function_rewrite_rules: An optional sequence of ``(pattern, replacement)`` pairs of
+            ``onnx.FunctionProto`` describing data-driven rewrite rules matched and applied natively by
+            onnxsim's C++ core (no onnxscript dependency), so the *same* rules also work from the C and
+            Rust bindings. The pattern's inputs are wildcards binding to graph values, its body is the
+            subgraph to match, and its outputs are rewired to the replacement's outputs; a node attribute
+            written ``@name`` (a ``ref_attr_name``) is an attribute wildcard bound and substituted into the
+            replacement. Build the FunctionProtos with ``onnx.parser.parse_function``. Runs inside the same
+            fixed point as ``custom_rewriter`` and is mutually exclusive with it (passing both raises
+            ``ValueError``).
     :return: A tuple (simplified model, success(True) or failed(False))
     """
     if dynamic_input_shape:
@@ -393,9 +410,22 @@ def simplify(
 
     # Wrap the user-supplied rewriter (if any) so the C++ simplifier can call it
     # between optimization rounds. ``None`` leaves the pipeline unchanged.
-    rewriter = (
-        _GraphRewriterAdapter(custom_rewriter) if custom_rewriter is not None else None
-    )
+    # ``custom_rewriter`` (a Python callable) and ``function_rewrite_rules`` (data
+    # matched natively in C++) both drive the single rewriter slot, so at most one
+    # may be given.
+    if custom_rewriter is not None and function_rewrite_rules:
+        raise ValueError(
+            "custom_rewriter and function_rewrite_rules are mutually exclusive; "
+            "pass only one."
+        )
+    if function_rewrite_rules:
+        rewriter = C.FunctionProtoRewriter(
+            [(pattern, replacement) for pattern, replacement in function_rewrite_rules]
+        )
+    elif custom_rewriter is not None:
+        rewriter = _GraphRewriterAdapter(custom_rewriter)
+    else:
+        rewriter = None
 
     if not perform_optimization:
         # None means skip all optimizers

--- a/rust/onnxsim-sys/src/lib.rs
+++ b/rust/onnxsim-sys/src/lib.rs
@@ -47,6 +47,39 @@ extern "C" {
         out_error: *mut *mut c_char,
     ) -> c_int;
 
+    /// Simplify a serialized ONNX `ModelProto`, additionally applying a set of
+    /// FunctionProto-based rewrite rules inside the simplification fixed point.
+    ///
+    /// See `onnxsim_c_api.h` for the full contract. Rule `i` is the
+    /// (pattern, replacement) pair of serialized `FunctionProto` bytes at
+    /// `pattern_data[i]`/`pattern_sizes[i]` and
+    /// `replacement_data[i]`/`replacement_sizes[i]`. `num_rules == 0` behaves
+    /// exactly like [`onnxsim_simplify`].
+    ///
+    /// # Safety
+    /// All non-null pointers must be valid; the rule arrays must each hold
+    /// `num_rules` entries, and every `*_data[i]` must point to at least the
+    /// matching `*_sizes[i]` bytes. Otherwise as [`onnxsim_simplify`].
+    pub fn onnxsim_simplify_with_rules(
+        model_data: *const c_void,
+        model_size: usize,
+        skip_optimizers: *const *const c_char,
+        num_skip_optimizers: usize,
+        skip_optimizers_is_null: c_int,
+        constant_folding: c_int,
+        shape_inference: c_int,
+        tensor_size_threshold: usize,
+        target_opset_version: c_int,
+        pattern_data: *const *const c_void,
+        pattern_sizes: *const usize,
+        replacement_data: *const *const c_void,
+        replacement_sizes: *const usize,
+        num_rules: usize,
+        out_data: *mut *mut c_void,
+        out_size: *mut usize,
+        out_error: *mut *mut c_char,
+    ) -> c_int;
+
     /// Simplify a model read from `in_path`, writing the result to `out_path`.
     ///
     /// # Safety

--- a/rust/onnxsim/src/lib.rs
+++ b/rust/onnxsim/src/lib.rs
@@ -96,6 +96,10 @@ pub struct Options {
     /// Target opset version (of the default ONNX domain) to convert the model
     /// to before simplifying. `None` leaves the opset version unchanged.
     target_opset_version: Option<i32>,
+    /// FunctionProto-based rewrite rules applied inside the fixed point. Each
+    /// entry is a `(pattern, replacement)` pair of serialized `FunctionProto`
+    /// bytes. Empty (the default) means no rule-based rewriting.
+    function_rewrite_rules: Vec<(Vec<u8>, Vec<u8>)>,
 }
 
 impl Default for Options {
@@ -106,6 +110,7 @@ impl Default for Options {
             shape_inference: true,
             tensor_size_threshold: DEFAULT_TENSOR_SIZE_THRESHOLD,
             target_opset_version: None,
+            function_rewrite_rules: Vec::new(),
         }
     }
 }
@@ -176,6 +181,26 @@ impl Options {
             .push(name.into());
         self
     }
+
+    /// Add a FunctionProto-based rewrite rule, matched and applied by onnxsim's
+    /// C++ core inside the simplification fixed point.
+    ///
+    /// `pattern` and `replacement` are serialized `onnx.FunctionProto` bytes:
+    /// the pattern's inputs are wildcards binding to graph values, its body is
+    /// the subgraph to match, and its outputs are rewired to the replacement's
+    /// outputs. The same rules work from the Python and C bindings; this is the
+    /// language-agnostic counterpart to onnxscript's Python rewriter. Only
+    /// [`simplify`]/[`simplify_with`] apply the rules; the path-based variants
+    /// reject a non-empty rule set.
+    pub fn function_rewrite_rule(
+        mut self,
+        pattern: impl Into<Vec<u8>>,
+        replacement: impl Into<Vec<u8>>,
+    ) -> Self {
+        self.function_rewrite_rules
+            .push((pattern.into(), replacement.into()));
+        self
+    }
 }
 
 /// Simplify a serialized ONNX `ModelProto` with default options.
@@ -195,21 +220,54 @@ pub fn simplify_with(model_bytes: &[u8], options: &Options) -> Result<Vec<u8>, E
     let mut out_size: usize = 0;
     let mut out_error: *mut c_char = ptr::null_mut();
 
-    let status = unsafe {
-        onnxsim_sys::onnxsim_simplify(
-            model_bytes.as_ptr() as *const c_void,
-            model_bytes.len(),
-            ffi.ptr(),
-            ffi.len(),
-            ffi.is_null_flag(),
-            bool_to_c(options.constant_folding),
-            bool_to_c(options.shape_inference),
-            options.tensor_size_threshold,
-            target_opset_to_c(options.target_opset_version),
-            &mut out_data,
-            &mut out_size,
-            &mut out_error,
-        )
+    let status = if options.function_rewrite_rules.is_empty() {
+        unsafe {
+            onnxsim_sys::onnxsim_simplify(
+                model_bytes.as_ptr() as *const c_void,
+                model_bytes.len(),
+                ffi.ptr(),
+                ffi.len(),
+                ffi.is_null_flag(),
+                bool_to_c(options.constant_folding),
+                bool_to_c(options.shape_inference),
+                options.tensor_size_threshold,
+                target_opset_to_c(options.target_opset_version),
+                &mut out_data,
+                &mut out_size,
+                &mut out_error,
+            )
+        }
+    } else {
+        // Borrow the rule byte buffers into the pointer/size arrays the C API
+        // expects; these locals stay alive across the call below.
+        let rules = &options.function_rewrite_rules;
+        let pattern_ptrs: Vec<*const c_void> =
+            rules.iter().map(|(p, _)| p.as_ptr() as *const c_void).collect();
+        let pattern_sizes: Vec<usize> = rules.iter().map(|(p, _)| p.len()).collect();
+        let replacement_ptrs: Vec<*const c_void> =
+            rules.iter().map(|(_, r)| r.as_ptr() as *const c_void).collect();
+        let replacement_sizes: Vec<usize> = rules.iter().map(|(_, r)| r.len()).collect();
+        unsafe {
+            onnxsim_sys::onnxsim_simplify_with_rules(
+                model_bytes.as_ptr() as *const c_void,
+                model_bytes.len(),
+                ffi.ptr(),
+                ffi.len(),
+                ffi.is_null_flag(),
+                bool_to_c(options.constant_folding),
+                bool_to_c(options.shape_inference),
+                options.tensor_size_threshold,
+                target_opset_to_c(options.target_opset_version),
+                pattern_ptrs.as_ptr(),
+                pattern_sizes.as_ptr(),
+                replacement_ptrs.as_ptr(),
+                replacement_sizes.as_ptr(),
+                rules.len(),
+                &mut out_data,
+                &mut out_size,
+                &mut out_error,
+            )
+        }
     };
 
     if status == onnxsim_sys::ONNXSIM_OK {
@@ -239,6 +297,13 @@ pub fn simplify_path_with<P: AsRef<Path>, Q: AsRef<Path>>(
     output_path: Q,
     options: &Options,
 ) -> Result<(), Error> {
+    if !options.function_rewrite_rules.is_empty() {
+        return Err(Error::InvalidArgument(
+            "function_rewrite_rules are only supported by simplify/simplify_with, \
+             not the path-based variants"
+                .to_string(),
+        ));
+    }
     let in_c = path_to_cstring(input_path.as_ref())?;
     let out_c = path_to_cstring(output_path.as_ref())?;
     let ffi = FfiSkipOptimizers::new(options)?;

--- a/rust/onnxsim/src/lib.rs
+++ b/rust/onnxsim/src/lib.rs
@@ -241,11 +241,15 @@ pub fn simplify_with(model_bytes: &[u8], options: &Options) -> Result<Vec<u8>, E
         // Borrow the rule byte buffers into the pointer/size arrays the C API
         // expects; these locals stay alive across the call below.
         let rules = &options.function_rewrite_rules;
-        let pattern_ptrs: Vec<*const c_void> =
-            rules.iter().map(|(p, _)| p.as_ptr() as *const c_void).collect();
+        let pattern_ptrs: Vec<*const c_void> = rules
+            .iter()
+            .map(|(p, _)| p.as_ptr() as *const c_void)
+            .collect();
         let pattern_sizes: Vec<usize> = rules.iter().map(|(p, _)| p.len()).collect();
-        let replacement_ptrs: Vec<*const c_void> =
-            rules.iter().map(|(_, r)| r.as_ptr() as *const c_void).collect();
+        let replacement_ptrs: Vec<*const c_void> = rules
+            .iter()
+            .map(|(_, r)| r.as_ptr() as *const c_void)
+            .collect();
         let replacement_sizes: Vec<usize> = rules.iter().map(|(_, r)| r.len()).collect();
         unsafe {
             onnxsim_sys::onnxsim_simplify_with_rules(

--- a/rust/onnxsim/tests/integration.rs
+++ b/rust/onnxsim/tests/integration.rs
@@ -63,7 +63,10 @@ fn simplify_with_function_rules() {
     let opts = onnxsim::Options::new().function_rewrite_rule(pattern_bytes, replacement_bytes);
     let simplified =
         onnxsim::simplify_with(&model_bytes, &opts).expect("simplify_with should succeed");
-    assert!(!simplified.is_empty(), "simplified model should not be empty");
+    assert!(
+        !simplified.is_empty(),
+        "simplified model should not be empty"
+    );
     assert_ne!(
         simplified, model_bytes,
         "the rule should have rewritten the model"

--- a/rust/onnxsim/tests/integration.rs
+++ b/rust/onnxsim/tests/integration.rs
@@ -20,6 +20,56 @@ fn list_optimizers_is_non_empty() {
     );
 }
 
+/// The path-based API cannot carry FunctionProto rules; it must reject them
+/// before touching the filesystem or the native library, so this runs without
+/// a model file.
+#[test]
+fn simplify_path_rejects_function_rules() {
+    let opts = onnxsim::Options::new().function_rewrite_rule(vec![0u8, 1, 2], vec![3u8, 4, 5]);
+    let err = onnxsim::simplify_path_with("in.onnx", "out.onnx", &opts)
+        .expect_err("path variant must reject function_rewrite_rules");
+    assert!(
+        matches!(err, onnxsim::Error::InvalidArgument(_)),
+        "expected InvalidArgument, got {err:?}"
+    );
+}
+
+/// Exercise the FunctionProto-based rewriter through the C ABI. Point the three
+/// env vars at a serialized ModelProto and the (pattern, replacement) pair of
+/// serialized FunctionProto files; the rule should rewrite the model so the
+/// output is non-empty and differs from the input.
+#[test]
+#[ignore = "requires the native onnxsim_c library and model + rule files"]
+fn simplify_with_function_rules() {
+    let (model, pattern, replacement) = match (
+        std::env::var("ONNXSIM_TEST_MODEL"),
+        std::env::var("ONNXSIM_TEST_PATTERN"),
+        std::env::var("ONNXSIM_TEST_REPLACEMENT"),
+    ) {
+        (Ok(m), Ok(p), Ok(r)) => (m, p, r),
+        _ => {
+            eprintln!(
+                "set ONNXSIM_TEST_MODEL / ONNXSIM_TEST_PATTERN / ONNXSIM_TEST_REPLACEMENT \
+                 to run this test"
+            );
+            return;
+        }
+    };
+    let model_bytes = std::fs::read(&model).expect("model file should be readable");
+    let pattern_bytes = std::fs::read(&pattern).expect("pattern file should be readable");
+    let replacement_bytes =
+        std::fs::read(&replacement).expect("replacement file should be readable");
+
+    let opts = onnxsim::Options::new().function_rewrite_rule(pattern_bytes, replacement_bytes);
+    let simplified =
+        onnxsim::simplify_with(&model_bytes, &opts).expect("simplify_with should succeed");
+    assert!(!simplified.is_empty(), "simplified model should not be empty");
+    assert_ne!(
+        simplified, model_bytes,
+        "the rule should have rewritten the model"
+    );
+}
+
 #[test]
 #[ignore = "requires the native onnxsim_c library and a model file"]
 fn roundtrip_simplify_path() {

--- a/tests/test_function_rewriter.py
+++ b/tests/test_function_rewriter.py
@@ -1,0 +1,247 @@
+"""Tests for the ``function_rewrite_rules`` hook of ``onnxsim.simplify``.
+
+Unlike ``custom_rewriter`` (a Python callable, e.g. an ``onnxscript.rewriter``
+rule set), ``function_rewrite_rules`` is *pure data*: a list of
+``(pattern, replacement)`` pairs of ``onnx.FunctionProto`` matched and applied
+natively by onnxsim's C++ core, so the exact same rules also work from the C
+and Rust bindings. These tests build the FunctionProtos with
+``onnx.parser.parse_function`` -- the intended authoring path.
+"""
+
+import collections
+
+import numpy as np
+import onnx
+import pytest
+from onnx import parser
+
+import onnxsim
+
+
+def _model(nodes, inputs, outputs, initializer, opset=18):
+    graph = onnx.helper.make_graph(nodes, "g", inputs, outputs, initializer)
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", opset)], ir_version=10
+    )
+
+
+def _vi(name, shape):
+    return onnx.helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _op_types(model):
+    return collections.Counter(n.op_type for n in model.graph.node)
+
+
+def _matmul_add_model(swap_add_operands=False):
+    """x @ W + B, i.e. a MatMul feeding an Add -- the classic Gemm fusion."""
+    add_inputs = ["B", "mm"] if swap_add_operands else ["mm", "B"]
+    nodes = [
+        onnx.helper.make_node("MatMul", ["x", "W"], ["mm"], name="mm"),
+        onnx.helper.make_node("Add", add_inputs, ["y"], name="add"),
+    ]
+    inits = [_f32(np.random.randn(4, 5), "W"), _f32(np.random.randn(5), "B")]
+    return _model(nodes, [_vi("x", [3, 4])], [_vi("y", [3, 5])], inits)
+
+
+# The canonical rule: y = MatMul(x, w) + b  ==>  y = Gemm(x, w, b).
+_GEMM_PATTERN = parser.parse_function(
+    """
+<domain: "com.onnxsim.test", opset_import: ["" : 18]>
+matmul_add_pattern (x, w, b) => (y)
+{
+    t = MatMul(x, w)
+    y = Add(t, b)
+}
+"""
+)
+_GEMM_REPLACEMENT = parser.parse_function(
+    """
+<domain: "com.onnxsim.test", opset_import: ["" : 18]>
+gemm_replacement (x, w, b) => (y)
+{
+    y = Gemm(x, w, b)
+}
+"""
+)
+
+
+def test_function_rewriter_matmul_add_to_gemm():
+    """The headline case: MatMul + Add fuse into a single Gemm."""
+    model = _matmul_add_model()
+    sim_model, check_ok = onnxsim.simplify(
+        model, check_n=1, function_rewrite_rules=[(_GEMM_PATTERN, _GEMM_REPLACEMENT)]
+    )
+    counts = _op_types(sim_model)
+    assert counts["Gemm"] == 1, counts
+    assert counts["MatMul"] == 0 and counts["Add"] == 0, counts
+    assert check_ok
+
+
+def test_function_rewriter_commutative_add():
+    """The matcher tries both operand orders for commutative ops, so an
+    ``Add(b, MatMul(x, w))`` (operands swapped) still fuses."""
+    model = _matmul_add_model(swap_add_operands=True)
+    sim_model, _ = onnxsim.simplify(
+        model, check_n=0, function_rewrite_rules=[(_GEMM_PATTERN, _GEMM_REPLACEMENT)]
+    )
+    assert _op_types(sim_model)["Gemm"] == 1
+
+
+def test_function_rewriter_attribute_wildcard():
+    """A ``@name`` ref-attribute is an attribute wildcard: it binds the matched
+    node's attribute and substitutes it into the replacement. Here ``Relu``
+    feeding a ``LeakyRelu<alpha>`` collapses to a single ``LeakyRelu`` that keeps
+    the original ``alpha``."""
+    pattern = parser.parse_function(
+        """
+<domain: "com.onnxsim.test", opset_import: ["" : 18]>
+relu_leaky (x) => (y)
+{
+    t = Relu(x)
+    y = LeakyRelu <alpha = @a> (t)
+}
+"""
+    )
+    replacement = parser.parse_function(
+        """
+<domain: "com.onnxsim.test", opset_import: ["" : 18]>
+leaky (x) => (y)
+{
+    y = LeakyRelu <alpha = @a> (x)
+}
+"""
+    )
+    model = _model(
+        [
+            onnx.helper.make_node("Relu", ["x"], ["t"], name="relu"),
+            onnx.helper.make_node("LeakyRelu", ["t"], ["y"], alpha=0.2, name="lr"),
+        ],
+        [_vi("x", [2, 2])],
+        [_vi("y", [2, 2])],
+        [],
+    )
+    sim_model, _ = onnxsim.simplify(
+        model, check_n=0, function_rewrite_rules=[(pattern, replacement)]
+    )
+    counts = _op_types(sim_model)
+    assert counts["Relu"] == 0 and counts["LeakyRelu"] == 1, counts
+    leaky = next(n for n in sim_model.graph.node if n.op_type == "LeakyRelu")
+    alpha = next(a.f for a in leaky.attribute if a.name == "alpha")
+    assert abs(alpha - 0.2) < 1e-6, alpha
+
+
+def test_function_rewriter_constant_value_match():
+    """A pattern ``Constant`` matches a host initializer with a byte-equal
+    tensor: ``Mul(x, ones)`` rewrites to ``Identity(x)``."""
+    ones = np.ones([4], dtype=np.float32)
+    pattern = onnx.helper.make_function(
+        "com.onnxsim.test",
+        "mul_ones",
+        ["x"],
+        ["y"],
+        [
+            onnx.helper.make_node(
+                "Constant", [], ["c"], value=onnx.numpy_helper.from_array(ones, "")
+            ),
+            onnx.helper.make_node("Mul", ["x", "c"], ["y"]),
+        ],
+        [onnx.helper.make_opsetid("", 18)],
+    )
+    replacement = onnx.helper.make_function(
+        "com.onnxsim.test",
+        "identity",
+        ["x"],
+        ["y"],
+        [onnx.helper.make_node("Identity", ["x"], ["y"])],
+        [onnx.helper.make_opsetid("", 18)],
+    )
+    model = _model(
+        [onnx.helper.make_node("Mul", ["x", "ones"], ["y"], name="mul")],
+        [_vi("x", [4])],
+        [_vi("y", [4])],
+        [onnx.numpy_helper.from_array(ones, "ones")],
+    )
+    sim_model, _ = onnxsim.simplify(
+        model, check_n=0, function_rewrite_rules=[(pattern, replacement)]
+    )
+    counts = _op_types(sim_model)
+    assert counts["Mul"] == 0 and counts["Identity"] >= 1, counts
+
+
+def test_function_rewriter_no_match_is_noop():
+    """A rule whose pattern never matches leaves the model's ops unchanged."""
+    model = _model(
+        [onnx.helper.make_node("MatMul", ["x", "W"], ["y"], name="mm")],
+        [_vi("x", [3, 4])],
+        [_vi("y", [3, 5])],
+        [_f32(np.random.randn(4, 5), "W")],
+    )
+    baseline, _ = onnxsim.simplify(model, check_n=0)
+    sim_model, _ = onnxsim.simplify(
+        model, check_n=0, function_rewrite_rules=[(_GEMM_PATTERN, _GEMM_REPLACEMENT)]
+    )
+    assert _op_types(sim_model) == _op_types(baseline)
+    assert _op_types(sim_model)["Gemm"] == 0
+
+
+def test_function_rewriter_safety_shared_intermediate():
+    """The matched interior value (the MatMul output) is also consumed by a Relu
+    outside the match, so fusing would break the Relu -- the rewrite must be
+    skipped and MatMul/Add kept."""
+    nodes = [
+        onnx.helper.make_node("MatMul", ["x", "W"], ["mm"], name="mm"),
+        onnx.helper.make_node("Add", ["mm", "B"], ["y"], name="add"),
+        onnx.helper.make_node("Relu", ["mm"], ["z"], name="relu"),
+    ]
+    inits = [_f32(np.random.randn(4, 5), "W"), _f32(np.random.randn(5), "B")]
+    model = _model(
+        nodes, [_vi("x", [3, 4])], [_vi("y", [3, 5]), _vi("z", [3, 5])], inits
+    )
+    sim_model, _ = onnxsim.simplify(
+        model, check_n=0, function_rewrite_rules=[(_GEMM_PATTERN, _GEMM_REPLACEMENT)]
+    )
+    counts = _op_types(sim_model)
+    assert counts["Gemm"] == 0 and counts["MatMul"] == 1 and counts["Add"] == 1, counts
+
+
+def test_function_rewriter_mutually_exclusive_with_custom_rewriter():
+    """Passing both a callable and data rules is a usage error."""
+    model = _matmul_add_model()
+    with pytest.raises(ValueError):
+        onnxsim.simplify(
+            model,
+            check_n=0,
+            custom_rewriter=lambda m: m,
+            function_rewrite_rules=[(_GEMM_PATTERN, _GEMM_REPLACEMENT)],
+        )
+
+
+def test_function_rewriter_replaces_builtin_pass():
+    """A FunctionProto rule can stand in for a hand-written onnxoptimizer pass.
+
+    With the built-in ``fuse_matmul_add_bias_into_gemm`` pass skipped, onnxsim no
+    longer fuses on its own; the rule reproduces exactly that fusion. (The
+    imperative pass additionally guards on a constant, rank-compatible bias and
+    sets alpha/transA -- guards a pure structural rule does not express, which is
+    why the two are equivalent here but not in general.)"""
+    model = _matmul_add_model()
+
+    skipped_no_rule, _ = onnxsim.simplify(
+        model, check_n=0, skipped_optimizers=["fuse_matmul_add_bias_into_gemm"]
+    )
+    assert _op_types(skipped_no_rule)["Gemm"] == 0, "sanity: builtin fusion was skipped"
+
+    with_rule, check_ok = onnxsim.simplify(
+        model,
+        check_n=1,
+        skipped_optimizers=["fuse_matmul_add_bias_into_gemm"],
+        function_rewrite_rules=[(_GEMM_PATTERN, _GEMM_REPLACEMENT)],
+    )
+    counts = _op_types(with_rule)
+    assert counts["Gemm"] == 1 and counts["MatMul"] == 0 and counts["Add"] == 0, counts
+    assert check_ok

--- a/tests/test_function_rewriter_common_rules.py
+++ b/tests/test_function_rewriter_common_rules.py
@@ -1,0 +1,172 @@
+"""Use onnxscript's built-in *common* rewrite rules as onnxsim
+``function_rewrite_rules``.
+
+onnxscript ships a library of ready-made rewrite rules in
+``onnxscript.rewriter.rules.common`` (e.g. ``matmul_add_to_gemm_rule``,
+``reshape_reshape_rule``). Those rules are authored in onnxscript's pattern DSL,
+but the simple, structural ones are equivalently expressible as a
+``(pattern, replacement)`` pair of ``onnx.FunctionProto`` -- exactly what
+onnxsim's ``function_rewrite_rules`` consumes, with no onnxscript dependency at
+run time.
+
+Each test here hand-authors the FunctionProto equivalent of a named common rule
+and asserts two things:
+  * onnxsim applies it (the fusion happens), and
+  * it matches what the *actual* onnxscript common rule does on the same model
+    (parity), so the FunctionProto really is that rule.
+
+Only rules within onnxsim's first-version matcher (main-graph, structural,
+attribute equality/``@``-wildcards, <=2-operand commutativity) are covered;
+rules that need condition predicates or attribute arithmetic (e.g.
+``cast_cast_rule``, ``transpose_transpose_rule``) are out of scope.
+"""
+
+import collections
+
+import numpy as np
+import onnx
+import pytest
+from onnx import helper, parser
+
+import onnxsim
+
+# The common rules live under this module; skip the whole file if the installed
+# onnxscript predates it.
+common = pytest.importorskip("onnxscript.rewriter.rules.common")
+_rewriter = pytest.importorskip("onnxscript.rewriter")
+
+
+def _op_types(model):
+    return collections.Counter(n.op_type for n in model.graph.node)
+
+
+def _apply_onnxscript_rule(model, rule):
+    """Run a single onnxscript common rule over ``model``."""
+    rules = _rewriter.pattern.RewriteRuleSet([rule])
+    return _rewriter.rewrite(model, pattern_rewrite_rules=rules)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _vi(name, shape):
+    return helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+# --------------------------------------------------------------------------
+# matmul_add_to_gemm_rule:  Add(MatMul(a, b), c)  ->  Gemm(a, b, c)
+# --------------------------------------------------------------------------
+_MATMUL_ADD_PATTERN = parser.parse_function(
+    """
+<domain: "onnxscript.common", opset_import: ["" : 18]>
+matmul_add (a, b, c) => (y)
+{
+    mm = MatMul(a, b)
+    y = Add(mm, c)
+}
+"""
+)
+_MATMUL_ADD_REPLACEMENT = parser.parse_function(
+    """
+<domain: "onnxscript.common", opset_import: ["" : 18]>
+gemm (a, b, c) => (y)
+{
+    y = Gemm(a, b, c)
+}
+"""
+)
+
+
+def _matmul_add_model():
+    nodes = [
+        helper.make_node("MatMul", ["x", "W"], ["mm"], name="mm"),
+        helper.make_node("Add", ["mm", "B"], ["y"], name="add"),
+    ]
+    inits = [_f32(np.random.randn(4, 5), "W"), _f32(np.random.randn(5), "B")]
+    graph = helper.make_graph(nodes, "g", [_vi("x", [3, 4])], [_vi("y", [3, 5])], inits)
+    return helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+    )
+
+
+def test_matmul_add_to_gemm_common_rule():
+    # onnxsim applies the FunctionProto form. The built-in
+    # ``fuse_matmul_add_bias_into_gemm`` pass is skipped so the rule is provably
+    # what produces the Gemm.
+    ours, check_ok = onnxsim.simplify(
+        _matmul_add_model(),
+        check_n=2,
+        skipped_optimizers=["fuse_matmul_add_bias_into_gemm"],
+        function_rewrite_rules=[(_MATMUL_ADD_PATTERN, _MATMUL_ADD_REPLACEMENT)],
+    )
+    counts = _op_types(ours)
+    assert counts["Gemm"] == 1 and counts["MatMul"] == 0 and counts["Add"] == 0, counts
+    assert check_ok
+
+    # Parity: the actual onnxscript common rule fuses the same way.
+    theirs = _apply_onnxscript_rule(_matmul_add_model(), common.matmul_add_to_gemm_rule)
+    tcounts = _op_types(theirs)
+    assert tcounts["Gemm"] == 1 and tcounts["MatMul"] == 0 and tcounts["Add"] == 0
+
+
+# --------------------------------------------------------------------------
+# reshape_reshape_rule:  Reshape(Reshape(x, s1), s2)  ->  Reshape(x, s2)
+# (Valid whenever s2 carries no zero dims -- which onnxscript's rule guards and
+# this test's shapes satisfy.)
+# --------------------------------------------------------------------------
+_RESHAPE_RESHAPE_PATTERN = parser.parse_function(
+    """
+<domain: "onnxscript.common", opset_import: ["" : 18]>
+reshape_reshape (x, s1, s2) => (y)
+{
+    t = Reshape(x, s1)
+    y = Reshape(t, s2)
+}
+"""
+)
+_RESHAPE_RESHAPE_REPLACEMENT = parser.parse_function(
+    """
+<domain: "onnxscript.common", opset_import: ["" : 18]>
+reshape (x, s2) => (y)
+{
+    y = Reshape(x, s2)
+}
+"""
+)
+
+
+def _reshape_reshape_model():
+    nodes = [
+        helper.make_node("Reshape", ["x", "s1"], ["t"], name="r1"),
+        helper.make_node("Reshape", ["t", "s2"], ["y"], name="r2"),
+    ]
+    inits = [
+        onnx.numpy_helper.from_array(np.array([2, 12], dtype=np.int64), "s1"),
+        onnx.numpy_helper.from_array(np.array([4, 6], dtype=np.int64), "s2"),
+    ]
+    graph = helper.make_graph(nodes, "g", [_vi("x", [3, 8])], [_vi("y", [4, 6])], inits)
+    return helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+    )
+
+
+def test_reshape_reshape_common_rule():
+    ours, check_ok = onnxsim.simplify(
+        _reshape_reshape_model(),
+        check_n=2,
+        function_rewrite_rules=[
+            (_RESHAPE_RESHAPE_PATTERN, _RESHAPE_RESHAPE_REPLACEMENT)
+        ],
+    )
+    assert _op_types(ours)["Reshape"] == 1, _op_types(ours)
+    assert check_ok
+    # The surviving Reshape consumes the original input and the outer shape.
+    reshape = next(n for n in ours.graph.node if n.op_type == "Reshape")
+    assert list(reshape.input) == ["x", "s2"], list(reshape.input)
+
+    # Parity: the actual onnxscript common rule collapses the pair the same way.
+    theirs = _apply_onnxscript_rule(
+        _reshape_reshape_model(), common.reshape_reshape_rule
+    )
+    assert _op_types(theirs)["Reshape"] == 1, _op_types(theirs)

--- a/tests/test_function_rewriter_compile_rule.py
+++ b/tests/test_function_rewriter_compile_rule.py
@@ -20,8 +20,10 @@ op.Gemm(..., **attrs)`` or ``ReshapeReshape.rewrite``'s
 ``op.initializer(ir.Tensor(self._new_shape, ...))`` -- is *not* compilable this
 way and raises. In practice the ``pattern`` side of a rule is usually structural
 (so it compiles), while the ``rewrite`` side often is not, so you pair a
-compiled pattern with a simple replacement function. This matches onnxsim's own
-matcher limits.
+compiled pattern with a simple replacement function. Some rules do have a
+structural rewrite too -- e.g. ``FuseSuccessiveRelu`` (``Relu(Relu(x)) ->
+Relu(x)``), whose rewrite is a plain ``op.Relu(x)`` -- and compile end to end
+from their own methods. This matches onnxsim's own matcher limits.
 """
 
 import ast
@@ -45,6 +47,22 @@ common = pytest.importorskip("onnxscript.rewriter.rules.common")
 _rewriter = pytest.importorskip("onnxscript.rewriter")
 
 
+class _StripAnnotations(ast.NodeTransformer):
+    """Drop parameter/return annotations. Rewrite-rule methods annotate their
+    tensor parameters ``x: ir.Value`` (onnxscript's rewriter typing), which the
+    ``@script`` converter rejects; the annotations carry no meaning for a
+    structural op graph, so remove them."""
+
+    def visit_arg(self, node):
+        node.annotation = None
+        return node
+
+    def visit_FunctionDef(self, node):
+        node.returns = None
+        self.generic_visit(node)
+        return node
+
+
 def _compile_fn_to_function_proto(fn, *, opset_version=18, name=None):
     """Compile ``fn(op, *inputs)`` / ``fn(self, op, *inputs)`` to a FunctionProto.
 
@@ -59,6 +77,8 @@ def _compile_fn_to_function_proto(fn, *, opset_version=18, name=None):
     fdef = ast.parse(src).body[0]
     fdef.decorator_list = []
     fdef.args.args = [a for a in fdef.args.args if a.arg not in ("self", "op")]
+    _StripAnnotations().visit(fdef)
+    ast.fix_missing_locations(fdef)
     if name is not None:
         fdef.name = name
     env = {**getattr(inspect.getmodule(fn), "__dict__", {}), "op": op_builder}
@@ -179,6 +199,42 @@ def test_compiled_reshape_reshape_pattern_from_real_rule():
 
     theirs = _apply_onnxscript_rule(build(), common.reshape_reshape_rule)
     assert _op_types(theirs)["Reshape"] == 1, _op_types(theirs)
+
+
+def test_compiled_successive_relu_both_from_real_rule():
+    """Some rules have *both* a structural pattern and a structural rewrite --
+    ``FuseSuccessiveRelu`` (``Relu(Relu(x)) -> Relu(x)``), whose rewrite is a
+    plain ``op.Relu(x)`` with no match-derived attributes -- so the whole rule
+    compiles straight from its own methods."""
+    from onnxscript.rewriter.rules.common._fuse_relus_clips import FuseSuccessiveRelu
+
+    pattern_fp = _compile_fn_to_function_proto(FuseSuccessiveRelu.pattern, name="pat")
+    replacement_fp = _compile_fn_to_function_proto(
+        FuseSuccessiveRelu.rewrite, name="rep"
+    )
+    assert [n.op_type for n in pattern_fp.node] == ["Relu", "Relu"]
+    assert [n.op_type for n in replacement_fp.node] == ["Relu"]
+
+    def build():
+        nodes = [
+            helper.make_node("Relu", ["x"], ["t"]),
+            helper.make_node("Relu", ["t"], ["y"]),
+        ]
+        graph = helper.make_graph(
+            nodes, "g", [_vi("x", [2, 2])], [_vi("y", [2, 2])], []
+        )
+        return helper.make_model(
+            graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+        )
+
+    ours, check_ok = onnxsim.simplify(
+        build(), check_n=2, function_rewrite_rules=[(pattern_fp, replacement_fp)]
+    )
+    assert _op_types(ours)["Relu"] == 1, _op_types(ours)
+    assert check_ok
+
+    theirs = _apply_onnxscript_rule(build(), common.successive_relu_rule)
+    assert _op_types(theirs)["Relu"] == 1, _op_types(theirs)
 
 
 def test_nonstructural_rewrite_method_is_rejected():

--- a/tests/test_function_rewriter_compile_rule.py
+++ b/tests/test_function_rewriter_compile_rule.py
@@ -1,0 +1,190 @@
+"""Compile an onnxscript ``RewriteRule``'s ``pattern``/``rewrite`` methods to
+``onnx.FunctionProto`` by reusing onnxscript's ``@script`` converter, then drive
+the result through onnxsim's ``function_rewrite_rules``.
+
+The pattern/rewrite of an onnxscript rewrite rule are Python functions of the
+form ``fn(op, *inputs)`` (or bound methods ``fn(self, op, *inputs)``), where
+``op`` is the *pattern builder*. onnxscript's ``@script`` decorator already
+compiles op-authoring functions to FunctionProtos, but it resolves ``op`` from
+the *module globals* and AST-parses real source, so you can't decorate a rule
+method directly. ``_compile_fn_to_function_proto`` below reuses the same
+converter machinery (``onnxscript._internal.main.script_check``): it strips
+``self``/``op`` from the signature, binds ``op`` to an authoring opset, and runs
+the checker on the resulting AST.
+
+**Caveats.** This uses onnxscript *internal* APIs (guarded -- the module skips if
+they move) and only handles the *structural* subset: plain op-call graphs. A
+method that computes attributes or constants from the match -- e.g.
+``MatMulAddToGemm.rewrite``'s ``if self.trans_a: attrs["transA"]=1;
+op.Gemm(..., **attrs)`` or ``ReshapeReshape.rewrite``'s
+``op.initializer(ir.Tensor(self._new_shape, ...))`` -- is *not* compilable this
+way and raises. In practice the ``pattern`` side of a rule is usually structural
+(so it compiles), while the ``rewrite`` side often is not, so you pair a
+compiled pattern with a simple replacement function. This matches onnxsim's own
+matcher limits.
+"""
+
+import ast
+import collections
+import inspect
+import textwrap
+
+import numpy as np
+import onnx
+import pytest
+from onnx import helper
+
+import onnxsim
+
+# Internal onnxscript machinery this helper stands on. Skip the whole module if
+# onnxscript (or the private entry point) is unavailable.
+_oxs_main = pytest.importorskip("onnxscript._internal.main")
+_oxs_values = pytest.importorskip("onnxscript.values")
+_oxs_opsets = pytest.importorskip("onnxscript.onnx_opset")
+common = pytest.importorskip("onnxscript.rewriter.rules.common")
+_rewriter = pytest.importorskip("onnxscript.rewriter")
+
+
+def _compile_fn_to_function_proto(fn, *, opset_version=18, name=None):
+    """Compile ``fn(op, *inputs)`` / ``fn(self, op, *inputs)`` to a FunctionProto.
+
+    ``op`` is bound to the ``opset_version`` authoring opset; the remaining
+    parameters become the function inputs (a Python-typed attribute parameter,
+    e.g. ``alpha: float``, becomes a ``ref_attr_name`` = onnxsim's ``@name``
+    wildcard). Raises whatever onnxscript raises when ``fn`` falls outside the
+    op-authoring subset.
+    """
+    op_builder = getattr(_oxs_opsets, f"opset{opset_version}")
+    src = textwrap.dedent(inspect.getsource(fn))
+    fdef = ast.parse(src).body[0]
+    fdef.decorator_list = []
+    fdef.args.args = [a for a in fdef.args.args if a.arg not in ("self", "op")]
+    if name is not None:
+        fdef.name = name
+    env = {**getattr(inspect.getmodule(fn), "__dict__", {}), "op": op_builder}
+    ir = _oxs_main.script_check(
+        fdef, _oxs_values.Opset("this", 1), env, src, default_opset=op_builder
+    )
+    return ir.to_function_proto()
+
+
+# Self-test at import: if onnxscript's internal compile path has drifted, skip
+# the whole module rather than fail with a confusing internal error.
+def _selftest_identity(op, x):
+    return op.Identity(x)
+
+
+try:
+    _probe = _compile_fn_to_function_proto(_selftest_identity, name="probe")
+    assert _probe.node[0].op_type == "Identity"
+except Exception as exc:  # pragma: no cover - environment/version guard
+    pytest.skip(
+        f"onnxscript @script internals unavailable/changed: {exc!r}",
+        allow_module_level=True,
+    )
+
+
+def _op_types(model):
+    return collections.Counter(n.op_type for n in model.graph.node)
+
+
+def _apply_onnxscript_rule(model, rule):
+    rules = _rewriter.pattern.RewriteRuleSet([rule])
+    return _rewriter.rewrite(model, pattern_rewrite_rules=rules)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _vi(name, shape):
+    return helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+# --------------------------------------------------------------------------
+# Compile a real rule's `pattern` method + a simple replacement, and run it.
+# --------------------------------------------------------------------------
+def _gemm_replacement(op, input_a, input_b, input_c):
+    return op.Gemm(input_a, input_b, input_c)
+
+
+def test_compiled_matmul_add_pattern_from_real_rule():
+    from onnxscript.rewriter.rules.common._matmul_add_to_gemm import MatMulAddToGemm
+
+    pattern_fp = _compile_fn_to_function_proto(MatMulAddToGemm.pattern, name="pat")
+    replacement_fp = _compile_fn_to_function_proto(_gemm_replacement, name="rep")
+    # The pattern really came from the onnxscript rule.
+    assert [n.op_type for n in pattern_fp.node] == ["MatMul", "Add"]
+
+    def build():
+        nodes = [
+            helper.make_node("MatMul", ["x", "W"], ["mm"]),
+            helper.make_node("Add", ["mm", "B"], ["y"]),
+        ]
+        inits = [_f32(np.random.randn(4, 5), "W"), _f32(np.random.randn(5), "B")]
+        graph = helper.make_graph(
+            nodes, "g", [_vi("x", [3, 4])], [_vi("y", [3, 5])], inits
+        )
+        return helper.make_model(
+            graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+        )
+
+    ours, check_ok = onnxsim.simplify(
+        build(),
+        check_n=2,
+        skipped_optimizers=["fuse_matmul_add_bias_into_gemm"],
+        function_rewrite_rules=[(pattern_fp, replacement_fp)],
+    )
+    counts = _op_types(ours)
+    assert counts["Gemm"] == 1 and counts["MatMul"] == 0 and counts["Add"] == 0, counts
+    assert check_ok
+
+    theirs = _apply_onnxscript_rule(build(), common.matmul_add_to_gemm_rule)
+    tcounts = _op_types(theirs)
+    assert tcounts["Gemm"] == 1 and tcounts["MatMul"] == 0 and tcounts["Add"] == 0
+
+
+def _reshape_replacement(op, x, shape):
+    return op.Reshape(x, shape)
+
+
+def test_compiled_reshape_reshape_pattern_from_real_rule():
+    from onnxscript.rewriter.rules.common._basic_rules import ReshapeReshape
+
+    pattern_fp = _compile_fn_to_function_proto(ReshapeReshape.pattern, name="pat")
+    replacement_fp = _compile_fn_to_function_proto(_reshape_replacement, name="rep")
+    assert [n.op_type for n in pattern_fp.node] == ["Reshape", "Reshape"]
+
+    def build():
+        nodes = [
+            helper.make_node("Reshape", ["x", "s1"], ["t"]),
+            helper.make_node("Reshape", ["t", "s2"], ["y"]),
+        ]
+        inits = [
+            onnx.numpy_helper.from_array(np.array([2, 12], dtype=np.int64), "s1"),
+            onnx.numpy_helper.from_array(np.array([4, 6], dtype=np.int64), "s2"),
+        ]
+        graph = helper.make_graph(
+            nodes, "g", [_vi("x", [3, 8])], [_vi("y", [4, 6])], inits
+        )
+        return helper.make_model(
+            graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+        )
+
+    ours, check_ok = onnxsim.simplify(
+        build(), check_n=2, function_rewrite_rules=[(pattern_fp, replacement_fp)]
+    )
+    assert _op_types(ours)["Reshape"] == 1, _op_types(ours)
+    assert check_ok
+
+    theirs = _apply_onnxscript_rule(build(), common.reshape_reshape_rule)
+    assert _op_types(theirs)["Reshape"] == 1, _op_types(theirs)
+
+
+def test_nonstructural_rewrite_method_is_rejected():
+    """A rewrite that derives attributes from the match can't be compiled this
+    way -- the boundary is explicit (and matches onnxsim's matcher)."""
+    from onnxscript.rewriter.rules.common._matmul_add_to_gemm import MatMulAddToGemm
+
+    with pytest.raises(Exception):
+        _compile_fn_to_function_proto(MatMulAddToGemm.rewrite, name="rep")

--- a/tests/test_function_rewriter_onnxscript_script.py
+++ b/tests/test_function_rewriter_onnxscript_script.py
@@ -1,0 +1,204 @@
+"""Author onnxsim ``function_rewrite_rules`` with onnxscript's ``@script``.
+
+An alternative to writing the ``(pattern, replacement)`` FunctionProtos by hand
+(``onnx.parser.parse_function``): write each as an ``onnxscript.script`` function
+and call ``.to_function_proto()``. That is the same authoring surface onnxscript
+uses for op functions, so:
+
+  * nested op calls, value inputs and concrete attributes all just work;
+  * a Python-typed *attribute parameter* (``alpha: float``, as opposed to a
+    tensor-typed input) compiles to a ``ref_attr_name`` in the body -- exactly
+    onnxsim's ``@name`` attribute wildcard, bound on match and substituted into
+    the replacement.
+
+``@script`` compiles an *executable* ONNX function, i.e. the same structural
+subset onnxsim's matcher handles; it can't express matcher-only constructs
+(OrValue, ANY_VALUE, condition predicates) or attributes computed from the match
+at rewrite time. These tests cover the structural rules and, where the rule
+mirrors an onnxscript *common* rule, check parity against it.
+"""
+
+import collections
+
+import numpy as np
+import onnx
+import pytest
+from onnx import helper
+
+import onnxsim
+
+# ``@script`` AST-parses its source at import, so onnxscript must be importable
+# for this module to even be collected.
+pytest.importorskip("onnxscript")
+common = pytest.importorskip("onnxscript.rewriter.rules.common")
+_rewriter = pytest.importorskip("onnxscript.rewriter")
+
+from onnxscript import opset18 as op  # noqa: E402
+from onnxscript import script  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Rules authored as @script functions. `.to_function_proto()` yields the
+# onnx.FunctionProto that onnxsim consumes directly.
+# --------------------------------------------------------------------------
+@script()
+def matmul_add_pattern(a, b, c):
+    return op.Add(op.MatMul(a, b), c)
+
+
+@script()
+def gemm_replacement(a, b, c):
+    return op.Gemm(a, b, c)
+
+
+@script()
+def reshape_reshape_pattern(x, s1, s2):
+    return op.Reshape(op.Reshape(x, s1), s2)
+
+
+@script()
+def reshape_replacement(x, s2):
+    return op.Reshape(x, s2)
+
+
+# `alpha: float` is an *attribute* parameter (not a tensor input), so it becomes
+# a ref-attribute -> onnxsim's `@name` wildcard.
+@script()
+def relu_leaky_pattern(x, alpha: float):
+    return op.LeakyRelu(op.Relu(x), alpha=alpha)
+
+
+@script()
+def leaky_replacement(x, alpha: float):
+    return op.LeakyRelu(x, alpha=alpha)
+
+
+_MATMUL_ADD_RULE = (
+    matmul_add_pattern.to_function_proto(),
+    gemm_replacement.to_function_proto(),
+)
+_RESHAPE_RULE = (
+    reshape_reshape_pattern.to_function_proto(),
+    reshape_replacement.to_function_proto(),
+)
+_RELU_LEAKY_RULE = (
+    relu_leaky_pattern.to_function_proto(),
+    leaky_replacement.to_function_proto(),
+)
+
+
+def _op_types(model):
+    return collections.Counter(n.op_type for n in model.graph.node)
+
+
+def _apply_onnxscript_rule(model, rule):
+    rules = _rewriter.pattern.RewriteRuleSet([rule])
+    return _rewriter.rewrite(model, pattern_rewrite_rules=rules)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _vi(name, shape):
+    return helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+def test_script_to_function_proto_shape():
+    """Sanity: ``@script`` produced the expected FunctionProto shape, including
+    the attribute parameter surfacing as a ref-attribute."""
+    pat = _RELU_LEAKY_RULE[0]
+    assert list(pat.attribute) == ["alpha"]
+    leaky = next(n for n in pat.node if n.op_type == "LeakyRelu")
+    alpha_attr = next(a for a in leaky.attribute if a.name == "alpha")
+    assert alpha_attr.ref_attr_name == "alpha"
+
+
+def test_script_matmul_add_to_gemm():
+    def build():
+        nodes = [
+            helper.make_node("MatMul", ["x", "W"], ["mm"]),
+            helper.make_node("Add", ["mm", "B"], ["y"]),
+        ]
+        inits = [_f32(np.random.randn(4, 5), "W"), _f32(np.random.randn(5), "B")]
+        graph = helper.make_graph(
+            nodes, "g", [_vi("x", [3, 4])], [_vi("y", [3, 5])], inits
+        )
+        return helper.make_model(
+            graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+        )
+
+    # onnxsim applies the @script-authored rule (built-in Gemm fusion skipped so
+    # the rule is provably responsible).
+    ours, check_ok = onnxsim.simplify(
+        build(),
+        check_n=2,
+        skipped_optimizers=["fuse_matmul_add_bias_into_gemm"],
+        function_rewrite_rules=[_MATMUL_ADD_RULE],
+    )
+    counts = _op_types(ours)
+    assert counts["Gemm"] == 1 and counts["MatMul"] == 0 and counts["Add"] == 0, counts
+    assert check_ok
+
+    # Parity with the onnxscript common rule.
+    theirs = _apply_onnxscript_rule(build(), common.matmul_add_to_gemm_rule)
+    tcounts = _op_types(theirs)
+    assert tcounts["Gemm"] == 1 and tcounts["MatMul"] == 0 and tcounts["Add"] == 0
+
+
+def test_script_reshape_reshape():
+    def build():
+        nodes = [
+            helper.make_node("Reshape", ["x", "s1"], ["t"]),
+            helper.make_node("Reshape", ["t", "s2"], ["y"]),
+        ]
+        inits = [
+            onnx.numpy_helper.from_array(np.array([2, 12], dtype=np.int64), "s1"),
+            onnx.numpy_helper.from_array(np.array([4, 6], dtype=np.int64), "s2"),
+        ]
+        graph = helper.make_graph(
+            nodes, "g", [_vi("x", [3, 8])], [_vi("y", [4, 6])], inits
+        )
+        return helper.make_model(
+            graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+        )
+
+    ours, check_ok = onnxsim.simplify(
+        build(), check_n=2, function_rewrite_rules=[_RESHAPE_RULE]
+    )
+    assert _op_types(ours)["Reshape"] == 1, _op_types(ours)
+    assert check_ok
+    reshape = next(n for n in ours.graph.node if n.op_type == "Reshape")
+    assert list(reshape.input) == ["x", "s2"], list(reshape.input)
+
+    theirs = _apply_onnxscript_rule(build(), common.reshape_reshape_rule)
+    assert _op_types(theirs)["Reshape"] == 1, _op_types(theirs)
+
+
+def test_script_attribute_wildcard():
+    """The ``alpha: float`` attribute parameter round-trips: onnxsim binds the
+    matched ``LeakyRelu``'s ``alpha`` and substitutes it into the replacement,
+    dropping the ``Relu``. (Structural demo -- not semantics preserving, so no
+    correctness check.)"""
+    model = helper.make_model(
+        helper.make_graph(
+            [
+                helper.make_node("Relu", ["x"], ["t"], name="relu"),
+                helper.make_node("LeakyRelu", ["t"], ["y"], alpha=0.2, name="lr"),
+            ],
+            "g",
+            [_vi("x", [2, 2])],
+            [_vi("y", [2, 2])],
+            [],
+        ),
+        opset_imports=[helper.make_opsetid("", 18)],
+        ir_version=10,
+    )
+    ours, _ = onnxsim.simplify(
+        model, check_n=0, function_rewrite_rules=[_RELU_LEAKY_RULE]
+    )
+    counts = _op_types(ours)
+    assert counts["Relu"] == 0 and counts["LeakyRelu"] == 1, counts
+    leaky = next(n for n in ours.graph.node if n.op_type == "LeakyRelu")
+    alpha = next(a.f for a in leaky.attribute if a.name == "alpha")
+    assert abs(alpha - 0.2) < 1e-6, alpha

--- a/tests/test_function_rewriter_vs_onnxscript.py
+++ b/tests/test_function_rewriter_vs_onnxscript.py
@@ -1,0 +1,194 @@
+"""Differential test: drive onnxsim's native FunctionProto matcher and
+``onnxscript.rewriter`` from the *same* FunctionProtos and compare.
+
+A single source of truth -- one ``(pattern, replacement)`` pair of
+``onnx.FunctionProto`` -- is fed to both engines: onnxsim via
+``simplify(function_rewrite_rules=...)``, and onnxscript via a small interpreter
+that rebuilds the pattern/replacement as an ``onnxscript.rewriter`` rule. This
+shows both where the two agree (parity) and where onnxsim's first-version
+matcher is deliberately narrower (limitations).
+"""
+
+import collections
+
+import numpy as np
+import onnx
+import pytest
+from onnx import helper, parser
+
+import onnxsim
+
+pattern_mod = pytest.importorskip("onnxscript.rewriter").pattern
+rewrite = pytest.importorskip("onnxscript.rewriter").rewrite
+
+
+# --------------------------------------------------------------------------
+# FunctionProto -> onnxscript rule interpreter (the shared source of truth).
+# Supports the subset these tests use: single-output nodes, value inputs, and
+# concrete attributes. That is enough for the MatMul+Add -> Gemm rule below.
+# --------------------------------------------------------------------------
+def _interp(op, fp, env):
+    env = dict(env)
+    for node in fp.node:
+        assert len(node.output) == 1, "interpreter supports single-output nodes only"
+        inputs = [env[name] for name in node.input]
+        attrs = {}
+        for attr in node.attribute:
+            assert not attr.ref_attr_name, "interpreter supports concrete attrs only"
+            attrs[attr.name] = helper.get_attribute_value(attr)
+        env[node.output[0]] = getattr(op, node.op_type)(*inputs, **attrs)
+    outs = tuple(env[o] for o in fp.output)
+    return outs[0] if len(outs) == 1 else outs
+
+
+def _to_callable(fp):
+    ns = {"_interp": _interp, "_fp": fp}
+    params = ", ".join(fp.input)
+    env_lit = ", ".join(f"{name!r}: {name}" for name in fp.input)
+    src = f"def _rule(op, {params}):\n    return _interp(op, _fp, {{{env_lit}}})\n"
+    exec(src, ns)  # noqa: S102 - trusted, generated from our own FunctionProto
+    return ns["_rule"]
+
+
+def _onnxscript_rules(pattern_fp, replacement_fp):
+    rule = pattern_mod.RewriteRule(
+        _to_callable(pattern_fp), _to_callable(replacement_fp)
+    )
+    return pattern_mod.RewriteRuleSet([rule])
+
+
+def _all_op_types(model):
+    """Op-type counts across the main graph AND every nested subgraph body."""
+    counts = collections.Counter()
+
+    def walk(graph):
+        for node in graph.node:
+            counts[node.op_type] += 1
+            for attr in node.attribute:
+                if attr.HasField("g"):
+                    walk(attr.g)
+                for subgraph in attr.graphs:
+                    walk(subgraph)
+
+    walk(model.graph)
+    return counts
+
+
+_PATTERN = parser.parse_function(
+    """
+<domain: "com.onnxsim.test", opset_import: ["" : 18]>
+matmul_add_pattern (x, w, b) => (y)
+{
+    t = MatMul(x, w)
+    y = Add(t, b)
+}
+"""
+)
+_REPLACEMENT = parser.parse_function(
+    """
+<domain: "com.onnxsim.test", opset_import: ["" : 18]>
+gemm_replacement (x, w, b) => (y)
+{
+    y = Gemm(x, w, b)
+}
+"""
+)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _vi(name, shape):
+    return helper.make_tensor_value_info(name, onnx.TensorProto.FLOAT, shape)
+
+
+# ==========================================================================
+# Parity: on a plain main-graph pattern, both engines produce the same fusion.
+# ==========================================================================
+def test_parity_matmul_add_to_gemm():
+    def build():
+        nodes = [
+            helper.make_node("MatMul", ["x", "W"], ["mm"]),
+            helper.make_node("Add", ["mm", "B"], ["y"]),
+        ]
+        inits = [_f32(np.random.randn(4, 5), "W"), _f32(np.random.randn(5), "B")]
+        graph = helper.make_graph(
+            nodes, "g", [_vi("x", [3, 4])], [_vi("y", [3, 5])], inits
+        )
+        return helper.make_model(
+            graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+        )
+
+    ours, _ = onnxsim.simplify(
+        build(), check_n=0, function_rewrite_rules=[(_PATTERN, _REPLACEMENT)]
+    )
+    theirs = rewrite(
+        build(), pattern_rewrite_rules=_onnxscript_rules(_PATTERN, _REPLACEMENT)
+    )
+
+    assert _all_op_types(ours)["Gemm"] == 1
+    assert _all_op_types(theirs)["Gemm"] == 1
+    # Same structural outcome from the same FunctionProto.
+    assert _all_op_types(ours)["MatMul"] == _all_op_types(theirs)["MatMul"] == 0
+    assert _all_op_types(ours)["Add"] == _all_op_types(theirs)["Add"] == 0
+
+
+# ==========================================================================
+# Limitation: onnxsim's matcher only traverses the main graph, so a pattern
+# living inside an If-branch subgraph is rewritten by onnxscript but NOT by
+# onnxsim. This is asserted (not xfail) so the boundary is explicit: if a future
+# version starts traversing subgraphs, this test flips and must be updated.
+# ==========================================================================
+def _model_with_pattern_in_subgraph():
+    then_nodes = [
+        helper.make_node("MatMul", ["x", "W"], ["mm"]),
+        helper.make_node("Add", ["mm", "B"], ["tb"]),
+    ]
+    then_g = helper.make_graph(then_nodes, "then", [], [_vi("tb", [3, 5])])
+    else_g = helper.make_graph(
+        [helper.make_node("Identity", ["B2"], ["eb"])], "else", [], [_vi("eb", [3, 5])]
+    )
+    nodes = [
+        helper.make_node("If", ["cond"], ["y"], then_branch=then_g, else_branch=else_g)
+    ]
+    inits = [
+        _f32(np.random.randn(4, 5), "W"),
+        _f32(np.random.randn(5), "B"),
+        _f32(np.random.randn(3, 5), "B2"),
+        _f32(np.random.randn(3, 4), "x"),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "g",
+        [helper.make_tensor_value_info("cond", onnx.TensorProto.BOOL, [])],
+        [_vi("y", [3, 5])],
+        inits,
+    )
+    return helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 18)], ir_version=10
+    )
+
+
+def test_limitation_subgraph_body_not_traversed():
+    # onnxscript rewrites inside the If branch...
+    theirs = rewrite(
+        _model_with_pattern_in_subgraph(),
+        pattern_rewrite_rules=_onnxscript_rules(_PATTERN, _REPLACEMENT),
+    )
+    theirs_counts = _all_op_types(theirs)
+    assert theirs_counts["Gemm"] == 1, theirs_counts
+    assert theirs_counts["MatMul"] == 0 and theirs_counts["Add"] == 0, theirs_counts
+
+    # ...but onnxsim's FunctionProto matcher only looks at the main graph, so the
+    # MatMul+Add inside the branch is left untouched. (Constant folding / shape
+    # inference do not fuse this, so the ops survive.)
+    ours, _ = onnxsim.simplify(
+        _model_with_pattern_in_subgraph(),
+        check_n=0,
+        skip_constant_folding=True,
+        function_rewrite_rules=[(_PATTERN, _REPLACEMENT)],
+    )
+    ours_counts = _all_op_types(ours)
+    assert ours_counts["Gemm"] == 0, ours_counts
+    assert ours_counts["MatMul"] == 1 and ours_counts["Add"] == 1, ours_counts


### PR DESCRIPTION
## Summary

This PR introduces a data-driven pattern rewriting system to onnxsim that works across all language bindings (Python, C, and Rust). Instead of relying on Python callables, rewrite rules are now expressed as pure protobuf data—pairs of `onnx.FunctionProto` objects—allowing the same rule set to be used from any binding.

## Key Changes

- **New C++ pattern matcher** (`function_rewriter.cpp/h`): Implements a sophisticated DAG pattern matcher supporting:
  - Wildcard inputs that bind to host graph values
  - Arbitrary connected DAG patterns with multiple outputs
  - Attribute matching with wildcards via `ref_attr_name`
  - Commutative operand reordering for binary ops (Add, Mul, etc.)
  - Constant value matching against initializers
  - Safety checks to prevent breaking unrelated graph consumers

- **Python API** (`onnxsim.py`): Added `function_rewrite_rules` parameter to `simplify()` accepting a sequence of `(pattern, replacement)` FunctionProto pairs. Mutually exclusive with `custom_rewriter`.

- **C API** (`onnxsim_c_api.h/cpp`): New `onnxsim_simplify_with_rules()` function accepting serialized FunctionProto rule pairs, enabling rule-based rewriting from C code.

- **Rust bindings** (`rust/onnxsim/src/lib.rs`): Added `function_rewrite_rule()` builder method and `onnxsim_simplify_with_rules()` FFI binding. Path-based API rejects non-empty rule sets with validation.

- **Comprehensive tests**:
  - `test_function_rewriter.py`: Tests core functionality (MatMul+Add→Gemm fusion, commutative matching, attribute wildcards, constant matching, safety checks)
  - `test_function_rewriter_vs_onnxscript.py`: Differential testing against onnxscript's rewriter to verify parity and document intentional limitations

- **Documentation** (README.md): Added section explaining FunctionProto rules with examples, showing how to replace built-in optimizer passes.

## Notable Implementation Details

- Rules are applied inside the simplification fixed point, allowing fusions to unlock further optimizations
- Pattern matching uses a read-only host graph index for efficient lookups
- Interior values are renamed with a collision-free prefix to guarantee freshness
- Opset imports are automatically added for replacement nodes
- Matched nodes are deleted and replacements spliced at the last matched position to maintain topological order
- First-version limitations documented: main graph only (no subgraph traversal), exact input arity matching, no attribute predicates

https://claude.ai/code/session_017TToRLd9LR66aE5WMi75Pu