### PR TITLE
Add custom graph rewriter support to C API and Rust bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,35 @@ A few things to keep in mind:
   pass over `model.graph`, an [onnx-graphsurgeon](https://github.com/NVIDIA/TensorRT/tree/main/tools/onnx-graphsurgeon)
   edit, etc. — as long as it takes and returns a `ModelProto`.
 
+### From the C API and Rust
+
+The custom rewriter lives in onnxsim's C++ core, so the C API and its Rust
+wrapper expose it too — the model is exchanged as serialized `ModelProto` bytes
+across the boundary instead of as an `onnx.ModelProto` object. In Rust, use
+[`simplify_with_rewriter`](rust/onnxsim) (or `simplify_path_with_rewriter`) and
+pass a closure `FnMut(&[u8]) -> Result<Option<Vec<u8>>, E>`: return `Ok(None)`
+when a round rewrote nothing (onnxsim skips the copy, matching the Python
+`False` sentinel), `Ok(Some(bytes))` for the rewritten model, or `Err(..)` to
+abort.
+
+```rust
+let simplified = onnxsim::simplify_with_rewriter(
+    &model_bytes,
+    &onnxsim::Options::new(),
+    |bytes: &[u8]| {
+        // Decode `bytes`, rewrite, and return the new bytes — or Ok(None).
+        let _ = bytes;
+        Ok::<_, onnxsim::Error>(None)
+    },
+)?;
+```
+
+In C, pass an `OnnxsimRewriteFn` callback (and an optional matching free
+callback) to `onnxsim_simplify` / `onnxsim_simplify_path`; see
+[`onnxsim/capi/onnxsim_c_api.h`](onnxsim/capi/onnxsim_c_api.h) for the contract.
+The only binding without it is the standalone CLI, which has no way to carry a
+user callback.
+
 ## Projects Using ONNX Simplifier
 
 * [MXNet](https://mxnet.apache.org/versions/1.9.1/api/python/docs/tutorials/deploy/export/onnx.html#Simplify-the-exported-ONNX-model)

--- a/onnxsim/capi/onnxsim_c_api.cpp
+++ b/onnxsim/capi/onnxsim_c_api.cpp
@@ -66,6 +66,59 @@ std::optional<int> BuildTargetOpsetVersion(int target_opset_version) {
   return target_opset_version;
 }
 
+// Adapts the C rewrite callback to the C++ GraphRewriter interface, exchanging
+// models as serialized ModelProto bytes. Mirrors the Python
+// `_GraphRewriterAdapter`: a return of 0 means "nothing rewritten" (keep the
+// model as-is and skip a copy), > 0 means the callback produced a rewritten
+// model, and < 0 is an error.
+class CApiGraphRewriter : public GraphRewriter {
+ public:
+  CApiGraphRewriter(OnnxsimRewriteFn fn, OnnxsimRewriteFreeFn free_fn,
+                    void* user_data)
+      : fn_(fn), free_fn_(free_fn), user_data_(user_data) {}
+
+  bool _Run(onnx::ModelProto& model) const override {
+    std::string in;
+    if (!model.SerializeToString(&in)) {
+      throw std::runtime_error(
+          "failed to serialize the model for the custom rewriter");
+    }
+    void* out_data = nullptr;
+    size_t out_size = 0;
+    const int rc = fn_(user_data_, in.data(), in.size(), &out_data, &out_size);
+    if (rc < 0) {
+      throw std::runtime_error("the custom rewriter callback reported an error");
+    }
+    if (rc == 0) {
+      // Nothing was rewritten this round: keep the model unchanged.
+      return false;
+    }
+    if (out_data == nullptr) {
+      throw std::runtime_error(
+          "the custom rewriter reported a rewrite but returned no model");
+    }
+    onnx::ModelProto rewritten;
+    const bool parsed = ParseProtoFromBytes(
+        &rewritten, static_cast<const char*>(out_data), out_size);
+    // Release the callback-owned buffer regardless of whether it parsed.
+    if (free_fn_ != nullptr) {
+      free_fn_(user_data_, out_data, out_size);
+    }
+    if (!parsed) {
+      throw std::runtime_error(
+          "the custom rewriter returned bytes that are not a valid ONNX "
+          "ModelProto");
+    }
+    model.Swap(&rewritten);
+    return true;
+  }
+
+ private:
+  OnnxsimRewriteFn fn_;
+  OnnxsimRewriteFreeFn free_fn_;
+  void* user_data_;
+};
+
 }  // namespace
 
 extern "C" {
@@ -76,7 +129,10 @@ OnnxsimStatus onnxsim_simplify(const void* model_data, size_t model_size,
                                int skip_optimizers_is_null,
                                int constant_folding, int shape_inference,
                                size_t tensor_size_threshold,
-                               int target_opset_version, void** out_data,
+                               int target_opset_version,
+                               OnnxsimRewriteFn rewrite_fn,
+                               OnnxsimRewriteFreeFn rewrite_free_fn,
+                               void* rewrite_user_data, void** out_data,
                                size_t* out_size, char** out_error) {
   if (out_data != nullptr) {
     *out_data = nullptr;
@@ -100,12 +156,19 @@ OnnxsimStatus onnxsim_simplify(const void* model_data, size_t model_size,
       SetError(out_error, "failed to parse ONNX ModelProto from input bytes");
       return ONNXSIM_ERROR;
     }
+    std::optional<CApiGraphRewriter> rewriter;
+    if (rewrite_fn != nullptr) {
+      rewriter.emplace(rewrite_fn, rewrite_free_fn, rewrite_user_data);
+    }
+    const GraphRewriter* rewriter_ptr =
+        rewriter.has_value() ? &rewriter.value() : nullptr;
+
     onnx::ModelProto result = Simplify(
         *GetBuiltinModelExecutor(), model,
         BuildSkipOptimizers(skip_optimizers, num_skip_optimizers,
                             skip_optimizers_is_null),
         constant_folding != 0, shape_inference != 0, tensor_size_threshold,
-        BuildTargetOpsetVersion(target_opset_version));
+        BuildTargetOpsetVersion(target_opset_version), rewriter_ptr);
 
     std::string out;
     if (!result.SerializeToString(&out)) {
@@ -137,7 +200,9 @@ OnnxsimStatus onnxsim_simplify_path(
     const char* in_path, const char* out_path,
     const char* const* skip_optimizers, size_t num_skip_optimizers,
     int skip_optimizers_is_null, int constant_folding, int shape_inference,
-    size_t tensor_size_threshold, int target_opset_version, char** out_error) {
+    size_t tensor_size_threshold, int target_opset_version,
+    OnnxsimRewriteFn rewrite_fn, OnnxsimRewriteFreeFn rewrite_free_fn,
+    void* rewrite_user_data, char** out_error) {
   if (out_error != nullptr) {
     *out_error = nullptr;
   }
@@ -147,12 +212,19 @@ OnnxsimStatus onnxsim_simplify_path(
   }
   try {
     InitEnv();
+    std::optional<CApiGraphRewriter> rewriter;
+    if (rewrite_fn != nullptr) {
+      rewriter.emplace(rewrite_fn, rewrite_free_fn, rewrite_user_data);
+    }
+    const GraphRewriter* rewriter_ptr =
+        rewriter.has_value() ? &rewriter.value() : nullptr;
+
     SimplifyPath(*GetBuiltinModelExecutor(), in_path, out_path,
                  BuildSkipOptimizers(skip_optimizers, num_skip_optimizers,
                                      skip_optimizers_is_null),
                  constant_folding != 0, shape_inference != 0,
                  tensor_size_threshold,
-                 BuildTargetOpsetVersion(target_opset_version));
+                 BuildTargetOpsetVersion(target_opset_version), rewriter_ptr);
     return ONNXSIM_OK;
   } catch (const std::exception& e) {
     SetError(out_error, e.what());

--- a/onnxsim/capi/onnxsim_c_api.cpp
+++ b/onnxsim/capi/onnxsim_c_api.cpp
@@ -87,7 +87,8 @@ class CApiGraphRewriter : public GraphRewriter {
     size_t out_size = 0;
     const int rc = fn_(user_data_, in.data(), in.size(), &out_data, &out_size);
     if (rc < 0) {
-      throw std::runtime_error("the custom rewriter callback reported an error");
+      throw std::runtime_error(
+          "the custom rewriter callback reported an error");
     }
     if (rc == 0) {
       // Nothing was rewritten this round: keep the model unchanged.
@@ -123,17 +124,14 @@ class CApiGraphRewriter : public GraphRewriter {
 
 extern "C" {
 
-OnnxsimStatus onnxsim_simplify(const void* model_data, size_t model_size,
-                               const char* const* skip_optimizers,
-                               size_t num_skip_optimizers,
-                               int skip_optimizers_is_null,
-                               int constant_folding, int shape_inference,
-                               size_t tensor_size_threshold,
-                               int target_opset_version,
-                               OnnxsimRewriteFn rewrite_fn,
-                               OnnxsimRewriteFreeFn rewrite_free_fn,
-                               void* rewrite_user_data, void** out_data,
-                               size_t* out_size, char** out_error) {
+OnnxsimStatus onnxsim_simplify(
+    const void* model_data, size_t model_size,
+    const char* const* skip_optimizers, size_t num_skip_optimizers,
+    int skip_optimizers_is_null, int constant_folding, int shape_inference,
+    size_t tensor_size_threshold, int target_opset_version,
+    OnnxsimRewriteFn rewrite_fn, OnnxsimRewriteFreeFn rewrite_free_fn,
+    void* rewrite_user_data, void** out_data, size_t* out_size,
+    char** out_error) {
   if (out_data != nullptr) {
     *out_data = nullptr;
   }

--- a/onnxsim/capi/onnxsim_c_api.h
+++ b/onnxsim/capi/onnxsim_c_api.h
@@ -33,6 +33,44 @@ typedef enum OnnxsimStatus {
 } OnnxsimStatus;
 
 /*
+ * Optional custom graph-rewriter callback.
+ *
+ * When supplied to onnxsim_simplify / onnxsim_simplify_path it is run inside
+ * onnxsim's simplification fixed point, interleaved with the built-in optimizer,
+ * shape inference and constant folding, so a rewrite can unlock further
+ * simplification and vice versa. It mirrors the C++ `GraphRewriter` and the
+ * Python `custom_rewriter` parameter, exchanging models as serialized ONNX
+ * ModelProto bytes across the C boundary.
+ *
+ * On each round it is called with the current model in `in_model_data`
+ * (`in_model_size` bytes) and must return:
+ *   - a value > 0 : the model was rewritten. `*out_model_data`/`*out_model_size`
+ *     must be set to a newly allocated buffer holding the rewritten serialized
+ *     ModelProto. onnxsim parses it and then, if a free callback was supplied,
+ *     calls it with exactly that pointer and size to release the buffer.
+ *   - 0           : nothing was rewritten this round. The out-parameters are
+ *     ignored and onnxsim keeps the model it already has (skipping a copy).
+ *   - a value < 0 : the callback failed; simplification aborts with
+ *     ONNXSIM_ERROR.
+ *
+ * `user_data` is passed through untouched on every call (both the rewrite and
+ * the free callback). Passing a NULL rewrite callback disables the feature and
+ * reproduces the previous behaviour exactly.
+ */
+typedef int (*OnnxsimRewriteFn)(void* user_data, const void* in_model_data,
+                                size_t in_model_size, void** out_model_data,
+                                size_t* out_model_size);
+
+/*
+ * Releases a buffer produced by an OnnxsimRewriteFn. Called with the same
+ * `user_data` and with the `out_model_data`/`out_model_size` the rewrite
+ * callback returned, once onnxsim has finished parsing it. May be NULL, in
+ * which case onnxsim never frees the rewriter's output (the callback owns it).
+ */
+typedef void (*OnnxsimRewriteFreeFn)(void* user_data, void* model_data,
+                                     size_t model_size);
+
+/*
  * Simplify a model given as a serialized ONNX ModelProto.
  *
  * skip_optimizers semantics mirror the C++/Python API:
@@ -51,6 +89,11 @@ typedef enum OnnxsimStatus {
  * the default ONNX domain (using onnx's version converter) before simplifying;
  * a value <= 0 leaves the opset version unchanged.
  *
+ * rewrite_fn, when non-NULL, is a custom graph rewriter run inside the
+ * simplification fixed point (see OnnxsimRewriteFn). rewrite_free_fn releases
+ * the buffers it produces (may be NULL). rewrite_user_data is passed through to
+ * both callbacks untouched. Pass a NULL rewrite_fn to disable the feature.
+ *
  * On ONNXSIM_OK, *out_data / *out_size receive a newly allocated buffer holding
  * the serialized simplified ModelProto; release it with onnxsim_free_buffer.
  * On ONNXSIM_ERROR, *out_error receives a newly allocated, NUL-terminated
@@ -61,8 +104,10 @@ ONNXSIM_C_API OnnxsimStatus onnxsim_simplify(
     const void* model_data, size_t model_size,
     const char* const* skip_optimizers, size_t num_skip_optimizers,
     int skip_optimizers_is_null, int constant_folding, int shape_inference,
-    size_t tensor_size_threshold, int target_opset_version, void** out_data,
-    size_t* out_size, char** out_error);
+    size_t tensor_size_threshold, int target_opset_version,
+    OnnxsimRewriteFn rewrite_fn, OnnxsimRewriteFreeFn rewrite_free_fn,
+    void* rewrite_user_data, void** out_data, size_t* out_size,
+    char** out_error);
 
 /*
  * Same as onnxsim_simplify, but reads the input model from `in_path` and writes
@@ -73,7 +118,9 @@ ONNXSIM_C_API OnnxsimStatus onnxsim_simplify_path(
     const char* in_path, const char* out_path,
     const char* const* skip_optimizers, size_t num_skip_optimizers,
     int skip_optimizers_is_null, int constant_folding, int shape_inference,
-    size_t tensor_size_threshold, int target_opset_version, char** out_error);
+    size_t tensor_size_threshold, int target_opset_version,
+    OnnxsimRewriteFn rewrite_fn, OnnxsimRewriteFreeFn rewrite_free_fn,
+    void* rewrite_user_data, char** out_error);
 
 /*
  * Return the names of all available fuse/elimination optimizer passes as a

--- a/onnxsim/capi/onnxsim_c_api.h
+++ b/onnxsim/capi/onnxsim_c_api.h
@@ -36,18 +36,19 @@ typedef enum OnnxsimStatus {
  * Optional custom graph-rewriter callback.
  *
  * When supplied to onnxsim_simplify / onnxsim_simplify_path it is run inside
- * onnxsim's simplification fixed point, interleaved with the built-in optimizer,
- * shape inference and constant folding, so a rewrite can unlock further
- * simplification and vice versa. It mirrors the C++ `GraphRewriter` and the
- * Python `custom_rewriter` parameter, exchanging models as serialized ONNX
+ * onnxsim's simplification fixed point, interleaved with the built-in
+ * optimizer, shape inference and constant folding, so a rewrite can unlock
+ * further simplification and vice versa. It mirrors the C++ `GraphRewriter` and
+ * the Python `custom_rewriter` parameter, exchanging models as serialized ONNX
  * ModelProto bytes across the C boundary.
  *
  * On each round it is called with the current model in `in_model_data`
  * (`in_model_size` bytes) and must return:
- *   - a value > 0 : the model was rewritten. `*out_model_data`/`*out_model_size`
- *     must be set to a newly allocated buffer holding the rewritten serialized
- *     ModelProto. onnxsim parses it and then, if a free callback was supplied,
- *     calls it with exactly that pointer and size to release the buffer.
+ *   - a value > 0 : the model was rewritten.
+ * `*out_model_data`/`*out_model_size` must be set to a newly allocated buffer
+ * holding the rewritten serialized ModelProto. onnxsim parses it and then, if a
+ * free callback was supplied, calls it with exactly that pointer and size to
+ * release the buffer.
  *   - 0           : nothing was rewritten this round. The out-parameters are
  *     ignored and onnxsim keeps the model it already has (skipping a copy).
  *   - a value < 0 : the callback failed; simplification aborts with
@@ -100,14 +101,14 @@ typedef void (*OnnxsimRewriteFreeFn)(void* user_data, void* model_data,
  * message; release it with onnxsim_free_string. Either out_* pointer may be
  * NULL if the caller does not want that value.
  */
-ONNXSIM_C_API OnnxsimStatus onnxsim_simplify(
-    const void* model_data, size_t model_size,
-    const char* const* skip_optimizers, size_t num_skip_optimizers,
-    int skip_optimizers_is_null, int constant_folding, int shape_inference,
-    size_t tensor_size_threshold, int target_opset_version,
-    OnnxsimRewriteFn rewrite_fn, OnnxsimRewriteFreeFn rewrite_free_fn,
-    void* rewrite_user_data, void** out_data, size_t* out_size,
-    char** out_error);
+ONNXSIM_C_API OnnxsimStatus
+onnxsim_simplify(const void* model_data, size_t model_size,
+                 const char* const* skip_optimizers, size_t num_skip_optimizers,
+                 int skip_optimizers_is_null, int constant_folding,
+                 int shape_inference, size_t tensor_size_threshold,
+                 int target_opset_version, OnnxsimRewriteFn rewrite_fn,
+                 OnnxsimRewriteFreeFn rewrite_free_fn, void* rewrite_user_data,
+                 void** out_data, size_t* out_size, char** out_error);
 
 /*
  * Same as onnxsim_simplify, but reads the input model from `in_path` and writes

--- a/rust/README.md
+++ b/rust/README.md
@@ -69,6 +69,34 @@ for name in onnxsim::list_optimizers() {
 }
 ```
 
+## Custom rewriter
+
+Run your own graph-rewriting logic inside the simplification fixed point — the
+Rust equivalent of the Python `custom_rewriter` parameter. The closure is called
+each round with the current model as serialized `ModelProto` bytes and returns
+`Ok(None)` (nothing changed this round), `Ok(Some(bytes))` (the rewritten
+model), or `Err(..)` to abort. Because it is interleaved with the built-in
+optimizer, shape inference and constant folding, a rewrite can unlock further
+simplification and vice versa.
+
+```rust
+fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let model = std::fs::read("model.onnx")?;
+    let simplified = onnxsim::simplify_with_rewriter(
+        &model,
+        &onnxsim::Options::new(),
+        |bytes: &[u8]| {
+            // Decode `bytes`, rewrite the graph, and return the new bytes,
+            // or `Ok(None)` to report that nothing changed this round.
+            let _ = bytes;
+            Ok::<_, onnxsim::Error>(None)
+        },
+    )?;
+    std::fs::write("model.opt.onnx", &simplified)?;
+    Ok(())
+}
+```
+
 ## Building the native library
 
 `onnxsim-sys` needs the `onnxsim_c` shared library. Its build script supports

--- a/rust/onnxsim-sys/src/lib.rs
+++ b/rust/onnxsim-sys/src/lib.rs
@@ -18,6 +18,26 @@ pub const ONNXSIM_OK: c_int = 0;
 /// Failure return code; an error message is written to the `out_error` slot.
 pub const ONNXSIM_ERROR: c_int = 1;
 
+/// Custom graph-rewriter callback (mirrors `OnnxsimRewriteFn` in the C header).
+///
+/// Invoked once per fixed-point round with the current model as serialized
+/// ModelProto bytes (`in_model_data`/`in_model_size`). Returns `> 0` after
+/// setting `*out_model_data`/`*out_model_size` to a newly allocated buffer with
+/// the rewritten model, `0` to report that nothing changed, or `< 0` on error.
+pub type OnnxsimRewriteFn = unsafe extern "C" fn(
+    user_data: *mut c_void,
+    in_model_data: *const c_void,
+    in_model_size: usize,
+    out_model_data: *mut *mut c_void,
+    out_model_size: *mut usize,
+) -> c_int;
+
+/// Frees a buffer produced by an [`OnnxsimRewriteFn`] (mirrors
+/// `OnnxsimRewriteFreeFn`). Called with the same `user_data` and the pointer and
+/// size the rewrite callback returned, once onnxsim has parsed it.
+pub type OnnxsimRewriteFreeFn =
+    unsafe extern "C" fn(user_data: *mut c_void, model_data: *mut c_void, model_size: usize);
+
 extern "C" {
     /// Simplify a serialized ONNX `ModelProto`.
     ///
@@ -31,7 +51,9 @@ extern "C" {
     /// # Safety
     /// All non-null pointers must be valid; `model_data` must point to at least
     /// `model_size` bytes and `skip_optimizers` to `num_skip_optimizers`
-    /// NUL-terminated strings when `skip_optimizers_is_null == 0`.
+    /// NUL-terminated strings when `skip_optimizers_is_null == 0`. When
+    /// `rewrite_fn` is `Some`, it (and the matching `rewrite_free_fn`) must obey
+    /// the callback contract in `onnxsim_c_api.h`.
     pub fn onnxsim_simplify(
         model_data: *const c_void,
         model_size: usize,
@@ -42,6 +64,9 @@ extern "C" {
         shape_inference: c_int,
         tensor_size_threshold: usize,
         target_opset_version: c_int,
+        rewrite_fn: Option<OnnxsimRewriteFn>,
+        rewrite_free_fn: Option<OnnxsimRewriteFreeFn>,
+        rewrite_user_data: *mut c_void,
         out_data: *mut *mut c_void,
         out_size: *mut usize,
         out_error: *mut *mut c_char,
@@ -51,7 +76,8 @@ extern "C" {
     ///
     /// # Safety
     /// `in_path`/`out_path` must be valid NUL-terminated paths; the
-    /// `skip_optimizers` rules match [`onnxsim_simplify`].
+    /// `skip_optimizers` and `rewrite_fn`/`rewrite_free_fn` rules match
+    /// [`onnxsim_simplify`].
     pub fn onnxsim_simplify_path(
         in_path: *const c_char,
         out_path: *const c_char,
@@ -62,6 +88,9 @@ extern "C" {
         shape_inference: c_int,
         tensor_size_threshold: usize,
         target_opset_version: c_int,
+        rewrite_fn: Option<OnnxsimRewriteFn>,
+        rewrite_free_fn: Option<OnnxsimRewriteFreeFn>,
+        rewrite_user_data: *mut c_void,
         out_error: *mut *mut c_char,
     ) -> c_int;
 

--- a/rust/onnxsim/src/lib.rs
+++ b/rust/onnxsim/src/lib.rs
@@ -46,6 +46,35 @@
 //!     Ok(())
 //! }
 //! ```
+//!
+//! # Custom rewriter
+//!
+//! [`simplify_with_rewriter`] (and [`simplify_path_with_rewriter`]) run a
+//! closure of yours inside the simplification fixed point — the Rust equivalent
+//! of the Python `custom_rewriter` parameter. The closure receives the current
+//! model as serialized `ModelProto` bytes each round and returns `Ok(None)`
+//! (nothing changed), `Ok(Some(bytes))` (rewritten model), or `Err(..)` to
+//! abort. Because it is interleaved with the built-in optimizer, shape inference
+//! and constant folding, a rewrite can unlock further simplification and vice
+//! versa.
+//!
+//! ```no_run
+//! fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+//!     let model = std::fs::read("model.onnx")?;
+//!     let simplified = onnxsim::simplify_with_rewriter(
+//!         &model,
+//!         &onnxsim::Options::new(),
+//!         |bytes: &[u8]| {
+//!             // Decode `bytes`, rewrite the graph with your library of choice,
+//!             // and return the new bytes — or `Ok(None)` to change nothing.
+//!             let _ = bytes;
+//!             Ok::<_, onnxsim::Error>(None)
+//!         },
+//!     )?;
+//!     let _ = simplified;
+//!     Ok(())
+//! }
+//! ```
 
 use std::ffi::{CStr, CString};
 use std::fmt;
@@ -206,6 +235,9 @@ pub fn simplify_with(model_bytes: &[u8], options: &Options) -> Result<Vec<u8>, E
             bool_to_c(options.shape_inference),
             options.tensor_size_threshold,
             target_opset_to_c(options.target_opset_version),
+            None,
+            None,
+            ptr::null_mut(),
             &mut out_data,
             &mut out_size,
             &mut out_error,
@@ -255,6 +287,9 @@ pub fn simplify_path_with<P: AsRef<Path>, Q: AsRef<Path>>(
             bool_to_c(options.shape_inference),
             options.tensor_size_threshold,
             target_opset_to_c(options.target_opset_version),
+            None,
+            None,
+            ptr::null_mut(),
             &mut out_error,
         )
     };
@@ -263,6 +298,233 @@ pub fn simplify_path_with<P: AsRef<Path>, Q: AsRef<Path>>(
         Ok(())
     } else {
         Err(take_error(out_error))
+    }
+}
+
+/// Error a custom rewriter closure may return. Any type convertible into a
+/// boxed [`std::error::Error`] works, including this crate's [`Error`].
+pub type RewriterError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Type-erased rewriter closure: `Ok(None)` => nothing rewritten this round,
+/// `Ok(Some(bytes))` => rewritten model, `Err` => abort simplification.
+type RewriteCallback<'a> = dyn FnMut(&[u8]) -> Result<Option<Vec<u8>>, RewriterError> + 'a;
+
+/// Holds the (type-erased) user closure and captures failures that cannot cross
+/// the FFI boundary as a return value. A single, non-generic pair of trampolines
+/// therefore serves every closure.
+struct RewriterState<'a> {
+    callback: &'a mut RewriteCallback<'a>,
+    error: Option<RewriterError>,
+    panicked: bool,
+}
+
+/// `extern "C"` shim matching [`onnxsim_sys::OnnxsimRewriteFn`]. Recovers the
+/// `RewriterState` from `user_data`, runs the closure under `catch_unwind` (an
+/// unwind across the C frames would be undefined behaviour), and translates its
+/// outcome into the C return convention.
+unsafe extern "C" fn rewrite_trampoline(
+    user_data: *mut c_void,
+    in_model_data: *const c_void,
+    in_model_size: usize,
+    out_model_data: *mut *mut c_void,
+    out_model_size: *mut usize,
+) -> c_int {
+    let state = &mut *(user_data as *mut RewriterState);
+    let input: &[u8] = if in_model_size == 0 {
+        &[]
+    } else {
+        std::slice::from_raw_parts(in_model_data as *const u8, in_model_size)
+    };
+    let outcome =
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| (state.callback)(input)));
+    match outcome {
+        Ok(Ok(None)) => 0,
+        Ok(Ok(Some(bytes))) => {
+            // Hand ownership of the buffer to the C core; it is returned to
+            // `rewrite_free_trampoline` (with this exact length) after parsing.
+            let boxed = bytes.into_boxed_slice();
+            *out_model_size = boxed.len();
+            *out_model_data = Box::into_raw(boxed) as *mut c_void;
+            1
+        }
+        Ok(Err(e)) => {
+            state.error = Some(e);
+            -1
+        }
+        Err(_) => {
+            state.panicked = true;
+            -1
+        }
+    }
+}
+
+/// `extern "C"` shim matching [`onnxsim_sys::OnnxsimRewriteFreeFn`]. Reclaims a
+/// buffer handed out by [`rewrite_trampoline`] using the length the C core
+/// passes back.
+unsafe extern "C" fn rewrite_free_trampoline(
+    _user_data: *mut c_void,
+    model_data: *mut c_void,
+    model_size: usize,
+) {
+    if !model_data.is_null() {
+        drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+            model_data as *mut u8,
+            model_size,
+        )));
+    }
+}
+
+// Map an FFI error, preferring a failure captured from the rewriter closure (it
+// is more specific than the generic C-side message). `out_error`, if set, is
+// always consumed so it cannot leak.
+fn rewriter_error(state: &mut RewriterState, out_error: *mut c_char) -> Error {
+    let c_message = if out_error.is_null() {
+        None
+    } else {
+        match take_error(out_error) {
+            Error::Simplify(msg) => Some(msg),
+            other => Some(other.to_string()),
+        }
+    };
+    if state.panicked {
+        return Error::Simplify("the custom rewriter panicked".to_string());
+    }
+    if let Some(e) = state.error.take() {
+        return Error::Simplify(format!("custom rewriter failed: {e}"));
+    }
+    Error::Simplify(c_message.unwrap_or_else(|| "unknown error (no message provided)".to_string()))
+}
+
+/// Simplify a serialized ONNX `ModelProto`, running a custom graph rewriter
+/// inside the simplification fixed point.
+///
+/// This is the Rust counterpart of the Python `custom_rewriter` parameter and
+/// the C API's rewrite callback. `rewriter` is called on each fixed-point round
+/// with the current model as serialized `ModelProto` bytes and must return:
+///
+/// * `Ok(None)` — nothing was rewritten this round (onnxsim keeps the model it
+///   already has and skips a copy);
+/// * `Ok(Some(bytes))` — the rewritten model as serialized `ModelProto` bytes;
+/// * `Err(e)` — abort simplification with this error.
+///
+/// Because the rewriter runs interleaved with the built-in optimizer, shape
+/// inference and constant folding, a rewrite can unlock further simplification
+/// and vice versa; the pipeline iterates until it converges.
+///
+/// ```no_run
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let model = std::fs::read("model.onnx")?;
+/// // A no-op rewriter that reports it changed nothing every round.
+/// let simplified = onnxsim::simplify_with_rewriter(
+///     &model,
+///     &onnxsim::Options::new(),
+///     |_bytes: &[u8]| Ok::<_, onnxsim::Error>(None),
+/// )?;
+/// # let _ = simplified;
+/// # Ok(())
+/// # }
+/// ```
+pub fn simplify_with_rewriter<F, E>(
+    model_bytes: &[u8],
+    options: &Options,
+    mut rewriter: F,
+) -> Result<Vec<u8>, Error>
+where
+    F: FnMut(&[u8]) -> Result<Option<Vec<u8>>, E>,
+    E: Into<RewriterError>,
+{
+    let mut wrapped = move |bytes: &[u8]| rewriter(bytes).map_err(Into::into);
+    let mut state = RewriterState {
+        callback: &mut wrapped,
+        error: None,
+        panicked: false,
+    };
+    let ffi = FfiSkipOptimizers::new(options)?;
+
+    let mut out_data: *mut c_void = ptr::null_mut();
+    let mut out_size: usize = 0;
+    let mut out_error: *mut c_char = ptr::null_mut();
+
+    let status = unsafe {
+        onnxsim_sys::onnxsim_simplify(
+            model_bytes.as_ptr() as *const c_void,
+            model_bytes.len(),
+            ffi.ptr(),
+            ffi.len(),
+            ffi.is_null_flag(),
+            bool_to_c(options.constant_folding),
+            bool_to_c(options.shape_inference),
+            options.tensor_size_threshold,
+            target_opset_to_c(options.target_opset_version),
+            Some(rewrite_trampoline),
+            Some(rewrite_free_trampoline),
+            &mut state as *mut RewriterState as *mut c_void,
+            &mut out_data,
+            &mut out_size,
+            &mut out_error,
+        )
+    };
+
+    if status == onnxsim_sys::ONNXSIM_OK {
+        let result =
+            unsafe { std::slice::from_raw_parts(out_data as *const u8, out_size) }.to_vec();
+        unsafe { onnxsim_sys::onnxsim_free_buffer(out_data) };
+        Ok(result)
+    } else {
+        Err(rewriter_error(&mut state, out_error))
+    }
+}
+
+/// Simplify the model at `input_path`, writing the result to `output_path`,
+/// running a custom graph rewriter inside the simplification fixed point.
+///
+/// See [`simplify_with_rewriter`] for the `rewriter` contract.
+pub fn simplify_path_with_rewriter<P, Q, F, E>(
+    input_path: P,
+    output_path: Q,
+    options: &Options,
+    mut rewriter: F,
+) -> Result<(), Error>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
+    F: FnMut(&[u8]) -> Result<Option<Vec<u8>>, E>,
+    E: Into<RewriterError>,
+{
+    let in_c = path_to_cstring(input_path.as_ref())?;
+    let out_c = path_to_cstring(output_path.as_ref())?;
+
+    let mut wrapped = move |bytes: &[u8]| rewriter(bytes).map_err(Into::into);
+    let mut state = RewriterState {
+        callback: &mut wrapped,
+        error: None,
+        panicked: false,
+    };
+    let ffi = FfiSkipOptimizers::new(options)?;
+
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let status = unsafe {
+        onnxsim_sys::onnxsim_simplify_path(
+            in_c.as_ptr(),
+            out_c.as_ptr(),
+            ffi.ptr(),
+            ffi.len(),
+            ffi.is_null_flag(),
+            bool_to_c(options.constant_folding),
+            bool_to_c(options.shape_inference),
+            options.tensor_size_threshold,
+            target_opset_to_c(options.target_opset_version),
+            Some(rewrite_trampoline),
+            Some(rewrite_free_trampoline),
+            &mut state as *mut RewriterState as *mut c_void,
+            &mut out_error,
+        )
+    };
+
+    if status == onnxsim_sys::ONNXSIM_OK {
+        Ok(())
+    } else {
+        Err(rewriter_error(&mut state, out_error))
     }
 }
 
@@ -446,5 +708,98 @@ mod tests {
             FfiSkipOptimizers::new(&opts),
             Err(Error::InvalidArgument(_))
         ));
+    }
+
+    // The rewriter trampolines are pure Rust (no FFI into the native library),
+    // so their translation of a closure's outcome to the C return convention —
+    // and the buffer hand-off/reclaim — can be exercised directly.
+
+    unsafe fn call_rewrite(
+        state: &mut RewriterState,
+        input: &[u8],
+        out_data: &mut *mut c_void,
+        out_size: &mut usize,
+    ) -> c_int {
+        rewrite_trampoline(
+            state as *mut RewriterState as *mut c_void,
+            input.as_ptr() as *const c_void,
+            input.len(),
+            out_data,
+            out_size,
+        )
+    }
+
+    #[test]
+    fn rewrite_trampoline_reports_unchanged() {
+        let mut cb = |_: &[u8]| Ok::<_, RewriterError>(None);
+        let mut state = RewriterState {
+            callback: &mut cb,
+            error: None,
+            panicked: false,
+        };
+        let mut out_data: *mut c_void = ptr::null_mut();
+        let mut out_size = 0usize;
+        let rc = unsafe { call_rewrite(&mut state, &[1, 2, 3], &mut out_data, &mut out_size) };
+        assert_eq!(rc, 0);
+        assert!(out_data.is_null());
+    }
+
+    #[test]
+    fn rewrite_trampoline_roundtrips_rewritten_buffer() {
+        let payload = vec![9u8, 8, 7, 6];
+        let expected = payload.clone();
+        let mut cb = move |_: &[u8]| Ok::<_, RewriterError>(Some(payload.clone()));
+        let mut state = RewriterState {
+            callback: &mut cb,
+            error: None,
+            panicked: false,
+        };
+        let mut out_data: *mut c_void = ptr::null_mut();
+        let mut out_size = 0usize;
+        let rc = unsafe { call_rewrite(&mut state, &[0], &mut out_data, &mut out_size) };
+        assert_eq!(rc, 1);
+        assert_eq!(out_size, expected.len());
+        let returned =
+            unsafe { std::slice::from_raw_parts(out_data as *const u8, out_size) }.to_vec();
+        assert_eq!(returned, expected);
+        // Reclaim through the free trampoline exactly as the C core would.
+        unsafe { rewrite_free_trampoline(ptr::null_mut(), out_data, out_size) };
+    }
+
+    #[test]
+    fn rewrite_trampoline_captures_error() {
+        let mut cb = |_: &[u8]| Err::<Option<Vec<u8>>, RewriterError>("boom".into());
+        let mut state = RewriterState {
+            callback: &mut cb,
+            error: None,
+            panicked: false,
+        };
+        let mut out_data: *mut c_void = ptr::null_mut();
+        let mut out_size = 0usize;
+        let rc = unsafe { call_rewrite(&mut state, &[0], &mut out_data, &mut out_size) };
+        assert_eq!(rc, -1);
+        let err = rewriter_error(&mut state, ptr::null_mut());
+        assert!(matches!(&err, Error::Simplify(m) if m.contains("boom")));
+    }
+
+    #[test]
+    fn rewrite_trampoline_captures_panic() {
+        let mut cb = |_: &[u8]| -> Result<Option<Vec<u8>>, RewriterError> { panic!("kaboom") };
+        let mut state = RewriterState {
+            callback: &mut cb,
+            error: None,
+            panicked: false,
+        };
+        let mut out_data: *mut c_void = ptr::null_mut();
+        let mut out_size = 0usize;
+        // Silence the default panic hook's backtrace print during the test.
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let rc = unsafe { call_rewrite(&mut state, &[0], &mut out_data, &mut out_size) };
+        std::panic::set_hook(prev);
+        assert_eq!(rc, -1);
+        assert!(state.panicked);
+        let err = rewriter_error(&mut state, ptr::null_mut());
+        assert!(matches!(&err, Error::Simplify(m) if m.contains("panicked")));
     }
 }


### PR DESCRIPTION
This PR exposes the custom graph rewriter functionality to the C API and Rust bindings, allowing users to run their own graph-rewriting logic inside onnxsim's simplification fixed point.

## Summary

The custom rewriter feature was previously only available in the Python API. This change extends it to the C API and Rust bindings by:

1. **C API changes** (`onnxsim_c_api.h` and `onnxsim_c_api.cpp`):
   - Added `OnnxsimRewriteFn` and `OnnxsimRewriteFreeFn` callback types
   - Extended `onnxsim_simplify` and `onnxsim_simplify_path` to accept optional rewrite callbacks
   - Implemented `CApiGraphRewriter` adapter class to bridge C callbacks with the C++ `GraphRewriter` interface
   - Models are exchanged as serialized `ModelProto` bytes across the C boundary

2. **Rust bindings** (`rust/onnxsim/src/lib.rs`):
   - Added `simplify_with_rewriter` and `simplify_path_with_rewriter` public functions
   - Implemented FFI trampolines (`rewrite_trampoline` and `rewrite_free_trampoline`) to safely call Rust closures from C
   - Added `RewriterState` struct to capture closure outcomes and errors that cannot cross the FFI boundary
   - Implemented panic catching via `catch_unwind` to prevent unwinding across C frames
   - Added comprehensive unit tests for the trampoline logic
   - Defined `RewriterError` type alias for flexible error handling

3. **Documentation**:
   - Added usage examples in library documentation and README files
   - Documented the rewriter contract: return `Ok(None)` for no changes, `Ok(Some(bytes))` for rewrites, or `Err(..)` to abort
   - Explained how the rewriter interleaves with built-in optimization, shape inference, and constant folding

## Key Implementation Details

- **Error handling**: Closure errors and panics are captured in `RewriterState` and converted to `Error::Simplify` after the FFI boundary
- **Memory safety**: Buffers produced by rewriters are properly handed off to C and reclaimed via the free callback
- **Flexibility**: The Rust API accepts any closure type `F: FnMut(&[u8]) -> Result<Option<Vec<u8>>, E>` where `E: Into<RewriterError>`, allowing various error types
- **Testing**: Direct unit tests of the trampolines verify correct translation of closure outcomes, buffer handling, error capture, and panic handling

https://claude.ai/code/session_01WqHpwMU5Y156nnKncjvDWw