### PR TITLE
Add ModelOpt integration tests for fp8/int8 QDQ simplification

### DIFF
--- a/.github/workflows/modelopt-integration.yml
+++ b/.github/workflows/modelopt-integration.yml
@@ -1,0 +1,91 @@
+name: ModelOpt Integration
+
+# End-to-end regression tests that quantize a model with the real NVIDIA
+# ModelOpt library (int8 and fp8 QDQ) and simplify the result with onnxsim
+# (tests/test_modelopt_integration.py). Guards the fp8 float8_e4m3fn handling
+# from GitHub issue #348 against actual ModelOpt output rather than the
+# hand-built graphs in tests/test_simple.py.
+#
+# ModelOpt drags in torch + CUDA runtime wheels and is not part of onnxsim's
+# test requirements, so this runs in its own workflow instead of the
+# build-and-test matrix. Calibration is pinned to the CPU EP, so an ordinary
+# CPU runner is enough. Runs on PRs that touch the QDQ path or this harness, on
+# a weekly schedule to catch new ModelOpt releases, and on demand.
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # Mondays 07:00 UTC (weekly)
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "tests/test_modelopt_integration.py"
+      - ".github/workflows/modelopt-integration.yml"
+      - "onnxsim/onnx_simplifier.py"
+      - "onnxsim/onnxsim.cpp"
+
+concurrency:
+  group: modelopt-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Build onnxsim once from the current tree, exactly like the model-regression
+  # workflow, and hand the wheel to the test job so it exercises this branch's
+  # code rather than a PyPI release.
+  build:
+    name: Build onnxsim wheel
+    runs-on: ubuntu-24.04
+    env:
+      SCCACHE_GHA_ENABLED: "on"
+      ACTIONS_CACHE_SERVICE_V2: "on"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - name: Build cp312 wheel
+        uses: pypa/cibuildwheel@v4.1.1
+        env:
+          CIBW_BUILD: "cp312-manylinux_x86_64"
+          CIBW_ARCHS: native
+          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_ENVIRONMENT_PASS_LINUX: CI SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN ACTIONS_CACHE_SERVICE_V2
+          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache"
+          CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF" CMAKE_GENERATOR=Ninja CMAKE_CXX_COMPILER_LAUNCHER=sccache CMAKE_LINKER_TYPE=LLD
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} --strip"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: onnxsim-wheel
+          path: ./wheelhouse/*.whl
+
+  test:
+    name: Quantize with ModelOpt and simplify
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - uses: actions/download-artifact@v8
+        with:
+          name: onnxsim-wheel
+          path: wheelhouse
+      - name: Install onnxsim wheel + NVIDIA ModelOpt
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest "nvidia-modelopt[onnx]"
+          python -m pip install wheelhouse/*.whl
+      - name: Verify the installed wheel is used (not the source tree)
+        working-directory: ${{ runner.temp }}
+        run: python -c "import onnxsim, onnxsim.onnxsim_cpp2py_export as m; print(onnxsim.__version__, m.__file__)"
+      # Run from a neutral directory so the repo root's ./onnxsim source package
+      # (without the compiled extension) does not shadow the installed wheel.
+      - name: Run ModelOpt integration tests
+        working-directory: ${{ runner.temp }}
+        run: pytest -v "$GITHUB_WORKSPACE/tests/test_modelopt_integration.py"

--- a/.github/workflows/modelopt-integration.yml
+++ b/.github/workflows/modelopt-integration.yml
@@ -10,11 +10,11 @@ name: ModelOpt Integration
 # test requirements, so this runs in its own workflow instead of the
 # build-and-test matrix. Calibration is pinned to the CPU EP, so an ordinary
 # CPU runner is enough. Runs on PRs that touch the QDQ path or this harness, on
-# a weekly schedule to catch new ModelOpt releases, and on demand.
+# a daily schedule to catch new ModelOpt releases, and on demand.
 
 on:
   schedule:
-    - cron: "0 7 * * 1" # Mondays 07:00 UTC (weekly)
+    - cron: "0 7 * * *" # Daily 07:00 UTC
   workflow_dispatch:
   pull_request:
     paths:

--- a/tests/test_modelopt_integration.py
+++ b/tests/test_modelopt_integration.py
@@ -1,0 +1,161 @@
+"""End-to-end regression tests against real NVIDIA ModelOpt output.
+
+``tests/test_simple.py`` already covers the fp8 QDQ handling with *synthetic*
+graphs that hand-build ``float8_e4m3fn`` zero points to mimic what NVIDIA
+ModelOpt emits (GitHub issue #348). Those guard the code path but not the
+assumption behind it: that ModelOpt actually produces graphs of that shape.
+
+This module closes that gap by driving the real
+``modelopt.onnx.quantization.quantize`` API -- the same call TensorRT users run
+to produce int8/fp8 QDQ ONNX models -- and then feeding its output straight
+through ``onnxsim.simplify``. If a future ModelOpt release changes its quantized
+graph in a way onnxsim can no longer simplify (a new unhashable element type, a
+QDQ layout the optimizers fold away, ...), these tests fail where the synthetic
+ones would keep passing.
+
+ModelOpt (and its torch / onnxruntime dependencies) is heavy and not part of
+onnxsim's test requirements, so the whole module is skipped when it is not
+installed. The dedicated ``modelopt-integration`` CI workflow installs it and
+runs these tests; the regular build-and-test matrix skips them.
+"""
+
+import numpy as np
+import onnx
+import pytest
+from onnx import TensorProto, helper
+
+# Skip the entire module unless NVIDIA ModelOpt's ONNX quantization is available.
+# Checked before importing onnxsim so a ModelOpt-less run skips cleanly.
+moq = pytest.importorskip(
+    "modelopt.onnx.quantization",
+    reason="nvidia-modelopt[onnx] is not installed",
+)
+
+import onnxsim  # noqa: E402  (imported after the ModelOpt availability check)
+
+
+def _build_fp32_model(path: str) -> None:
+    """Write a small Conv + MatMul fp32 model that ModelOpt will quantize.
+
+    ModelOpt only inserts QDQ around layers big enough to benefit from
+    low-precision TensorRT kernels: Conv needs input/output channels > 16 and a
+    filter size <= 32, MatMul/Gemm needs its contracted/output dims >= 16 (see
+    ``find_nodes_from_convs_to_exclude`` / the ``_MIN_MATMUL_DIM`` guard in
+    modelopt.onnx.quantization.graph_utils). Undersized layers are silently left
+    in fp16 and produce no QDQ, which would make these tests vacuous, so the
+    32-channel Conv and 32x32 MatMul below are deliberately above those floors.
+    """
+    rng = np.random.RandomState(0)
+    conv_w = helper.make_tensor(
+        "conv_w",
+        TensorProto.FLOAT,
+        [32, 32, 3, 3],
+        rng.randn(32 * 32 * 3 * 3).astype(np.float32).tolist(),
+    )
+    mm_w = helper.make_tensor(
+        "mm_w",
+        TensorProto.FLOAT,
+        [32, 32],
+        rng.randn(32 * 32).astype(np.float32).tolist(),
+    )
+    nodes = [
+        helper.make_node(
+            "Conv", ["X", "conv_w"], ["c"], kernel_shape=[3, 3], pads=[1, 1, 1, 1]
+        ),
+        helper.make_node("Relu", ["c"], ["r"]),
+        helper.make_node("GlobalAveragePool", ["r"], ["p"]),
+        helper.make_node("Flatten", ["p"], ["f"], axis=1),
+        helper.make_node("MatMul", ["f", "mm_w"], ["Y"]),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "modelopt_src",
+        [helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 32, 8, 8])],
+        [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 32])],
+        [conv_w, mm_w],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+    onnx.save(model, path)
+
+
+def _quantize_with_modelopt(tmp_path, quantize_mode: str) -> onnx.ModelProto:
+    """Quantize the fp32 model with real ModelOpt and return the QDQ model.
+
+    Calibration is pinned to the CPU EP so the test runs on CPU-only CI.
+    """
+    src = str(tmp_path / "fp32.onnx")
+    out = str(tmp_path / f"quant_{quantize_mode}.onnx")
+    _build_fp32_model(src)
+    moq.quantize(
+        onnx_path=src,
+        quantize_mode=quantize_mode,
+        calibration_data={
+            "X": np.random.RandomState(1).randn(4, 32, 8, 8).astype(np.float32)
+        },
+        calibration_eps=["cpu"],
+        output_path=out,
+    )
+    return onnx.load(out)
+
+
+def _qdq_counts(model: onnx.ModelProto):
+    op_types = [n.op_type for n in model.graph.node]
+    return op_types.count("QuantizeLinear"), op_types.count("DequantizeLinear")
+
+
+def _has_float8_tensor(model: onnx.ModelProto) -> bool:
+    """Whether any initializer/attribute tensor uses the float8 element type."""
+    if any(
+        init.data_type == TensorProto.FLOAT8E4M3FN for init in model.graph.initializer
+    ):
+        return True
+    for node in model.graph.node:
+        for attr in node.attribute:
+            if attr.HasField("t") and attr.t.data_type == TensorProto.FLOAT8E4M3FN:
+                return True
+            if any(t.data_type == TensorProto.FLOAT8E4M3FN for t in attr.tensors):
+                return True
+    return False
+
+
+def test_modelopt_int8_qdq_simplifies(tmp_path):
+    # int8 zero points are a hashable element type, so this exercises the
+    # ordinary path: onnxsim must simplify a real ModelOpt int8 QDQ graph, keep
+    # ``check_ok`` True (ModelOpt wrapped simplify in a try/except that dropped
+    # the simplified model on error -- issue #348), and preserve every QDQ pair
+    # that TensorRT relies on.
+    model = _quantize_with_modelopt(tmp_path, "int8")
+    n_q, n_dq = _qdq_counts(model)
+    assert n_q > 0 and n_dq > 0, "ModelOpt produced no int8 QDQ nodes to test"
+
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+
+    # onnxsim must neither fold nor dedupe the QDQ structure away.
+    assert _qdq_counts(sim_model) == (n_q, n_dq)
+
+
+def test_modelopt_fp8_qdq_simplifies(tmp_path):
+    # The regression that motivated this: ModelOpt's fp8 mode emits
+    # ``float8_e4m3fn`` (element type 17) zero points. onnxoptimizer's
+    # tensor-value hashing passes cannot hash that type and used to abort the
+    # whole simplification with "no supported data type: 17" (issue #348).
+    # onnxsim now detects such tensors and transparently skips those passes.
+    model = _quantize_with_modelopt(tmp_path, "fp8")
+    n_q, n_dq = _qdq_counts(model)
+    assert n_q > 0 and n_dq > 0, "ModelOpt produced no fp8 QDQ nodes to test"
+    # Guard that this test really exercises the unhashable-tensor path: if a
+    # future ModelOpt stops emitting float8 zero points here, we want to know.
+    assert _has_float8_tensor(model), "expected float8_e4m3fn zero points"
+
+    # Must not raise "no supported data type: 17".
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+
+    # The fp8 QDQ structure TensorRT consumes must survive simplification.
+    assert _qdq_counts(sim_model) == (n_q, n_dq)
+    assert _has_float8_tensor(sim_model)


### PR DESCRIPTION
## Summary
This PR adds end-to-end regression tests that validate onnxsim's ability to simplify real NVIDIA ModelOpt-generated quantized models (both int8 and fp8 QDQ graphs). These tests close a gap where synthetic graphs in `test_simple.py` covered the code path but not the actual ModelOpt output format.

## Key Changes
- **New test module** (`tests/test_modelopt_integration.py`):
  - `test_modelopt_int8_qdq_simplifies`: Validates that onnxsim correctly simplifies real ModelOpt int8 QDQ graphs while preserving all QDQ pairs that TensorRT depends on
  - `test_modelopt_fp8_qdq_simplifies`: Validates fp8 mode with `float8_e4m3fn` zero points (the unhashable tensor type from issue #348), ensuring simplification succeeds and preserves the fp8 QDQ structure
  - Helper functions to build fp32 models, invoke ModelOpt's quantization API, and inspect QDQ/float8 tensor presence
  - Module-level skip when ModelOpt is not installed to keep it out of regular test runs

- **New CI workflow** (`.github/workflows/modelopt-integration.yml`):
  - Dedicated workflow that builds onnxsim from the current branch and tests it against real ModelOpt output
  - Runs on PRs touching QDQ-related code, daily schedule, and manual dispatch
  - Builds a wheel to ensure the compiled extension is tested (not the source tree)
  - Uses CPU-only calibration for compatibility with standard runners

## Implementation Details
- Tests deliberately use Conv (32 channels) and MatMul (32×32) dimensions above ModelOpt's minimum thresholds to ensure QDQ nodes are actually inserted
- Validates that simplification preserves QDQ pair counts and float8 tensors, critical for TensorRT consumption
- Calibration pinned to CPU EP so tests run on CPU-only infrastructure
- Module uses `pytest.importorskip` to gracefully skip when ModelOpt is unavailable, keeping the regular test matrix unaffected

https://claude.ai/code/session_01MRjoRPuz7t2rbPnrp3UgNv