### PR TITLE
Add execution provider support for GPU-accelerated constant folding

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,57 @@ the standalone `onnxsim` binary (`--target-opset`), and the
 [web version](https://onnxsim.github.io/onnxsim/) (the "target opset version"
 field).
 
+## Constant folding on the GPU (CUDA execution provider)
+
+onnxsim constant-folds by running the foldable sub-graphs through ONNX Runtime.
+By default it uses the CPU execution provider, which is always available and
+gives deterministic results. For large models it can be much faster to fold on
+an NVIDIA GPU. Pass `providers` to `simplify` to choose the ONNX Runtime
+[execution providers](https://onnxruntime.ai/docs/execution-providers/), in
+priority order:
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load(filename)
+
+# Fold on the GPU, falling back to CPU for ops CUDA cannot run.
+model_simp, check = onnxsim.simplify(
+    model, providers=["CUDAExecutionProvider", "CPUExecutionProvider"]
+)
+```
+
+On the command line:
+
+```
+# Explicit provider list (priority order):
+onnxsim input_onnx_model output_onnx_model \
+    --providers CUDAExecutionProvider CPUExecutionProvider
+
+# Or the shortcut, equivalent to the line above:
+onnxsim input_onnx_model output_onnx_model --cuda
+```
+
+Keeping `CPUExecutionProvider` last is recommended: ONNX Runtime falls back to
+it for any operator the GPU provider cannot run. Each provider entry may also be
+a `(name, options)` tuple, exactly as
+[`onnxruntime.InferenceSession`](https://onnxruntime.ai/docs/api/python/api_summary.html)
+accepts it, for example to pin a specific `device_id`:
+
+```python
+model_simp, check = onnxsim.simplify(
+    model,
+    providers=[("CUDAExecutionProvider", {"device_id": 1}), "CPUExecutionProvider"],
+)
+```
+
+The CUDA execution provider requires the GPU build of ONNX Runtime
+(`pip install onnxruntime-gpu`). If you request a provider the installed ONNX
+Runtime does not offer, onnxsim raises a `ValueError` listing the available
+providers instead of silently folding on the CPU. When `providers` is left
+unset (the default), folding runs on the CPU.
+
 ## Custom rewriters
 
 Beyond the built-in optimizer passes, you can plug your own graph rewriting

--- a/onnxsim/backend.py
+++ b/onnxsim/backend.py
@@ -8,7 +8,7 @@ sometimes harmful, see https://github.com/onnxsim/onnxsim/issues/441).
 
 import os
 from collections import OrderedDict
-from typing import Dict, Optional, Sequence, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import onnx
@@ -22,9 +22,50 @@ except ImportError:
     _HAS_ONNXRUNTIME = False
 
 
+# An execution provider is either the provider name (e.g.
+# ``"CUDAExecutionProvider"``) or a ``(name, options_dict)`` tuple as accepted
+# by ``onnxruntime.InferenceSession``. onnxruntime tries the providers in order
+# and falls back to the next one for operators a provider cannot run, so the CPU
+# provider is normally kept last as a catch-all.
+Provider = Union[str, Tuple[str, Dict[str, object]]]
+
+# Constant folding runs on CPU unless the caller asks otherwise. CPU is always
+# available and deterministic, which keeps folding results stable regardless of
+# the machine onnxsim happens to run on.
+DEFAULT_PROVIDERS: List[str] = ["CPUExecutionProvider"]
+
+
 def has_onnxruntime() -> bool:
     """Whether onnxruntime is available as the inference backend."""
     return _HAS_ONNXRUNTIME
+
+
+def _provider_name(provider: Provider) -> str:
+    """The provider name whether ``provider`` is a bare string or a
+    ``(name, options)`` tuple."""
+    return provider[0] if isinstance(provider, (tuple, list)) else provider
+
+
+def _check_providers_available(providers: Sequence[Provider]) -> None:
+    """Raise a helpful error if any requested provider is not built into the
+    installed onnxruntime.
+
+    onnxruntime otherwise only logs a warning and silently drops an unavailable
+    provider (e.g. ``CUDAExecutionProvider`` when the CPU-only wheel is
+    installed), so a user who asked to fold on the GPU would quietly get CPU
+    execution instead. Failing loudly makes that misconfiguration obvious.
+    """
+    available = set(rt.get_available_providers())
+    missing = [
+        _provider_name(p) for p in providers if _provider_name(p) not in available
+    ]
+    if missing:
+        raise ValueError(
+            "The following execution provider(s) are not available in the "
+            f"installed onnxruntime: {missing}. Available providers: "
+            f"{sorted(available)}. For CUDA, install the GPU build with "
+            "`pip install onnxruntime-gpu`."
+        )
 
 
 def _run_with_onnxruntime(
@@ -32,7 +73,11 @@ def _run_with_onnxruntime(
     inputs: Dict[str, np.ndarray],
     output_names: Optional[Sequence[str]],
     custom_lib: Optional[str],
+    providers: Optional[Sequence[Provider]] = None,
 ) -> "OrderedDict[str, np.ndarray]":
+    if providers is None:
+        providers = DEFAULT_PROVIDERS
+    _check_providers_available(providers)
     sess_options = rt.SessionOptions()
     if custom_lib is not None:
         if os.path.exists(custom_lib):
@@ -46,7 +91,7 @@ def _run_with_onnxruntime(
     sess = rt.InferenceSession(
         model,
         sess_options=sess_options,
-        providers=["CPUExecutionProvider"],
+        providers=list(providers),
     )
     if output_names is None:
         output_names = [x.name for x in sess.get_outputs()]
@@ -61,9 +106,22 @@ def _run_with_reference(
     inputs: Dict[str, np.ndarray],
     output_names: Optional[Sequence[str]],
     custom_lib: Optional[str],
+    providers: Optional[Sequence[Provider]] = None,
 ) -> "OrderedDict[str, np.ndarray]":
     if custom_lib is not None:
         raise ValueError("custom_lib is only supported when onnxruntime is installed")
+    # The reference evaluator runs in pure Python on the CPU and has no notion of
+    # execution providers. Asking for a non-CPU provider (e.g. CUDA) without
+    # onnxruntime installed cannot be honoured, so surface that instead of
+    # silently ignoring the request.
+    if providers is not None and any(
+        _provider_name(p) != "CPUExecutionProvider" for p in providers
+    ):
+        raise ValueError(
+            "Execution providers other than CPUExecutionProvider require "
+            "onnxruntime. Please install it (e.g. `pip install onnxruntime-gpu` "
+            f"for CUDA). Requested providers: {[_provider_name(p) for p in providers]}."
+        )
     from onnx.reference import ReferenceEvaluator
 
     if isinstance(model, str):
@@ -82,6 +140,7 @@ def run_model(
     inputs: Dict[str, np.ndarray],
     output_names: Optional[Sequence[str]] = None,
     custom_lib: Optional[str] = None,
+    providers: Optional[Sequence[Provider]] = None,
 ) -> "OrderedDict[str, np.ndarray]":
     """Run ``model`` on ``inputs`` and return an ordered ``{name: array}`` map.
 
@@ -89,7 +148,10 @@ def run_model(
     :param inputs: mapping from input name to numpy array
     :param output_names: outputs to fetch, ``None`` means all model outputs
     :param custom_lib: onnxruntime custom ops's shared library (onnxruntime only)
+    :param providers: onnxruntime execution providers to run with, in priority
+            order (e.g. ``["CUDAExecutionProvider", "CPUExecutionProvider"]``).
+            ``None`` means CPU only. Non-CPU providers require onnxruntime.
     """
     if _HAS_ONNXRUNTIME:
-        return _run_with_onnxruntime(model, inputs, output_names, custom_lib)
-    return _run_with_reference(model, inputs, output_names, custom_lib)
+        return _run_with_onnxruntime(model, inputs, output_names, custom_lib, providers)
+    return _run_with_reference(model, inputs, output_names, custom_lib, providers)

--- a/onnxsim/backend.py
+++ b/onnxsim/backend.py
@@ -68,6 +68,39 @@ def _check_providers_available(providers: Sequence[Provider]) -> None:
         )
 
 
+def validate_providers(providers: Optional[Sequence[Provider]]) -> None:
+    """Validate a requested execution-provider list, raising if it cannot be
+    honoured by the current backend.
+
+    Callers use this to fail fast *before* constant folding starts. onnxsim's
+    folding loop catches per-op executor errors and simply leaves the op
+    unfolded, so an unavailable provider raised deep inside a fold would be
+    swallowed and silently degrade to no folding rather than surfacing to the
+    user. Checking here instead turns a misconfigured provider into an
+    immediate, actionable error.
+
+    ``None`` (fold on CPU) is always valid.
+    """
+    if providers is None:
+        return
+    if _HAS_ONNXRUNTIME:
+        _check_providers_available(providers)
+        return
+    # Without onnxruntime only the pure-Python reference evaluator is available,
+    # which runs on the CPU and cannot honour any other provider.
+    non_cpu = [
+        _provider_name(p)
+        for p in providers
+        if _provider_name(p) != "CPUExecutionProvider"
+    ]
+    if non_cpu:
+        raise ValueError(
+            "Execution providers other than CPUExecutionProvider require "
+            "onnxruntime. Please install it (e.g. `pip install onnxruntime-gpu` "
+            f"for CUDA). Requested providers: {non_cpu}."
+        )
+
+
 def _run_with_onnxruntime(
     model: Union[str, bytes, onnx.ModelProto],
     inputs: Dict[str, np.ndarray],
@@ -77,7 +110,7 @@ def _run_with_onnxruntime(
 ) -> "OrderedDict[str, np.ndarray]":
     if providers is None:
         providers = DEFAULT_PROVIDERS
-    _check_providers_available(providers)
+    validate_providers(providers)
     sess_options = rt.SessionOptions()
     if custom_lib is not None:
         if os.path.exists(custom_lib):
@@ -114,14 +147,7 @@ def _run_with_reference(
     # execution providers. Asking for a non-CPU provider (e.g. CUDA) without
     # onnxruntime installed cannot be honoured, so surface that instead of
     # silently ignoring the request.
-    if providers is not None and any(
-        _provider_name(p) != "CPUExecutionProvider" for p in providers
-    ):
-        raise ValueError(
-            "Execution providers other than CPUExecutionProvider require "
-            "onnxruntime. Please install it (e.g. `pip install onnxruntime-gpu` "
-            f"for CUDA). Requested providers: {[_provider_name(p) for p in providers]}."
-        )
+    validate_providers(providers)
     from onnx.reference import ReferenceEvaluator
 
     if isinstance(model, str):

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -338,6 +338,7 @@ def simplify(
     function_rewrite_rules: Optional[Sequence[FunctionRewriteRule]] = None,
     check_rtol: float = 1e-4,
     check_atol: float = 1e-5,
+    providers: Optional[Sequence[backend.Provider]] = None,
 ) -> Tuple[onnx.ModelProto, bool]:
     """
     :param model: onnx ModelProto object or file path
@@ -389,6 +390,16 @@ def simplify(
             enough to accumulate a larger-but-benign difference (e.g. RF-DETR's XLarge segmentation
             variants -- see ``scripts/rfdetr/FAILURE_ANALYSIS.md``). Ignored when ``check_n == 0``.
     :param check_atol: Absolute tolerance counterpart of ``check_rtol``.
+    :param providers: onnxruntime execution providers used to run the model
+            during constant folding, in priority order, for example
+            ``["CUDAExecutionProvider", "CPUExecutionProvider"]`` to fold on an
+            NVIDIA GPU (falling back to CPU for ops CUDA cannot run). An entry may
+            also be a ``(name, options)`` tuple as accepted by
+            ``onnxruntime.InferenceSession``. ``None`` (the default) folds on the
+            CPU. Non-CPU providers require onnxruntime to be installed (the CUDA
+            provider specifically needs the ``onnxruntime-gpu`` build); a
+            requested provider that the installed onnxruntime does not offer
+            raises ``ValueError`` instead of silently falling back.
     :return: A tuple (simplified model, success(True) or failed(False))
     """
     if dynamic_input_shape:
@@ -543,7 +554,7 @@ def simplify(
             model_bytes = None
             raise EncodeError("Message larger than 2GiB")
         model_opt_bytes = C.simplify(
-            _get_model_executor(),
+            _get_model_executor(providers),
             model_bytes,
             skipped_optimizers,
             not skip_constant_folding,
@@ -609,7 +620,7 @@ def simplify(
                 save_as_external_data=True,
             )
             check_ok = C.simplify_path(
-                _get_model_executor(),
+                _get_model_executor(providers),
                 os.path.join(tmpdirname, "model.onnx"),
                 os.path.join(tmpdirname, "opt.onnx"),
                 skipped_optimizers,
@@ -635,6 +646,12 @@ def simplify(
 
 
 class PyModelExecutor(C.ModelExecutor):
+    def __init__(self, providers: Optional[Sequence[backend.Provider]] = None):
+        super().__init__()
+        # onnxruntime execution providers used to run the throwaway sub-models
+        # the C++ core builds during constant folding. ``None`` means CPU only.
+        self.providers = providers
+
     def Run(self, model_str: str, inputs_str: List[str]):
         model = onnx.ModelProto()
         model.ParseFromString(model_str)
@@ -648,7 +665,7 @@ class PyModelExecutor(C.ModelExecutor):
         input_arrs = map(onnx.numpy_helper.to_array, input_tps)
         input_names = [x.name for x in model.graph.input]
         inputs = dict(zip(input_names, input_arrs))
-        outputs = backend.run_model(model, inputs)
+        outputs = backend.run_model(model, inputs, providers=self.providers)
         # The inference backend may return a non-ndarray for an output (for
         # example onnxruntime yields an empty Python list for an empty sequence
         # output). onnx.numpy_helper.from_array only accepts numpy arrays, so
@@ -706,15 +723,20 @@ class _GraphRewriterAdapter(C.GraphRewriter):
 _model_executor: Optional[PyModelExecutor] = None
 
 
-def _get_model_executor() -> PyModelExecutor:
+def _get_model_executor(
+    providers: Optional[Sequence[backend.Provider]] = None,
+) -> PyModelExecutor:
     """Return the process-wide Python model executor, creating it on demand.
 
     The executor is passed explicitly to the C++ ``simplify``/``simplify_path``
-    entry points instead of being registered as a global instance.
+    entry points instead of being registered as a global instance. The cached
+    executor is reused only when it was built for the same ``providers`` request,
+    so a later call asking for a different provider set gets a fresh executor
+    rather than silently keeping the previous one.
     """
     global _model_executor
-    if _model_executor is None:
-        _model_executor = PyModelExecutor()
+    if _model_executor is None or _model_executor.providers != providers:
+        _model_executor = PyModelExecutor(providers)
     return _model_executor
 
 
@@ -859,6 +881,23 @@ def main():
         default=None,
     )
     parser.add_argument(
+        "--providers",
+        help="onnxruntime execution providers used to run the model during "
+        "constant folding, in priority order, for example '--providers "
+        "CUDAExecutionProvider CPUExecutionProvider' to fold on an NVIDIA GPU "
+        "(falling back to CPU for ops CUDA cannot run). Defaults to CPU only. "
+        "The CUDA provider requires the 'onnxruntime-gpu' build.",
+        type=str,
+        nargs="+",
+        default=None,
+    )
+    parser.add_argument(
+        "--cuda",
+        help="Shortcut for '--providers CUDAExecutionProvider "
+        "CPUExecutionProvider'. Requires the 'onnxruntime-gpu' build.",
+        action="store_true",
+    )
+    parser.add_argument(
         "-v", "--version", action="version", version="onnxsim " + version.version
     )
 
@@ -927,6 +966,19 @@ def main():
         args.skip_optimization.append("fuse_bn_into_conv")
 
     perform_optimization = False if args.skip_optimization is None else True
+
+    # Resolve the execution providers for constant folding. ``--cuda`` is a
+    # shortcut for the common GPU-then-CPU order; it and an explicit
+    # ``--providers`` cannot both be given.
+    if args.cuda and args.providers is not None:
+        raise RuntimeError(
+            "--cuda and --providers are mutually exclusive; --cuda is a shortcut "
+            "for '--providers CUDAExecutionProvider CPUExecutionProvider'."
+        )
+    if args.cuda:
+        providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    else:
+        providers = args.providers
 
     def parse_shapes(shapes_arg):
         shapes = {}
@@ -1035,6 +1087,7 @@ def main():
         target_opset_version=args.target_opset,
         check_rtol=args.check_rtol,
         check_atol=args.check_atol,
+        providers=providers,
     )
 
     try:

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -402,6 +402,13 @@ def simplify(
             raises ``ValueError`` instead of silently falling back.
     :return: A tuple (simplified model, success(True) or failed(False))
     """
+    # Validate the requested execution providers up front. onnxsim's constant
+    # folding catches per-op executor failures and leaves the op unfolded, so an
+    # unavailable provider raised mid-fold would be swallowed and silently
+    # degrade to no folding. Checking here turns a misconfigured provider (e.g.
+    # CUDA requested without the onnxruntime-gpu build) into an immediate error.
+    backend.validate_providers(providers)
+
     if dynamic_input_shape:
         print(
             Text(

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -64,6 +64,34 @@ def test_simplify_without_onnxruntime(monkeypatch):
     assert len(opt.graph.node) == 1
 
 
+@pytest.mark.skipif(
+    not backend.has_onnxruntime(), reason="requires onnxruntime for provider selection"
+)
+def test_simplify_with_explicit_provider():
+    # ``simplify`` threads ``providers`` down to the constant-folding executor.
+    # An explicit CPU provider must fold identically to the default.
+    model = _make_foldable_model()
+    opt, check_ok = onnxsim.simplify(
+        model, check_n=3, providers=["CPUExecutionProvider"]
+    )
+    assert check_ok
+    assert len(opt.graph.node) == 1
+
+
+def test_simplify_with_unavailable_provider_raises():
+    # Requesting a provider the installed onnxruntime does not offer surfaces a
+    # clear error rather than silently folding on the CPU.
+    import onnxruntime as rt
+
+    if not backend.has_onnxruntime():
+        pytest.skip("requires onnxruntime")
+    if "CUDAExecutionProvider" in rt.get_available_providers():
+        pytest.skip("CUDA provider is available; cannot test the unavailable path")
+    model = _make_foldable_model()
+    with pytest.raises(ValueError, match="not available"):
+        onnxsim.simplify(model, providers=["CUDAExecutionProvider"])
+
+
 def test_reference_evaluator_rejects_custom_lib(monkeypatch):
     monkeypatch.setattr(backend, "_HAS_ONNXRUNTIME", False)
     model = _make_foldable_model()
@@ -71,3 +99,69 @@ def test_reference_evaluator_rejects_custom_lib(monkeypatch):
         backend.run_model(
             model, {"x": np.zeros((2, 2), np.float32)}, custom_lib="does_not_exist.so"
         )
+
+
+@pytest.mark.skipif(
+    not backend.has_onnxruntime(), reason="requires onnxruntime for provider selection"
+)
+def test_explicit_cpu_provider_produces_correct_result():
+    # Passing an explicit provider list is honoured and gives the same result as
+    # the default (which is CPU).
+    model = _make_foldable_model()
+    x = np.arange(4, dtype=np.float32).reshape(2, 2)
+    outputs = backend.run_model(
+        model, {"x": x}, providers=["CPUExecutionProvider"]
+    )
+    np.testing.assert_allclose(outputs["y"], x + 3.0)
+
+
+@pytest.mark.skipif(
+    not backend.has_onnxruntime(), reason="requires onnxruntime for provider selection"
+)
+def test_provider_options_tuple_form():
+    # onnxruntime also accepts ``(name, options)`` tuples; onnxsim passes them
+    # through unchanged.
+    model = _make_foldable_model()
+    x = np.arange(4, dtype=np.float32).reshape(2, 2)
+    outputs = backend.run_model(
+        model, {"x": x}, providers=[("CPUExecutionProvider", {})]
+    )
+    np.testing.assert_allclose(outputs["y"], x + 3.0)
+
+
+@pytest.mark.skipif(
+    not backend.has_onnxruntime(), reason="requires onnxruntime for provider selection"
+)
+def test_unavailable_provider_raises():
+    # A requested provider the installed onnxruntime does not offer (e.g. CUDA on
+    # a CPU-only wheel) fails loudly instead of silently falling back to CPU.
+    import onnxruntime as rt
+
+    if "CUDAExecutionProvider" in rt.get_available_providers():
+        pytest.skip("CUDA provider is available; cannot test the unavailable path")
+    model = _make_foldable_model()
+    with pytest.raises(ValueError, match="not available"):
+        backend.run_model(
+            model,
+            {"x": np.zeros((2, 2), np.float32)},
+            providers=["CUDAExecutionProvider"],
+        )
+
+
+def test_reference_evaluator_rejects_non_cpu_provider(monkeypatch):
+    # Without onnxruntime the pure-Python reference evaluator cannot honour a
+    # non-CPU provider, so asking for one is an error rather than a silent no-op.
+    monkeypatch.setattr(backend, "_HAS_ONNXRUNTIME", False)
+    model = _make_foldable_model()
+    with pytest.raises(ValueError, match="require onnxruntime"):
+        backend.run_model(
+            model,
+            {"x": np.zeros((2, 2), np.float32)},
+            providers=["CUDAExecutionProvider"],
+        )
+    # The reference evaluator still accepts an explicit CPU provider.
+    x = np.arange(4, dtype=np.float32).reshape(2, 2)
+    outputs = backend.run_model(
+        model, {"x": x}, providers=["CPUExecutionProvider"]
+    )
+    np.testing.assert_allclose(outputs["y"], x + 3.0)


### PR DESCRIPTION
## Summary
This PR adds support for specifying ONNX Runtime execution providers (e.g., CUDA) to accelerate constant folding during model simplification. Previously, onnxsim always folded constants on the CPU. Now users can opt into GPU folding for faster simplification of large models.

## Key Changes

- **Backend provider support**: Extended `backend.run_model()` to accept an optional `providers` parameter that gets passed through to ONNX Runtime's `InferenceSession`. Added validation to ensure requested providers are actually available, raising a clear error instead of silently falling back to CPU.

- **Simplify API enhancement**: Added `providers` parameter to `onnxsim.simplify()` to control which execution providers are used during constant folding. Defaults to CPU-only for deterministic, portable results.

- **PyModelExecutor provider threading**: Modified `PyModelExecutor` to accept and store providers, passing them through to `backend.run_model()` when executing throwaway sub-models during constant folding.

- **CLI support**: Added `--providers` and `--cuda` command-line arguments to the standalone `onnxsim` binary. The `--cuda` flag is a convenient shortcut for GPU-then-CPU fallback (`["CUDAExecutionProvider", "CPUExecutionProvider"]`).

- **Provider validation**: Implemented `_check_providers_available()` to validate that requested providers exist in the installed onnxruntime, preventing silent fallback to CPU when a user explicitly requests CUDA (e.g., on a CPU-only wheel).

- **Reference evaluator handling**: Updated the pure-Python reference evaluator fallback to reject non-CPU providers with a helpful error message, since it cannot honor GPU execution.

- **Documentation**: Added comprehensive README section explaining GPU constant folding with examples for both Python API and CLI usage, including provider tuple syntax for advanced options like `device_id`.

## Implementation Details

- Provider type is defined as `Union[str, Tuple[str, Dict[str, object]]]` to match onnxruntime's API, supporting both bare provider names and `(name, options)` tuples.
- Default providers list is `["CPUExecutionProvider"]` for deterministic, reproducible folding.
- The cached `PyModelExecutor` is invalidated and recreated if a different provider set is requested, ensuring correct behavior across multiple `simplify()` calls with different providers.
- Provider availability checking happens early to surface configuration errors immediately rather than during model execution.

https://claude.ai/code/session_012sQVMPnRaVy1pXx6oy8Uci