### PR TITLE
Add Qualcomm QNN integration test suite

### DIFF
--- a/.github/workflows/qualcomm-integration.yml
+++ b/.github/workflows/qualcomm-integration.yml
@@ -1,0 +1,100 @@
+name: Qualcomm Integration
+
+# Compiles and runs onnxsim's output through the Qualcomm AI Runtime (QNN)
+# execution provider to catch simplifications that break the Qualcomm toolchain
+# (SNPE / QAIRT) — a graph the QNN converter can no longer compile, or whose
+# on-device result changed.
+#
+# Runs entirely on a stock x86-64 CPU runner: the pip `onnxruntime-qnn` wheel's
+# HTP backend does the full offline graph compile (libHtpPrepare.so) and executes
+# in the x86 emulator, so no Snapdragon device is needed. See
+# scripts/qualcomm/README.md for the fidelity tiers this covers (and the SDK /
+# AI Hub paths for real-hardware numerics).
+#
+# Scheduled + on demand (like the model regression), plus on PRs that touch the
+# harness so it stays valid.
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # Mondays 07:00 UTC (weekly)
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/qualcomm-integration.yml"
+      - "scripts/qualcomm/**"
+      - "tests/test_qnn_compat.py"
+
+concurrency:
+  group: qualcomm-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Build onnxsim once from the current tree, so the QNN check runs against the
+  # actual simplifier in this branch rather than a released wheel.
+  build:
+    name: Build onnxsim wheel
+    runs-on: ubuntu-24.04
+    env:
+      SCCACHE_GHA_ENABLED: "on"
+      ACTIONS_CACHE_SERVICE_V2: "on"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - name: Build cp312 wheel
+        uses: pypa/cibuildwheel@v4.1.1
+        env:
+          CIBW_BUILD: "cp312-manylinux_x86_64"
+          CIBW_ARCHS: native
+          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_ENVIRONMENT_PASS_LINUX: CI SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN ACTIONS_CACHE_SERVICE_V2
+          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache"
+          CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF" CMAKE_GENERATOR=Ninja CMAKE_CXX_COMPILER_LAUNCHER=sccache CMAKE_LINKER_TYPE=LLD
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} --strip"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: onnxsim-wheel-qnn
+          path: ./wheelhouse/*.whl
+
+  qnn-compat:
+    name: QNN compatibility check
+    needs: [build]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          # onnxruntime-qnn ships cp311/cp312/cp313 x86-64 Linux wheels.
+          python-version: "3.12"
+      - uses: actions/download-artifact@v8
+        with:
+          name: onnxsim-wheel-qnn
+          path: wheelhouse
+      - name: Install onnxsim wheel + onnxruntime-qnn
+        run: |
+          python -m pip install --upgrade pip
+          # onnxruntime-qnn brings its own onnxruntime (the QNN plugin EP).
+          python -m pip install onnxruntime-qnn
+          python -m pip install wheelhouse/*.whl
+      - name: Show environment
+        run: |
+          python -c "import onnxsim, onnxruntime_qnn as q; print('onnxsim', onnxsim.__version__); print('onnxruntime-qnn', q.__version__)"
+          python -c "import sys; sys.path.insert(0, 'scripts/qualcomm'); import qnn_backend as q; print('QNN available:', q.QNN_AVAILABLE, '| backend:', q.backend_path() if q.QNN_AVAILABLE else q.unavailable_reason())"
+      - name: Run QNN compatibility check
+        run: |
+          python scripts/qualcomm/run_qnn_compat.py \
+            --require-qnn \
+            --output qnn-compat.csv
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: qnn-compat-report
+          path: qnn-compat.csv
+          if-no-files-found: ignore

--- a/.github/workflows/qualcomm-integration.yml
+++ b/.github/workflows/qualcomm-integration.yml
@@ -83,18 +83,24 @@ jobs:
           # onnxruntime-qnn brings its own onnxruntime (the QNN plugin EP).
           python -m pip install onnxruntime-qnn
           python -m pip install wheelhouse/*.whl
+      # Run from runner.temp, not the checkout: the repo root contains the
+      # `onnxsim/` source dir (no compiled extension), which would shadow the
+      # installed wheel on `import onnxsim`. Reference the harness by absolute
+      # $GITHUB_WORKSPACE path. Same guard the model-regression workflow uses.
       - name: Show environment
+        working-directory: ${{ runner.temp }}
         run: |
           python -c "import onnxsim, onnxruntime_qnn as q; print('onnxsim', onnxsim.__version__); print('onnxruntime-qnn', q.__version__)"
-          python -c "import sys; sys.path.insert(0, 'scripts/qualcomm'); import qnn_backend as q; print('QNN available:', q.QNN_AVAILABLE, '| backend:', q.backend_path() if q.QNN_AVAILABLE else q.unavailable_reason())"
+          python -c "import sys, os; sys.path.insert(0, os.path.join(os.environ['GITHUB_WORKSPACE'], 'scripts', 'qualcomm')); import qnn_backend as q; print('QNN available:', q.QNN_AVAILABLE, '| backend:', q.backend_path() if q.QNN_AVAILABLE else q.unavailable_reason())"
       - name: Run QNN compatibility check
+        working-directory: ${{ runner.temp }}
         run: |
-          python scripts/qualcomm/run_qnn_compat.py \
+          python "$GITHUB_WORKSPACE/scripts/qualcomm/run_qnn_compat.py" \
             --require-qnn \
             --output qnn-compat.csv
       - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: qnn-compat-report
-          path: qnn-compat.csv
+          path: ${{ runner.temp }}/qnn-compat.csv
           if-no-files-found: ignore

--- a/scripts/qualcomm/README.md
+++ b/scripts/qualcomm/README.md
@@ -1,0 +1,86 @@
+# Qualcomm QNN integration check
+
+Verifies that `onnxsim`'s output still works with the **Qualcomm AI Runtime
+(QNN)** software stack — the runtime behind SNPE / the Qualcomm Neural Processing
+SDK and QAIRT. The goal is to catch the failure mode the unit tests and the
+large-model regression don't: a simplification that produces a graph the
+Qualcomm toolchain can no longer **compile**, or that **changes the result** on a
+Qualcomm target.
+
+It uses the pip-installable [`onnxruntime-qnn`](https://pypi.org/project/onnxruntime-qnn/)
+wheel (the QNN execution provider for ONNX Runtime). On an ordinary **x86-64
+Linux CPU runner with no Snapdragon device**, the bundled **HTP** backend still
+performs the full *offline graph compile* (`libHtpPrepare.so` — the same
+preparation a Qualcomm converter runs) and then executes the compiled graph in
+the **x86 host emulator**. So the whole check runs on a free GitHub-hosted runner
+with nothing but `pip install onnxruntime-qnn`.
+
+## What it checks
+
+For each model the harness runs **original vs. simplified through the same QNN
+backend**, so backend quirks cancel and only an onnxsim-introduced change can
+fail the run:
+
+1. `simplify` the model with onnxsim.
+2. Compile + run the **original** graph on the QNN EP.
+   If that already fails, the backend just doesn't support the graph → reported
+   as `unsupported`, **not** a failure.
+3. Compile + run the **simplified** graph on the QNN EP.
+   If the original compiled but the simplified doesn't → `qnn_regression`
+   (a failure): simplification broke QNN compatibility.
+4. Compare the two QNN outputs. Divergence beyond tolerance → `qnn_regression`:
+   simplification changed the on-device result.
+5. Record the ONNX Runtime CPU-reference diff and the QNN **coverage** (does the
+   whole graph map onto QNN, or do some nodes fall back to ORT's CPU provider)
+   as information.
+
+Partial coverage and `unsupported` are reported, never failed — plenty of valid
+graphs are not 100% HTP-mappable, and that is a backend property, not an onnxsim
+bug.
+
+## Files
+
+| file | purpose |
+| --- | --- |
+| `qnn_backend.py` | wraps the QNN EP: registers the plugin, builds/runs a model on QNN (offline HTP compile + x86 emulation) and on the ORT CPU reference, measures coverage, synthesizes inputs, compares outputs. Degrades gracefully (`QNN_AVAILABLE`) when the EP is absent. |
+| `models.py` | a small, network-free suite of synthetic graphs covering common layer patterns (conv/BN/relu, foldable shape→reshape, MLP, cancelling transposes, swish), each carrying the redundancy onnxsim is meant to remove. |
+| `worker.py` | runs the check for one model in an isolated subprocess (the HTP compiler can abort at the C++ level), printing one `__RESULT__<json>` line. |
+| `run_qnn_compat.py` | drives the suite, writes a CSV, and exits non-zero on any regression. Entry point for CI. |
+
+## Running locally
+
+Requires an x86-64 Linux host (the `onnxruntime-qnn` HTP backend platform).
+
+```bash
+pip install onnxruntime-qnn      # brings its own onnxruntime
+pip install .                    # or install an onnxsim wheel
+
+python scripts/qualcomm/run_qnn_compat.py --output qnn-compat.csv
+```
+
+The in-tree smoke test `tests/test_qnn_compat.py` reuses this harness and is
+skipped automatically when `onnxruntime-qnn` isn't installed.
+
+## Fidelity tiers (what this does and doesn't cover)
+
+This check runs the QNN **HTP** backend via **offline compile + x86 emulation**.
+That validates *graph compatibility* and *functional numerics* with no device.
+Two things it deliberately does not do:
+
+- **True CPU reference backend.** The pip wheel does not ship `libQnnCpu.so`
+  (the QNN CPU reference backend); it comes with the full QAIRT SDK. To use it
+  instead of HTP emulation, install the SDK and set
+  `QNN_BACKEND_PATH=/path/to/libQnnCpu.so` — the harness picks it up.
+- **Real NPU/HTP hardware numerics.** Emulation is functional, not
+  bit-identical to silicon, and does not quantize. For on-device validation use
+  a self-hosted Snapdragon runner or [Qualcomm AI Hub](https://aihub.qualcomm.com/)
+  (`qai-hub`), which compiles/profiles/runs on cloud Snapdragon devices via an
+  API token.
+
+## Extending
+
+`models.py` is intentionally small and self-contained so the CI job needs no
+downloads. Real models (e.g. the Hugging Face
+[`onnxmodelzoo`](https://huggingface.co/onnxmodelzoo) set used by the large-model
+regression) can be layered on by passing an on-disk path as `worker.py`'s second
+argument; a scheduled job can iterate those the way `scripts/regression` does.

--- a/scripts/qualcomm/models.py
+++ b/scripts/qualcomm/models.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""A small, self-contained suite of ONNX graphs for the QNN compatibility check.
+
+These are synthetic graphs, deliberately tiny, chosen to (a) cover common
+layer patterns a Qualcomm target would see and (b) include the redundancy that
+onnxsim is meant to remove — foldable constant subgraphs, shape/gather chains
+feeding a Reshape, no-op transposes — so the test actually exercises the
+"did simplification change the QNN path" question rather than just "does a clean
+graph convert".
+
+Kept network-free on purpose: the fast CI job needs no downloads. The heavier
+scheduled job can layer real onnxmodelzoo models on top later.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Tuple
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+
+_OPSET = 18
+_IR = 10
+
+
+def _model(nodes, inputs, outputs, initializers, name) -> onnx.ModelProto:
+    graph = helper.make_graph(nodes, name, inputs, outputs, initializers)
+    model = helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", _OPSET)], ir_version=_IR
+    )
+    onnx.checker.check_model(model)
+    return model
+
+
+def _const(name: str, array: np.ndarray):
+    return numpy_helper.from_array(array, name)
+
+
+def _rand(*shape, seed=0) -> np.ndarray:
+    return np.random.RandomState(seed).randn(*shape).astype(np.float32)
+
+
+def conv_bn_relu() -> onnx.ModelProto:
+    """Conv -> (scale/shift as Mul/Add, foldable) -> Relu -> GlobalAveragePool."""
+    w = _const("w", _rand(8, 3, 3, 3, seed=1))
+    b = _const("b", np.zeros(8, np.float32))
+    scale = _const("scale", _rand(1, 8, 1, 1, seed=2))
+    shift = _const("shift", _rand(1, 8, 1, 1, seed=3))
+    nodes = [
+        helper.make_node("Conv", ["x", "w", "b"], ["c"], pads=[1, 1, 1, 1]),
+        helper.make_node("Mul", ["c", "scale"], ["m"]),
+        helper.make_node("Add", ["m", "shift"], ["a"]),
+        helper.make_node("Relu", ["a"], ["r"]),
+        helper.make_node("GlobalAveragePool", ["r"], ["y"]),
+    ]
+    return _model(
+        nodes,
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 16, 16])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 8, 1, 1])],
+        [w, b, scale, shift],
+        "conv_bn_relu",
+    )
+
+
+def foldable_shape_reshape() -> onnx.ModelProto:
+    """Shape -> Gather -> Concat -> Reshape: the classic chain onnxsim folds.
+
+    The reshape target is fully determined by constants, so onnxsim collapses
+    the whole shape-computation subgraph into a single constant. A good check
+    that the folded result still converts and matches.
+    """
+    w = _const("w", _rand(8, 3, 3, 3, seed=1))
+    idx = _const("idx", np.array([0], np.int64))
+    minus1 = _const("m1", np.array([-1], np.int64))
+    ch = _const("ch", np.array([8], np.int64))
+    nodes = [
+        helper.make_node("Conv", ["x", "w"], ["c"], pads=[1, 1, 1, 1]),
+        helper.make_node("Relu", ["c"], ["r"]),
+        helper.make_node("Shape", ["r"], ["shp"]),
+        helper.make_node("Gather", ["shp", "idx"], ["n"], axis=0),
+        helper.make_node("Concat", ["n", "ch", "m1"], ["newshape"], axis=0),
+        helper.make_node("Reshape", ["r", "newshape"], ["y"]),
+    ]
+    return _model(
+        nodes,
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 8, 8])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 8, 64])],
+        [w, idx, minus1, ch],
+        "foldable_shape_reshape",
+    )
+
+
+def matmul_bias_tanh() -> onnx.ModelProto:
+    """A small MLP block: MatMul -> Add(bias) -> Tanh.
+
+    The bias is expressed as ``bias0 + bias1`` so onnxsim folds it to a single
+    constant; the QNN result must be unchanged by that fold.
+    """
+    wt = _const("wt", _rand(32, 64, seed=4))
+    bias0 = _const("bias0", _rand(64, seed=5))
+    bias1 = _const("bias1", _rand(64, seed=6))
+    nodes = [
+        helper.make_node("Add", ["bias0", "bias1"], ["bias"]),
+        helper.make_node("MatMul", ["x", "wt"], ["mm"]),
+        helper.make_node("Add", ["mm", "bias"], ["h"]),
+        helper.make_node("Tanh", ["h"], ["y"]),
+    ]
+    return _model(
+        nodes,
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [4, 32])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [4, 64])],
+        [wt, bias0, bias1],
+        "matmul_bias_tanh",
+    )
+
+
+def redundant_transpose() -> onnx.ModelProto:
+    """Two transposes that cancel, plus an Add with a foldable constant.
+
+    onnxsim removes the no-op transpose pair and folds ``k0 + k1``; the QNN
+    result should be unchanged.
+    """
+    k0 = _const("k0", _rand(1, 4, 8, 8, seed=6))
+    k1 = _const("k1", _rand(1, 4, 8, 8, seed=7))
+    nodes = [
+        helper.make_node("Add", ["k0", "k1"], ["k"]),
+        helper.make_node("Add", ["x", "k"], ["s"]),
+        helper.make_node("Transpose", ["s"], ["t1"], perm=[0, 2, 3, 1]),
+        helper.make_node("Transpose", ["t1"], ["t2"], perm=[0, 3, 1, 2]),
+        helper.make_node("Relu", ["t2"], ["y"]),
+    ]
+    return _model(
+        nodes,
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 4, 8, 8])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 4, 8, 8])],
+        [k0, k1],
+        "redundant_transpose",
+    )
+
+
+def sigmoid_mul_swish() -> onnx.ModelProto:
+    """Conv -> Sigmoid -> Mul (Swish/SiLU), a common mobile activation."""
+    w = _const("w", _rand(6, 3, 1, 1, seed=8))
+    nodes = [
+        helper.make_node("Conv", ["x", "w"], ["c"]),
+        helper.make_node("Sigmoid", ["c"], ["s"]),
+        helper.make_node("Mul", ["c", "s"], ["y"]),
+    ]
+    return _model(
+        nodes,
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 12, 12])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 6, 12, 12])],
+        [w],
+        "sigmoid_mul_swish",
+    )
+
+
+# Ordered so the registry is stable across runs.
+_BUILDERS: List[Tuple[str, Callable[[], onnx.ModelProto]]] = [
+    ("conv_bn_relu", conv_bn_relu),
+    ("foldable_shape_reshape", foldable_shape_reshape),
+    ("matmul_bias_tanh", matmul_bias_tanh),
+    ("redundant_transpose", redundant_transpose),
+    ("sigmoid_mul_swish", sigmoid_mul_swish),
+]
+
+
+def all_models() -> Dict[str, onnx.ModelProto]:
+    """Build the whole suite: {name: ModelProto}."""
+    return {name: build() for name, build in _BUILDERS}
+
+
+def names() -> List[str]:
+    return [name for name, _ in _BUILDERS]
+
+
+def build(name: str) -> onnx.ModelProto:
+    for n, builder in _BUILDERS:
+        if n == name:
+            return builder()
+    raise KeyError(name)
+
+
+if __name__ == "__main__":
+    for n, m in all_models().items():
+        print(f"{n:24} {len(m.graph.node)} nodes")

--- a/scripts/qualcomm/qnn_backend.py
+++ b/scripts/qualcomm/qnn_backend.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Thin wrapper around the ONNX Runtime QNN execution provider.
+
+The Qualcomm AI Runtime (QNN) execution provider ships in the ``onnxruntime-qnn``
+PyPI wheel. On an ordinary x86-64 Linux host (no Snapdragon device) the bundled
+**HTP** backend still does the full *offline graph preparation* — the same
+compile that a Qualcomm converter would run — via ``libHtpPrepare.so``, and then
+executes the compiled graph in the **x86 host emulator**. That gives us two
+signals with nothing but ``pip install onnxruntime-qnn`` and a CPU runner:
+
+* **compatibility** — does the (simplified) graph compile onto QNN at all, and
+  how much of it maps to the accelerator vs. falling back to ONNX Runtime's CPU
+  provider;
+* **numerics** — do the emulated QNN outputs match the ONNX Runtime CPU
+  reference, i.e. did onnxsim preserve semantics along the QNN path.
+
+The wheel does **not** ship the QNN *CPU reference* backend (``libQnnCpu.so``);
+that only comes with the full QAIRT SDK. Point ``QNN_BACKEND_PATH`` at a
+``libQnnCpu.so`` from an SDK install to use the true reference backend instead
+of HTP emulation; everything else here is unchanged.
+
+This module degrades gracefully: on a host where the QNN EP cannot be loaded
+(e.g. no ``onnxruntime-qnn``, or an unsupported platform) ``QNN_AVAILABLE`` is
+False and ``unavailable_reason()`` explains why, so callers can skip rather than
+error.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import onnx
+
+# HTP graph-finalization optimization level. "3" is the most aggressive offline
+# optimization; it makes the compile a little slower but exercises the same path
+# a shipped model would take.
+_HTP_OPT_MODE = os.environ.get("QNN_HTP_OPT_MODE", "3")
+
+_EP_NAME = "QNNExecutionProvider"
+
+QNN_AVAILABLE = False
+_UNAVAILABLE_REASON: Optional[str] = None
+_REGISTERED = False
+
+try:
+    import onnxruntime as ort
+    import onnxruntime_qnn as _oqnn
+
+    # Backend selection: default to the wheel-bundled HTP backend (offline
+    # prepare + x86 emulation); allow an override to e.g. a QAIRT libQnnCpu.so.
+    _BACKEND_PATH = os.environ.get("QNN_BACKEND_PATH") or _oqnn.get_qnn_htp_path()
+    if not os.path.exists(_BACKEND_PATH):
+        raise FileNotFoundError(f"QNN backend library not found: {_BACKEND_PATH}")
+    QNN_AVAILABLE = True
+except Exception as exc:  # pragma: no cover - depends on the host
+    _UNAVAILABLE_REASON = f"{type(exc).__name__}: {exc}"
+
+
+def unavailable_reason() -> Optional[str]:
+    """Why the QNN EP is unusable on this host, or None if it is usable."""
+    return _UNAVAILABLE_REASON
+
+
+def backend_path() -> str:
+    """Absolute path to the QNN backend library in use (HTP by default)."""
+    return _BACKEND_PATH
+
+
+def ensure_registered() -> None:
+    """Register the QNN plugin EP with ONNX Runtime (idempotent).
+
+    ORT 1.24+ loads the QNN provider as a plugin: the library is registered by
+    name, then selected per session via the OrtEpDevice API. Registering twice
+    raises, so guard it.
+    """
+    global _REGISTERED
+    if _REGISTERED:
+        return
+    ort.register_execution_provider_library(_EP_NAME, _oqnn.get_library_path())
+    _REGISTERED = True
+
+
+def _qnn_devices() -> list:
+    ensure_registered()
+    devices = [d for d in ort.get_ep_devices() if d.ep_name == _EP_NAME]
+    if not devices:
+        raise RuntimeError("QNN EP registered but no QNN OrtEpDevice was exposed")
+    return devices
+
+
+@contextlib.contextmanager
+def silence_native_output():
+    """Silence C-level stdout/stderr (the HTP compiler is very chatty).
+
+    The QNN HTP backend prints its compile stages straight to the process's file
+    descriptors, below Python's ``sys.stdout``. Redirect fds 1/2 to /dev/null
+    for the duration so aggregated logs stay readable. Only wrap the ORT calls,
+    never the code that emits real results.
+    """
+    devnull = os.open(os.devnull, os.O_WRONLY)
+    saved = (os.dup(1), os.dup(2))
+    try:
+        os.dup2(devnull, 1)
+        os.dup2(devnull, 2)
+        yield
+    finally:
+        os.dup2(saved[0], 1)
+        os.dup2(saved[1], 2)
+        for fd in (devnull, *saved):
+            os.close(fd)
+
+
+def _session_options(strict: bool):
+    so = ort.SessionOptions()
+    so.log_severity_level = 3  # ERROR
+    if strict:
+        # Fail session creation if any node cannot be placed on QNN, instead of
+        # silently falling back to ORT's CPU provider. Used to measure coverage.
+        so.add_session_config_entry("session.disable_cpu_ep_fallback", "1")
+    return so
+
+
+def run_with_qnn(
+    model: onnx.ModelProto,
+    feeds: Dict[str, np.ndarray],
+    strict: bool = False,
+) -> List[np.ndarray]:
+    """Compile ``model`` with the QNN EP and run it, returning the outputs.
+
+    With ``strict=True`` the session is built with CPU fallback disabled, so
+    creation raises unless the *entire* graph maps onto QNN.
+    """
+    devices = _qnn_devices()
+    so = _session_options(strict)
+    so.add_provider_for_devices(
+        devices,
+        {
+            "backend_path": _BACKEND_PATH,
+            "htp_graph_finalization_optimization_mode": _HTP_OPT_MODE,
+        },
+    )
+    with silence_native_output():
+        sess = ort.InferenceSession(model.SerializeToString(), sess_options=so)
+        return sess.run(None, feeds)
+
+
+def run_with_cpu(
+    model: onnx.ModelProto, feeds: Dict[str, np.ndarray]
+) -> List[np.ndarray]:
+    """Run ``model`` on ONNX Runtime's CPU provider (the numerical reference)."""
+    so = _session_options(strict=False)
+    with silence_native_output():
+        sess = ort.InferenceSession(
+            model.SerializeToString(),
+            sess_options=so,
+            providers=["CPUExecutionProvider"],
+        )
+        return sess.run(None, feeds)
+
+
+def coverage(model: onnx.ModelProto) -> str:
+    """ "full" if the whole graph maps onto QNN, else "partial".
+
+    Determined by trying to build a session with CPU fallback disabled: success
+    means every node was accepted by the QNN EP.
+    """
+    try:
+        devices = _qnn_devices()
+        so = _session_options(strict=True)
+        so.add_provider_for_devices(
+            devices,
+            {
+                "backend_path": _BACKEND_PATH,
+                "htp_graph_finalization_optimization_mode": _HTP_OPT_MODE,
+            },
+        )
+        with silence_native_output():
+            ort.InferenceSession(model.SerializeToString(), sess_options=so)
+        return "full"
+    except Exception:
+        return "partial"
+
+
+_ELEM_TO_NP = {
+    onnx.TensorProto.FLOAT: np.float32,
+    onnx.TensorProto.DOUBLE: np.float64,
+    onnx.TensorProto.FLOAT16: np.float16,
+    onnx.TensorProto.INT64: np.int64,
+    onnx.TensorProto.INT32: np.int32,
+    onnx.TensorProto.BOOL: np.bool_,
+}
+
+
+def random_feeds(
+    model: onnx.ModelProto, seed: int = 0, default_dim: int = 1
+) -> Dict[str, np.ndarray]:
+    """Deterministic random inputs for every graph input that is not an initializer.
+
+    Unknown / dynamic dimensions (``dim_param`` or missing) are filled with
+    ``default_dim``. Float inputs use a small range so HTP emulation does not
+    overflow; integer inputs use small non-negative values.
+    """
+    rng = np.random.RandomState(seed)
+    initializers = {init.name for init in model.graph.initializer}
+    feeds: Dict[str, np.ndarray] = {}
+    for inp in model.graph.input:
+        if inp.name in initializers:
+            continue
+        ttype = inp.type.tensor_type
+        shape = []
+        for dim in ttype.shape.dim:
+            if dim.HasField("dim_value") and dim.dim_value > 0:
+                shape.append(dim.dim_value)
+            else:
+                shape.append(default_dim)
+        np_dtype = _ELEM_TO_NP.get(ttype.elem_type, np.float32)
+        if np.issubdtype(np_dtype, np.floating):
+            feeds[inp.name] = (rng.rand(*shape).astype(np_dtype) - 0.5) * 2.0
+        elif np_dtype == np.bool_:
+            feeds[inp.name] = rng.rand(*shape) > 0.5
+        else:
+            feeds[inp.name] = rng.randint(0, 4, size=shape).astype(np_dtype)
+    return feeds
+
+
+def compare(
+    reference: List[np.ndarray],
+    candidate: List[np.ndarray],
+    rtol: float = 1e-2,
+    atol: float = 1e-3,
+) -> Tuple[bool, float]:
+    """Return (all_close, max_abs_diff) over matching output tensors."""
+    max_diff = 0.0
+    ok = True
+    for ref, cand in zip(reference, candidate):
+        ref_a = np.asarray(ref, dtype=np.float64)
+        cand_a = np.asarray(cand, dtype=np.float64)
+        if ref_a.shape != cand_a.shape:
+            return False, float("inf")
+        diff = float(np.max(np.abs(ref_a - cand_a))) if ref_a.size else 0.0
+        max_diff = max(max_diff, diff)
+        if not np.allclose(ref_a, cand_a, rtol=rtol, atol=atol):
+            ok = False
+    return ok, max_diff

--- a/scripts/qualcomm/run_qnn_compat.py
+++ b/scripts/qualcomm/run_qnn_compat.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Run the QNN compatibility check over the model suite and report.
+
+Drives ``worker.py`` once per model (isolated subprocess, hard timeout), collects
+the JSON results, writes a CSV, prints a summary, and exits non-zero if any model
+failed. This is the entry point the ``Qualcomm Integration`` workflow calls.
+
+A model **fails** the check when simplification breaks QNN compatibility or
+changes the on-device result (``qnn_regression``), when onnxsim raises
+(``simplify_error``), or when the worker crashes/times out. A graph the QNN
+backend cannot handle even *before* simplification is ``unsupported`` and is
+**reported, not failed** — that is a backend limitation, not an onnxsim bug.
+Partial QNN coverage (some nodes falling back to ORT's CPU provider) is likewise
+reported, not failed — plenty of valid graphs are not 100% HTP-mappable.
+
+If the QNN EP is unavailable on the host, every model reports ``skipped`` and the
+run passes (nothing to test) unless ``--require-qnn`` is given.
+
+Usage:
+    run_qnn_compat.py --output qnn.csv
+    run_qnn_compat.py --require-qnn          # fail if the QNN EP is missing
+    run_qnn_compat.py --models conv_bn_relu matmul_add_gelu
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import models  # noqa: E402
+
+FAIL_STATUSES = {"qnn_regression", "simplify_error", "crash", "timeout", "error"}
+
+
+def run_one(model_name: str, timeout: int) -> dict:
+    t0 = time.time()
+    try:
+        proc = subprocess.run(
+            [sys.executable, os.path.join(HERE, "worker.py"), model_name],
+            capture_output=True,
+            text=True,
+            timeout=None if timeout <= 0 else timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "model": model_name,
+            "status": "timeout",
+            "error": f">{timeout}s",
+            "seconds": timeout,
+        }
+    result = None
+    for line in proc.stdout.splitlines():
+        if line.startswith("__RESULT__"):
+            result = json.loads(line[len("__RESULT__") :])
+    if result is None:
+        result = {
+            "model": model_name,
+            "status": "crash",
+            "error": (proc.stderr or proc.stdout or "no result line")[-400:],
+            "seconds": round(time.time() - t0, 1),
+        }
+    return result
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--models",
+        nargs="*",
+        default=None,
+        help="subset of model names to run (default: the whole suite)",
+    )
+    ap.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="per-model wall-clock cap in seconds; <=0 disables",
+    )
+    ap.add_argument(
+        "--require-qnn",
+        action="store_true",
+        help="fail if the QNN EP is unavailable instead of skipping",
+    )
+    ap.add_argument("--output", default="qnn-compat.csv")
+    args = ap.parse_args()
+
+    selected = args.models or models.names()
+    print(f"QNN compatibility check | {len(selected)} models", flush=True)
+
+    rows = []
+    failures = []
+    skipped = 0
+    for i, name in enumerate(selected, 1):
+        print(f"[{i}/{len(selected)}] {name} ...", end=" ", flush=True)
+        r = run_one(name, args.timeout)
+        rows.append(r)
+        status = r.get("status")
+        if status == "skipped":
+            skipped += 1
+            print(f"skipped ({r.get('error')})", flush=True)
+            continue
+        detail = ""
+        if r.get("orig_nodes") is not None:
+            detail = f"{r.get('orig_nodes')}->{r.get('simp_nodes')} nodes"
+        if r.get("coverage_orig") or r.get("coverage_simp"):
+            detail += f", qnn={r.get('coverage_orig')}->{r.get('coverage_simp')}"
+        if r.get("diff_vs_qnn_orig") is not None:
+            detail += f", d(orig)={r.get('diff_vs_qnn_orig'):.2g}"
+        print(f"{status} ({detail}) {r.get('seconds')}s", flush=True)
+        if status in FAIL_STATUSES:
+            failures.append((name, status, str(r.get("error"))[:200]))
+
+    fields = [
+        "model",
+        "status",
+        "orig_nodes",
+        "simp_nodes",
+        "coverage_orig",
+        "coverage_simp",
+        "diff_vs_qnn_orig",
+        "diff_vs_cpu_ref",
+        "seconds",
+        "error",
+    ]
+    with open(args.output, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+    print(f"\nwrote {args.output} ({len(rows)} rows)", flush=True)
+
+    if skipped == len(selected):
+        msg = "QNN EP unavailable on this host; all models skipped."
+        if args.require_qnn:
+            print(f"\n{msg} (--require-qnn set -> failing)", flush=True)
+            return 1
+        print(f"\n{msg} Nothing to test; passing.", flush=True)
+        return 0
+
+    if failures:
+        print(f"\n{len(failures)} FAILED:", flush=True)
+        for name, status, err in failures:
+            print(f"  - {name}: {status} {err}", flush=True)
+        return 1
+    passed = sum(1 for r in rows if r.get("status") == "ok")
+    unsupported = sum(1 for r in rows if r.get("status") == "unsupported")
+    print(
+        f"\nall passed ({passed} ok, {unsupported} unsupported, {skipped} skipped)",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/qualcomm/worker.py
+++ b/scripts/qualcomm/worker.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Check one model against the QNN execution provider, in an isolated subprocess.
+
+Run as ``worker.py <model_name> [onnx_path]``. With just a name, the model comes
+from the built-in ``models.py`` suite; with an ``onnx_path`` the graph is loaded
+from disk (so the same worker handles real onnxmodelzoo models later). The QNN
+HTP compiler can be heavy and, on some ops, abort at the C++ level, so each model
+runs in its own process and the final stdout line is exactly ``__RESULT__<json>``
+— the same protocol as the large-model regression harness.
+
+The check is deliberately framed as *original vs. simplified on the same QNN
+backend*, so that a backend limitation (an op the HTP x86 emulator will not
+finalize in fp32, say) cancels out and only an onnxsim-introduced change can
+fail the run. For one model:
+
+1. ``simplify`` it with onnxsim.
+2. Build deterministic random inputs.
+3. Run the **original** graph on the QNN EP.
+   * If that already fails to compile/run, the backend simply does not support
+     this graph — status ``unsupported`` (reported, not a failure).
+4. Run the **simplified** graph on the QNN EP.
+   * If the original compiled but the simplified does not, simplification broke
+     QNN compatibility — status ``qnn_regression`` (a failure).
+5. Compare the two QNN outputs. Divergence beyond tolerance means simplification
+   changed the on-device result — ``qnn_regression`` (a failure).
+6. Also record the ONNX Runtime CPU reference diff and the QNN partition coverage
+   (full vs. partial) for both graphs, as information.
+
+Status values:
+
+* ``ok``             - original & simplified both ran on QNN and agreed.
+* ``qnn_regression`` - the simplified graph broke QNN compat or changed results.
+* ``simplify_error`` - onnxsim raised on this model.
+* ``unsupported``    - the QNN backend could not handle even the original graph.
+* ``skipped``        - the QNN EP is not available on this host.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import traceback
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+
+def check(model_name: str, onnx_path: str | None) -> dict:
+    res = {
+        "model": model_name,
+        "status": "error",
+        "orig_nodes": None,
+        "simp_nodes": None,
+        "coverage_orig": None,
+        "coverage_simp": None,
+        "diff_vs_qnn_orig": None,
+        "diff_vs_cpu_ref": None,
+        "error": None,
+        "seconds": None,
+    }
+    t0 = time.time()
+    try:
+        import onnx
+        import qnn_backend as qnn
+
+        if not qnn.QNN_AVAILABLE:
+            res["status"] = "skipped"
+            res["error"] = qnn.unavailable_reason()
+            return res
+
+        from onnxsim import simplify
+
+        if onnx_path:
+            model = onnx.load(onnx_path)
+        else:
+            import models
+
+            model = models.build(model_name)
+        res["orig_nodes"] = len(model.graph.node)
+
+        try:
+            simp, _check_ok = simplify(model)
+        except Exception as exc:
+            res["status"] = "simplify_error"
+            res["error"] = f"{type(exc).__name__}: {exc}"
+            return res
+        res["simp_nodes"] = len(simp.graph.node)
+
+        feeds = qnn.random_feeds(model, seed=0)
+
+        # ORT CPU reference (informational end-to-end check).
+        cpu_ref = qnn.run_with_cpu(model, feeds)
+
+        # Original graph on QNN. If this fails, the backend can't handle the
+        # graph at all — not something onnxsim did.
+        try:
+            res["coverage_orig"] = qnn.coverage(model)
+            qnn_orig = qnn.run_with_qnn(model, feeds)
+        except Exception as exc:
+            res["status"] = "unsupported"
+            res["error"] = f"original graph not supported by QNN: {exc}"
+            return res
+
+        # Simplified graph on QNN. The original worked, so a failure here is an
+        # onnxsim-introduced compatibility regression.
+        try:
+            res["coverage_simp"] = qnn.coverage(simp)
+            qnn_simp = qnn.run_with_qnn(simp, feeds)
+        except Exception as exc:
+            res["status"] = "qnn_regression"
+            res["error"] = f"simplified graph broke QNN compile/run: {exc}"
+            return res
+
+        # Simplification must not change the on-device result.
+        agree, diff_backend = qnn.compare(qnn_orig, qnn_simp)
+        _, diff_ref = qnn.compare(cpu_ref, qnn_simp)
+        res["diff_vs_qnn_orig"] = diff_backend
+        res["diff_vs_cpu_ref"] = diff_ref
+        if agree:
+            res["status"] = "ok"
+        else:
+            res["status"] = "qnn_regression"
+            res["error"] = (
+                f"simplified QNN output diverged from original "
+                f"(max_abs_diff={diff_backend:.3g})"
+            )
+    except Exception as exc:
+        res["error"] = f"{type(exc).__name__}: {exc}"
+        res["trace"] = traceback.format_exc()[-800:]
+    finally:
+        res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+if __name__ == "__main__":
+    name = sys.argv[1]
+    path = sys.argv[2] if len(sys.argv) > 2 else None
+    print("__RESULT__" + json.dumps(check(name, path)))

--- a/tests/test_qnn_compat.py
+++ b/tests/test_qnn_compat.py
@@ -1,0 +1,75 @@
+"""Qualcomm QNN execution-provider compatibility test.
+
+Verifies that onnxsim's output still compiles and runs on the Qualcomm AI Runtime
+(QNN) execution provider, and that simplification does not change the on-device
+result. Uses the pip-installable ``onnxruntime-qnn`` wheel: on a plain x86-64
+CPU host (no Snapdragon device) the bundled HTP backend does the full offline
+graph compile and executes in the x86 emulator, so this runs on an ordinary CI
+runner.
+
+The whole module is skipped when ``onnxruntime-qnn`` is not installed (the
+default test matrix does not pull it in), so it is safe to keep in ``tests/``.
+The heavy, curated model sweep lives in ``scripts/qualcomm`` and runs on a
+schedule; this file is the fast, in-tree smoke test.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+# The QNN harness lives under scripts/qualcomm; reuse it rather than duplicate.
+_QUALCOMM_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "qualcomm"
+)
+if _QUALCOMM_DIR not in sys.path:
+    sys.path.insert(0, _QUALCOMM_DIR)
+
+import models  # noqa: E402
+import qnn_backend as qnn  # noqa: E402
+from worker import check  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not qnn.QNN_AVAILABLE,
+    reason=f"QNN execution provider unavailable: {qnn.unavailable_reason()}",
+)
+
+
+@pytest.mark.parametrize("name", models.names())
+def test_qnn_compat_suite(name):
+    """Each suite model: simplification must not break or change the QNN result."""
+    result = check(name, None)
+    # ``unsupported`` (the backend can't handle the graph at all) is acceptable;
+    # a regression / crash / error is not.
+    assert result["status"] in ("ok", "unsupported"), result
+
+
+def test_qnn_matches_cpu_reference():
+    """A directly-built graph: QNN(simplified) matches the ORT CPU reference."""
+    from onnxsim import simplify
+
+    model = models.conv_bn_relu()
+    simp, _ = simplify(model)
+    feeds = qnn.random_feeds(model, seed=0)
+
+    reference = qnn.run_with_cpu(model, feeds)
+    candidate = qnn.run_with_qnn(simp, feeds)
+
+    close, max_diff = qnn.compare(reference, candidate)
+    assert close, f"QNN output diverged from CPU reference: max_abs_diff={max_diff}"
+
+
+def test_simplify_is_bit_exact_on_qnn():
+    """Simplification should not change what the QNN backend computes."""
+    from onnxsim import simplify
+
+    model = models.redundant_transpose()
+    simp, _ = simplify(model)
+    feeds = qnn.random_feeds(model, seed=1)
+
+    qnn_orig = qnn.run_with_qnn(model, feeds)
+    qnn_simp = qnn.run_with_qnn(simp, feeds)
+
+    for a, b in zip(qnn_orig, qnn_simp):
+        np.testing.assert_allclose(a, b, rtol=0, atol=0)


### PR DESCRIPTION
## Summary

Adds a comprehensive integration test suite for validating that `onnxsim` simplifications remain compatible with the Qualcomm AI Runtime (QNN) execution provider. This catches a critical failure mode: simplifications that produce graphs the Qualcomm toolchain can no longer compile or that change results on-device.

## Key Changes

- **`scripts/qualcomm/qnn_backend.py`**: Thin wrapper around the ONNX Runtime QNN execution provider. Handles plugin registration, session creation with HTP offline compilation and x86 emulation, coverage measurement, input generation, and output comparison. Degrades gracefully when the QNN EP is unavailable.

- **`scripts/qualcomm/models.py`**: Self-contained suite of 5 synthetic ONNX graphs covering common patterns (conv+BN+relu, foldable shape→reshape chains, MLP blocks, cancelling transposes, swish activation). Each model includes the redundancy that `onnxsim` is designed to remove, ensuring the test exercises actual simplification.

- **`scripts/qualcomm/worker.py`**: Per-model checker that runs in an isolated subprocess. Compares original vs. simplified graphs on the same QNN backend, so backend quirks cancel and only onnxsim-introduced changes can fail. Outputs a single `__RESULT__<json>` line for structured result collection.

- **`scripts/qualcomm/run_qnn_compat.py`**: Orchestrator that drives the suite, collects results, writes a CSV report, and exits non-zero on regressions. Distinguishes between failures (simplification broke compatibility/numerics) and unsupported graphs (backend limitation, not a bug).

- **`.github/workflows/qualcomm-integration.yml`**: CI workflow that builds `onnxsim` from the current branch, installs `onnxruntime-qnn`, and runs the full compatibility check. Scheduled weekly, on-demand, and on PRs touching the harness.

- **`scripts/qualcomm/README.md`**: Documentation explaining the check's scope, fidelity tiers (HTP emulation vs. real hardware), and how to run locally.

- **`tests/test_qnn_compat.py`**: Fast in-tree smoke test that reuses the harness. Parametrized over the model suite; skipped automatically when `onnxruntime-qnn` is not installed.

## Implementation Details

- **Graceful degradation**: The entire suite works without `onnxruntime-qnn` installed; tests skip rather than error.
- **No device required**: Uses the pip-installable `onnxruntime-qnn` wheel's bundled HTP backend, which performs full offline graph compilation and executes in an x86 emulator on a standard CPU runner.
- **Subprocess isolation**: Each model runs in its own process with a hard timeout, since the HTP compiler can be heavy and abort at the C++ level.
- **Comprehensive reporting**: CSV output includes node counts, QNN coverage (full vs. partial), numerical diffs vs. CPU reference, and per-model timing.
- **Failure classification**: Distinguishes regressions (simplification broke something) from unsupported graphs (backend limitation) and skipped runs (QNN EP unavailable).

https://claude.ai/code/session_01H27hunBcnaJCpKBPsNASC1