### PR TITLE
Add initializers_as_constants option to control constant folding

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ At its core onnxsim runs a fixed point of shape inference, graph optimization an
 constant folding until the model stops changing. Around that it offers:
 
 - **Constant folding.** Evaluates the constant parts of the graph and replaces
-  redundant operators with their computed outputs.
+  redundant operators with their computed outputs. By default initializers count
+  as constants; pass `--initializers-as-non-constants` (Python:
+  `initializers_as_constants=False`) to keep weights as tunable tensors so nodes
+  rooted only at initializers — and value-baking fusions such as fuse BatchNorm
+  into Conv — are left untouched.
 - **Graph optimization passes.** Runs onnx-optimizer's fusions and eliminations
   (e.g. fuse BatchNorm into Conv). List them with
   `onnxsim --list-default-optimizers`; skip all or some with

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -313,11 +313,10 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
          ONNX_NAMESPACE::ModelProto model;
          ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
                              model_proto_bytes.size());
-         auto const result =
-             Simplify(*executor, model, skip_optimizers, constant_folding,
-                      shape_inference, tensor_size_threshold,
-                      target_opset_version, rewriter.get(),
-                      initializers_as_constants);
+         auto const result = Simplify(
+             *executor, model, skip_optimizers, constant_folding,
+             shape_inference, tensor_size_threshold, target_opset_version,
+             rewriter.get(), initializers_as_constants);
          std::string out;
          result.SerializeToString(&out);
          return py::bytes(out.data(), out.size());

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -306,7 +306,8 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
           std::optional<std::vector<std::string>> skip_optimizers,
           bool constant_folding, bool shape_inference,
           size_t tensor_size_threshold, std::optional<int> target_opset_version,
-          std::shared_ptr<GraphRewriter> rewriter) -> py::bytes {
+          std::shared_ptr<GraphRewriter> rewriter,
+          bool initializers_as_constants) -> py::bytes {
          // force env initialization to register opset
          InitEnv();
          ONNX_NAMESPACE::ModelProto model;
@@ -315,7 +316,8 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
          auto const result =
              Simplify(*executor, model, skip_optimizers, constant_folding,
                       shape_inference, tensor_size_threshold,
-                      target_opset_version, rewriter.get());
+                      target_opset_version, rewriter.get(),
+                      initializers_as_constants);
          std::string out;
          result.SerializeToString(&out);
          return py::bytes(out.data(), out.size());
@@ -323,7 +325,7 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
        "executor"_a, "model_bytes"_a, "skip_optimizers"_a.none(),
        "constant_folding"_a = true, "shape_inference"_a = true,
        "tensor_size_threshold"_a, "target_opset_version"_a.none(),
-       "rewriter"_a.none())
+       "rewriter"_a.none(), "initializers_as_constants"_a = true)
       .def(
           "simplify_path",
           [](std::shared_ptr<PyModelExecutor> executor,
@@ -332,19 +334,20 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
              bool constant_folding, bool shape_inference,
              size_t tensor_size_threshold,
              std::optional<int> target_opset_version,
-             std::shared_ptr<GraphRewriter> rewriter) -> bool {
+             std::shared_ptr<GraphRewriter> rewriter,
+             bool initializers_as_constants) -> bool {
             // force env initialization to register opset
             InitEnv();
             SimplifyPath(*executor, in_path, out_path, skip_optimizers,
                          constant_folding, shape_inference,
                          tensor_size_threshold, target_opset_version,
-                         rewriter.get());
+                         rewriter.get(), initializers_as_constants);
             return true;
           },
           "executor"_a, "in_path"_a, "out_path"_a, "skip_optimizers"_a.none(),
           "constant_folding"_a = true, "shape_inference"_a = true,
           "tensor_size_threshold"_a, "target_opset_version"_a.none(),
-          "rewriter"_a.none())
+          "rewriter"_a.none(), "initializers_as_constants"_a = true)
       .def("_list_optimizers",
            []() {
              py::list ret;

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -331,6 +331,7 @@ def simplify(
     tensor_size_threshold: str = DEFAULT_TENSOR_SIZE_THRESHOLDHOLD,
     mutable_initializer: bool = False,
     *,
+    initializers_as_constants: bool = True,
     import_custom_schemas: bool = True,
     input_shapes=None,
     target_opset_version: Optional[int] = None,
@@ -357,6 +358,14 @@ def simplify(
     :param custom_lib: onnxruntime custom ops's shared library
     :param include_subgraph: Simplify subgraph (e.g. true graph and false graph of "If" operator) instead of only the main graph
     :param unused_output: name of unused outputs that will be eliminated from the model
+    :param initializers_as_constants: Whether initializers are treated as constant tensors
+            (the default, ``True``). When set to ``False``, initializers are treated as
+            non-constant: constant folding leaves nodes that depend only on initializers in the
+            graph, and the onnx optimizer's value-baking passes (e.g. ``fuse_bn_into_conv``) are
+            told to leave initializer-backed weights alone, so the weights survive simplification
+            as tunable tensors. ``Constant`` nodes are still folded either way. This is orthogonal
+            to ``mutable_initializer`` (which controls whether initializers also remain graph
+            inputs).
     :param import_custom_schemas: Import operator schemas registered in the Python `onnx` module
             (e.g. via `onnx.defs.register_schema`) into onnxsim's own registry so models using
             custom operators pass validation. Set to False to disable this and leave onnxsim's
@@ -569,6 +578,7 @@ def simplify(
             tensor_size_threshold_bytes,
             target_opset_version,
             rewriter,
+            initializers_as_constants,
         )
         # The serialized original (~1x model) is not needed once the C++
         # simplifier has consumed it -- the large-model fallback below
@@ -636,6 +646,7 @@ def simplify(
                 tensor_size_threshold_bytes,
                 target_opset_version,
                 rewriter,
+                initializers_as_constants,
             )
             check_ok = model_checking.compare(
                 os.path.join(tmpdirname, "opt.onnx"),
@@ -872,6 +883,15 @@ def main():
         action="store_true",
     )
     parser.add_argument(
+        "--initializers-as-non-constants",
+        help="Treat initializers as non-constant tensors. By default onnxsim treats "
+        "initializers as constants, so it constant-folds nodes that depend only on them "
+        "and lets value-baking optimizers (e.g. fuse_bn_into_conv) fold their weights. "
+        "Specify this flag to keep such weights untouched as tunable tensors; Constant "
+        "nodes are still folded. This is independent of --mutable-initializer.",
+        action="store_true",
+    )
+    parser.add_argument(
         "--save-as-external-data",
         help="Save parameters as external data. This will make the .onnx file much smaller, but the .onnx file will depend on the external data file (.data).",
         action="store_true",
@@ -1090,6 +1110,7 @@ def main():
         args.unused_output,
         args.tensor_size_threshold,
         args.mutable_initializer,
+        initializers_as_constants=not args.initializers_as_non_constants,
         import_custom_schemas=not args.skip_schema_import,
         target_opset_version=args.target_opset,
         check_rtol=args.check_rtol,

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -506,10 +506,10 @@ ConstantNodePartition GetConstantNodes(const onnx::ModelProto& model) {
   // the graph untouched; a node fed by a Constant node still folds because ""
   // and Constant outputs remain in the constant set.
   if (config.initializers_as_constants) {
-    std::transform(
-        model.graph().initializer().begin(), model.graph().initializer().end(),
-        std::back_inserter(const_names),
-        [](const auto& x) { return x.name(); });
+    std::transform(model.graph().initializer().begin(),
+                   model.graph().initializer().end(),
+                   std::back_inserter(const_names),
+                   [](const auto& x) { return x.name(); });
   }
   // Map each domain to its imported opset version so the correct operator
   // schema can be looked up. The default ONNX domain is normalized to an empty
@@ -1239,8 +1239,10 @@ onnx::ModelProto Optimize(const onnx::ModelProto& model) {
   // value-baking passes (fuse_bn_into_conv, ...) respect it too. The setting is
   // thread-local in the optimizer; restore it afterwards so we do not leak it.
   const bool prev = onnx::optimization::InitializersAsConstants();
-  onnx::optimization::SetInitializersAsConstants(config.initializers_as_constants);
-  auto result = onnx::optimization::OptimizeFixed(model, config.optimizer_passes);
+  onnx::optimization::SetInitializersAsConstants(
+      config.initializers_as_constants);
+  auto result =
+      onnx::optimization::OptimizeFixed(model, config.optimizer_passes);
   onnx::optimization::SetInitializersAsConstants(prev);
   return result;
 }

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -31,6 +31,12 @@ struct Config {
   std::vector<std::string> optimizer_passes;
   // default value is max
   size_t tensor_size_threshold = -1;
+  // Whether graph initializers are treated as constant tensors. When false,
+  // constant folding does not seed its constant set with initializer names, so
+  // nodes rooted only at initializers are left unfolded (see GetConstantNodes),
+  // and the onnx optimizer is told to leave initializer-backed weights alone
+  // too (see Optimize). Constant nodes are always constant.
+  bool initializers_as_constants = true;
 };
 
 Config config;
@@ -494,9 +500,17 @@ ConstantNodePartition GetConstantNodes(const onnx::ModelProto& model) {
   ConstantNodePartition partition;
   auto& const_nodes = partition.const_nodes;
   auto& non_const_nodes = partition.non_const_nodes;
-  std::transform(
-      model.graph().initializer().begin(), model.graph().initializer().end(),
-      std::back_inserter(const_names), [](const auto& x) { return x.name(); });
+  // Seed the constant set with the initializer names, unless the caller asked
+  // for initializers to be treated as non-constant. In that case a node whose
+  // inputs are (only) initializers is not foldable, so its weights are left in
+  // the graph untouched; a node fed by a Constant node still folds because ""
+  // and Constant outputs remain in the constant set.
+  if (config.initializers_as_constants) {
+    std::transform(
+        model.graph().initializer().begin(), model.graph().initializer().end(),
+        std::back_inserter(const_names),
+        [](const auto& x) { return x.name(); });
+  }
   // Map each domain to its imported opset version so the correct operator
   // schema can be looked up. The default ONNX domain is normalized to an empty
   // string, which is how the schema registry stores it.
@@ -1221,7 +1235,14 @@ onnx::ModelProto _FoldConstant(const ModelExecutor& executor,
 }
 
 onnx::ModelProto Optimize(const onnx::ModelProto& model) {
-  return onnx::optimization::OptimizeFixed(model, config.optimizer_passes);
+  // Mirror the initializer treatment into the onnx optimizer so its
+  // value-baking passes (fuse_bn_into_conv, ...) respect it too. The setting is
+  // thread-local in the optimizer; restore it afterwards so we do not leak it.
+  const bool prev = onnx::optimization::InitializersAsConstants();
+  onnx::optimization::SetInitializersAsConstants(config.initializers_as_constants);
+  auto result = onnx::optimization::OptimizeFixed(model, config.optimizer_passes);
+  onnx::optimization::SetInitializersAsConstants(prev);
+  return result;
 }
 
 // A 128-bit fingerprint of a model, used by FixedPointFn to detect when an
@@ -1497,7 +1518,8 @@ onnx::ModelProto Simplify(
     const ModelExecutor& executor, const onnx::ModelProto& model,
     std::optional<std::vector<std::string>> skip_optimizers,
     bool constant_folding, bool shape_inference, size_t tensor_size_threshold,
-    std::optional<int> target_opset_version, const GraphRewriter* rewriter) {
+    std::optional<int> target_opset_version, const GraphRewriter* rewriter,
+    bool initializers_as_constants) {
   // Make shape inference aware of ONNX Runtime's quantized contrib operators
   // (QLinearAdd and friends) so shape deduction does not stop at them.
   onnxsim::RegisterContribOpSchemas();
@@ -1509,6 +1531,7 @@ onnx::ModelProto Simplify(
   Check(model);
 
   config.tensor_size_threshold = tensor_size_threshold;
+  config.initializers_as_constants = initializers_as_constants;
   config.optimizer_passes.clear();
   // onnxsim already folds ``Gather`` on a ``Shape`` into constants on its own:
   // ``_EvalPartialShape`` (above) plus data-propagating shape inference resolve
@@ -1517,8 +1540,17 @@ onnx::ModelProto Simplify(
   // redundant here, and it aborts the whole process on graphs where a Gather
   // index cannot be statically resolved to an axis (common in dynamic-shape
   // detection models such as FasterRCNN). Always drop it from the pass list.
-  static const std::vector<std::string> kAlwaysDisabledPasses = {
-      "eliminate_shape_gather"};
+  std::vector<std::string> always_disabled_passes = {"eliminate_shape_gather"};
+  // When initializers are treated as non-constant, keep ``Constant`` nodes in
+  // producer form: ``extract_constant_to_initializer`` would rewrite every
+  // Constant into an initializer, which -- being non-constant now -- would then
+  // block onnxsim's own constant folding of genuinely-constant subgraphs. The
+  // value-baking passes themselves already leave initializer weights alone via
+  // ``IsConstantTensor`` (see the onnx-optimizer changes), so only this
+  // representation-changing pass needs dropping.
+  if (!initializers_as_constants) {
+    always_disabled_passes.push_back("extract_constant_to_initializer");
+  }
   auto is_disabled = [](const std::vector<std::string>& list,
                         const std::string& pass) {
     return std::find(list.begin(), list.end(), pass) != list.end();
@@ -1530,7 +1562,7 @@ onnx::ModelProto Simplify(
     const auto all_passes = onnx::optimization::GetFuseAndEliminationPass();
     for (const auto& pass : all_passes) {
       if (!is_disabled(*skip_optimizers, pass) &&
-          !is_disabled(kAlwaysDisabledPasses, pass)) {
+          !is_disabled(always_disabled_passes, pass)) {
         passes.push_back(pass);
       }
     }
@@ -1630,13 +1662,14 @@ void SimplifyPath(const ModelExecutor& executor, const std::string& in_path,
                   bool constant_folding, bool shape_inference,
                   size_t tensor_size_threshold,
                   std::optional<int> target_opset_version,
-                  const GraphRewriter* rewriter) {
+                  const GraphRewriter* rewriter,
+                  bool initializers_as_constants) {
   onnx::ModelProto model;
   onnx::optimization::loadModel(&model, in_path, true);
 
   model = Simplify(executor, model, skip_optimizers, constant_folding,
                    shape_inference, tensor_size_threshold, target_opset_version,
-                   rewriter);
+                   rewriter, initializers_as_constants);
 
   onnx::optimization::saveModel(&model, out_path, true, "");
 }

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -47,12 +47,21 @@ std::shared_ptr<const ModelExecutor> GetBuiltinModelExecutor();
 // of the default ONNX domain (using onnx's version converter) before
 // simplifying, so the simplifier can clean up any redundant nodes the
 // conversion introduces. std::nullopt leaves the opset version unchanged.
+// ``initializers_as_constants`` (default true) controls whether graph
+// initializers are treated as constant tensors during simplification. With the
+// default, initializers are constants: constant folding materializes nodes that
+// depend only on them, and the onnx optimizer's value-baking passes (e.g.
+// fuse_bn_into_conv) may fold them. When set to false, initializers are treated
+// as non-constant, so nodes rooted only at initializers are left in the graph
+// and their weights survive simplification as tunable tensors; ``Constant``
+// nodes are still treated as constants either way.
 onnx::ModelProto Simplify(
     const ModelExecutor& executor, const onnx::ModelProto& model,
     std::optional<std::vector<std::string>> skip_optimizers,
     bool constant_folding, bool shape_inference, size_t tensor_size_threshold,
     std::optional<int> target_opset_version = std::nullopt,
-    const GraphRewriter* rewriter = nullptr);
+    const GraphRewriter* rewriter = nullptr,
+    bool initializers_as_constants = true);
 
 void SimplifyPath(const ModelExecutor& executor, const std::string& in_path,
                   const std::string& out_path,
@@ -60,4 +69,5 @@ void SimplifyPath(const ModelExecutor& executor, const std::string& in_path,
                   bool constant_folding, bool shape_inference,
                   size_t tensor_size_threshold,
                   std::optional<int> target_opset_version = std::nullopt,
-                  const GraphRewriter* rewriter = nullptr);
+                  const GraphRewriter* rewriter = nullptr,
+                  bool initializers_as_constants = true);

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -1350,3 +1350,53 @@ def test_simplify_threads_check_tolerance(monkeypatch):
         check_atol=0.456,
     )
     assert captured == {"rtol": 0.123, "atol": 0.456}
+
+
+def _mul_init_by_const_model() -> onnx.ModelProto:
+    """A model ``y = (W * K) + x`` where ``W`` is an initializer and ``K`` is a
+    ``Constant`` node. ``W * K`` is foldable only when initializers count as
+    constants; ``x`` is a genuine graph input so the ``Add`` never folds."""
+    x = onnx.helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT, [1, 3])
+    y = onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [1, 3])
+    w = onnx.helper.make_tensor("W", onnx.TensorProto.FLOAT, [1, 3], [1.0, 2.0, 3.0])
+    const_node = onnx.helper.make_node(
+        "Constant",
+        inputs=[],
+        outputs=["K"],
+        value=onnx.helper.make_tensor(
+            "value", onnx.TensorProto.FLOAT, [1, 3], [2.0, 2.0, 2.0]
+        ),
+    )
+    mul = onnx.helper.make_node("Mul", inputs=["W", "K"], outputs=["M"])
+    add = onnx.helper.make_node("Add", inputs=["x", "M"], outputs=["y"])
+    graph = onnx.helper.make_graph(
+        [const_node, mul, add], "g", [x], [y], initializer=[w]
+    )
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 14)], ir_version=10
+    )
+
+
+def test_initializers_as_constants_default_folds_initializer():
+    # By default the initializer W is constant, so W * K is constant-folded away
+    # and only the Add on the real input survives.
+    model = _mul_init_by_const_model()
+    sim_model, ok = onnxsim.simplify(model)
+    assert ok
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert "Mul" not in op_types
+    assert op_types.count("Add") == 1
+
+
+def test_initializers_as_non_constants_keeps_initializer_node():
+    # Treating initializers as non-constant leaves the Mul on the initializer in
+    # the graph; only the Constant node (K) is still folded.
+    model = _mul_init_by_const_model()
+    sim_model, ok = onnxsim.simplify(model, initializers_as_constants=False)
+    assert ok
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert "Mul" in op_types
+    assert "Add" in op_types
+    # W stays an initializer, and K has been folded into one too.
+    init_names = {i.name for i in sim_model.graph.initializer}
+    assert "W" in init_names


### PR DESCRIPTION
## Summary
This PR adds a new `initializers_as_constants` configuration option that controls whether graph initializers are treated as constant tensors during simplification. This allows users to preserve initializer-based weights as tunable tensors while still folding genuinely constant subgraphs.

## Key Changes

- **New configuration option**: Added `initializers_as_constants` (default `true`) to the `Config` struct in `onnxsim.cpp`
  - When `true` (default): Initializers are treated as constants, enabling constant folding and value-baking optimizations (existing behavior)
  - When `false`: Initializers are treated as non-constant, preserving nodes that depend only on initializers as tunable weights

- **Constant folding logic**: Modified `GetConstantNodes()` to conditionally seed the constant set with initializer names based on the configuration flag

- **Optimizer integration**: Updated `Optimize()` to mirror the initializer treatment into the ONNX optimizer's value-baking passes via `SetInitializersAsConstants()`

- **Pass management**: Added logic to disable `extract_constant_to_initializer` pass when `initializers_as_constants=false` to prevent converting Constant nodes to initializers (which would then be treated as non-constant)

- **Python API**: 
  - Added `initializers_as_constants` parameter to `simplify()` function with default `True`
  - Added `--initializers-as-non-constants` CLI flag to control the behavior
  - Updated C++ bindings in `cpp2py_export.cc` to expose the new parameter

- **Documentation**: Updated README.md and docstrings to explain the new option and its use cases

- **Tests**: Added comprehensive test cases demonstrating the behavior with and without the flag

## Implementation Details

- The configuration is thread-local in the ONNX optimizer and is properly restored after optimization to avoid leaking state
- `Constant` nodes are always treated as constants regardless of the setting
- The feature is orthogonal to `mutable_initializer` which controls whether initializers remain as graph inputs
- When disabled, only nodes rooted exclusively at initializers are preserved; nodes fed by `Constant` nodes still fold normally

https://claude.ai/code/session_01MyzBiNk5LvTaVPgURqD5UH