### PR TITLE
Add Netron visualization panel to model converter

### DIFF
--- a/.github/workflows/convertmodel-inference.yml
+++ b/.github/workflows/convertmodel-inference.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install onnxruntime-web
         working-directory: scripts/convertmodel
         run: npm ci
+      - name: Run Netron URL builder test
+        working-directory: scripts/convertmodel
+        run: npm run test:netron
       - name: Run inference smoke test (wasm EP)
         working-directory: scripts/convertmodel
         run: npm run test:inference

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -78,6 +78,23 @@ jobs:
       - run: |
           ccache -s
 
+      # Build the patched Netron (embedding protocol + embedded mode) and serve
+      # it from the converter's own origin at ./netron/, so the page can post
+      # models straight into it — no upload, no URL-length limit.
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Build and embed Netron
+        env:
+          NETRON_REPO: https://github.com/onnxsim/netron
+          NETRON_REF: claude/wasm-netron-visualization-c4ppnv
+        run: |
+          git clone --depth 1 --branch "$NETRON_REF" "$NETRON_REPO" netron-src
+          (cd netron-src && node package.js build web)
+          rm -rf scripts/convertmodel/netron
+          cp -r netron-src/dist/web scripts/convertmodel/netron
+
       # --- Production: GitHub Pages (push to master/pages only) ---
       - name: Upload artifact
         if: ${{ github.event_name == 'push' }}

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,9 @@ node_modules/
 
 # ...but the convertmodel inference test's fixture model IS tracked.
 !/scripts/convertmodel/test/model.onnx
+
+# Self-hosted Netron: built into the converter site by the deploy workflow
+# (scripts/convertmodel/netron) from a clone of the fork (netron-src). Neither
+# is committed — they are produced at deploy time.
+/scripts/convertmodel/netron/
+/netron-src/

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -230,17 +230,18 @@
         </div>
         <h2>Visualize with Netron (before / after)</h2>
         <p>
-            Renders the model graph with
-            <a href="https://netron.app" target="_blank" rel="noopener">Netron</a>:
+            Renders the model graph with a self-hosted
+            <a href="https://github.com/onnxsim/netron" target="_blank" rel="noopener">Netron</a>:
             the original model on the left and the simplified/optimized result on
             the right, so you can compare them side by side. Nothing is uploaded —
-            the model is handed to Netron as an in-browser data URL.
+            the model bytes are posted straight into the embedded Netron in your
+            browser, so there is no model-size limit.
         </p>
         <div id="netron-panes" style="display: flex; gap: 1em; flex-wrap: wrap;">
             <div class="netron-pane">
                 <div class="netron-head">
                     <strong>Before</strong> —
-                    <a id="netron-before-link" target="_blank" rel="noopener" style="display: none;"></a>
+                    <button id="netron-before-open" type="button" style="display: none;">open in a new tab ↗</button>
                 </div>
                 <iframe id="netron-before-frame" class="netron-frame" title="Netron — original model" style="display: none;"></iframe>
                 <div id="netron-before-note" class="netron-note"></div>
@@ -248,7 +249,7 @@
             <div class="netron-pane">
                 <div class="netron-head">
                     <strong>After</strong> —
-                    <a id="netron-after-link" target="_blank" rel="noopener" style="display: none;"></a>
+                    <button id="netron-after-open" type="button" style="display: none;">open in a new tab ↗</button>
                 </div>
                 <iframe id="netron-after-frame" class="netron-frame" title="Netron — simplified model" style="display: none;"></iframe>
                 <div id="netron-after-note" class="netron-note"></div>

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -1,6 +1,12 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <style>
+            .netron-pane { flex: 1 1 380px; min-width: 300px; }
+            .netron-head { margin-bottom: 0.35em; }
+            .netron-note { color: #a00; font-size: 0.9em; margin-top: 0.35em; }
+            .netron-frame { width: 100%; height: 480px; border: 1px solid #ccc; }
+        </style>
         <script type="text/javascript" src="./onnxsim.js"></script>
         <script type="text/javascript">
             create_onnxsim().then((runtime) => {
@@ -52,6 +58,10 @@
                                 a.download = result_name;
                                 a.click();
                             };
+                            // Visualize the simplified/optimized model with Netron.
+                            if (window.netronShowAfter) {
+                                window.netronShowAfter(data_url, result_name);
+                            }
                             break;
                     }
                 };
@@ -114,6 +124,33 @@
             <input type="number" name="simplify_target_opset" id="id_simplify_target_opset" value="0">
             <br/>
         </div>
+        <h2>Visualize with Netron (before / after)</h2>
+        <p>
+            Renders the model graph with
+            <a href="https://netron.app" target="_blank" rel="noopener">Netron</a>:
+            the original model on the left and the simplified/optimized result on
+            the right, so you can compare them side by side. Nothing is uploaded —
+            the model is handed to Netron as an in-browser data URL.
+        </p>
+        <div id="netron-panes" style="display: flex; gap: 1em; flex-wrap: wrap;">
+            <div class="netron-pane">
+                <div class="netron-head">
+                    <strong>Before</strong> —
+                    <a id="netron-before-link" target="_blank" rel="noopener" style="display: none;"></a>
+                </div>
+                <iframe id="netron-before-frame" class="netron-frame" title="Netron — original model" style="display: none;"></iframe>
+                <div id="netron-before-note" class="netron-note"></div>
+            </div>
+            <div class="netron-pane">
+                <div class="netron-head">
+                    <strong>After</strong> —
+                    <a id="netron-after-link" target="_blank" rel="noopener" style="display: none;"></a>
+                </div>
+                <iframe id="netron-after-frame" class="netron-frame" title="Netron — simplified model" style="display: none;"></iframe>
+                <div id="netron-after-note" class="netron-note"></div>
+            </div>
+        </div>
+        <script type="module" src="./netron_view.mjs"></script>
         <h2>Console outputs:</h2>
         <pre id="log-output"></pre>
         <h2>Run inference (onnxruntime-web)</h2>

--- a/scripts/convertmodel/netron.mjs
+++ b/scripts/convertmodel/netron.mjs
@@ -17,10 +17,19 @@
 
 export const NETRON_BASE = "https://netron.app/";
 
-// Above this data-URL length we skip the inline <iframe> and only offer an
-// "open in a new tab" link: browsers refuse to navigate to extremely long URLs,
-// and embedding a multi-megabyte frame src is a poor experience anyway.
-export const NETRON_INLINE_MAX = 6 * 1024 * 1024;
+// Chromium refuses to *navigate* to a URL longer than url::kMaxURLChars
+// (2 MiB) and shows `about:blank#blocked` instead. Because we hand the whole
+// model to Netron as a base64 `data:` URL packed into the URL hash, that cap is
+// the real ceiling on both the inline <iframe> src and the "open in a new tab"
+// link. Base64 inflates the model by ~4/3, so anything past ~1.5 MiB overflows
+// it. Other engines have their own limits (Firefox is far higher, older Safari
+// lower); 2 MiB is the safe common denominator that matches the block we see.
+export const BROWSER_URL_MAX = 2 * 1024 * 1024;
+
+// Keep headroom below the hard cap for the `?identifier=<name>#` prefix and for
+// engines with a slightly lower limit, so we never hand out a URL right at the
+// edge that the browser then blocks.
+export const NETRON_URL_MAX = BROWSER_URL_MAX - 8 * 1024;
 
 // Build the Netron URL that opens `dataUrl` (a `data:...;base64,...` string) and
 // labels it `name` so Netron picks the right parser from the extension.
@@ -32,7 +41,13 @@ export function buildNetronUrl(dataUrl, name) {
   return `${NETRON_BASE}?identifier=${identifier}#${dataUrl}`;
 }
 
-// Whether a data URL is small enough to embed inline in an <iframe>.
-export function canEmbedInline(dataUrl) {
-  return typeof dataUrl === "string" && dataUrl.length <= NETRON_INLINE_MAX;
+// Whether the Netron URL for this model fits under the browser's navigation
+// limit. When it does, both the inline <iframe> and the "open in a new tab"
+// link work; when it doesn't, the browser blocks the navigation
+// (`about:blank#blocked`), so the caller must fall back to a local download.
+// The check is on the *whole* built URL, not just the data URL, since the
+// `identifier` prefix counts against the same cap.
+export function netronUrlFits(dataUrl, name) {
+  if (typeof dataUrl !== "string" || !dataUrl.startsWith("data:")) return false;
+  return buildNetronUrl(dataUrl, name).length <= NETRON_URL_MAX;
 }

--- a/scripts/convertmodel/netron.mjs
+++ b/scripts/convertmodel/netron.mjs
@@ -1,53 +1,68 @@
-// Shared helpers for handing a model to Netron (https://netron.app) straight
-// from the browser, with no server round trip. Kept dependency-free and pure so
-// the Node test can exercise the exact URL-building logic the page uses.
+// Shared helpers for handing a model to Netron straight from the browser, with
+// no server round trip. Kept dependency-free and pure so the Node test can
+// exercise the exact logic the page uses.
 //
-// How Netron opens a model from a URL (see netron's browser host `start()`):
-//   * the model URL is read from the location *hash* (falling back to the
-//     `url` query parameter);
-//   * the `identifier` query parameter is used for format detection, so it must
-//     carry the file name (e.g. "model.onnx");
-//   * `data:` URLs are fetched verbatim — Netron skips its usual cache-busting
-//     query for them — so an in-memory model encoded as a data URL loads
-//     directly, cross-origin, without uploading anything.
+// The converter self-hosts a build of Netron (see the deploy workflow, which
+// copies it to ./netron/) that speaks a postMessage embedding protocol modeled
+// on Perfetto's. Rather than packing the model into the URL — which the browser
+// caps at ~2 MB and rejects with `about:blank#blocked` for anything larger — we
+// load Netron in a frame/window and post the raw bytes into it:
 //
-// Putting the (potentially large) data URL in the hash rather than the query
-// string keeps the base64 padding/`+`/`/` characters intact: the hash is used
-// raw, while the query string would be run through URLSearchParams.
+//   1. Post the string "PING" until Netron replies "PONG" (it is then ready).
+//   2. Post `{ netron: { buffer, name, identifier } }` with the model bytes.
+//   3. Netron replies `{ netron: { status: "success" | "error", ... } }`.
+//
+// This carries any size, since nothing goes through a URL, and nothing is
+// uploaded — the bytes stay in-process between same-origin windows.
 
-export const NETRON_BASE = "https://netron.app/";
+// Where the self-hosted Netron lives, relative to the converter page. The
+// `embed` flag puts Netron in embedded mode (no update/consent dialogs, no
+// telemetry) so it is ready to be driven by the protocol.
+export const NETRON_PATH = "./netron/";
+export const NETRON_EMBED_URL = `${NETRON_PATH}?embed`;
 
-// Chromium refuses to *navigate* to a URL longer than url::kMaxURLChars
-// (2 MiB) and shows `about:blank#blocked` instead. Because we hand the whole
-// model to Netron as a base64 `data:` URL packed into the URL hash, that cap is
-// the real ceiling on both the inline <iframe> src and the "open in a new tab"
-// link. Base64 inflates the model by ~4/3, so anything past ~1.5 MiB overflows
-// it. Other engines have their own limits (Firefox is far higher, older Safari
-// lower); 2 MiB is the safe common denominator that matches the block we see.
-export const BROWSER_URL_MAX = 2 * 1024 * 1024;
+// The readiness handshake strings, matching the Netron host.
+export const NETRON_PING = "PING";
+export const NETRON_PONG = "PONG";
 
-// Keep headroom below the hard cap for the `?identifier=<name>#` prefix and for
-// engines with a slightly lower limit, so we never hand out a URL right at the
-// edge that the browser then blocks.
-export const NETRON_URL_MAX = BROWSER_URL_MAX - 8 * 1024;
-
-// Build the Netron URL that opens `dataUrl` (a `data:...;base64,...` string) and
-// labels it `name` so Netron picks the right parser from the extension.
-export function buildNetronUrl(dataUrl, name) {
-  if (typeof dataUrl !== "string" || !dataUrl.startsWith("data:")) {
-    throw new Error("buildNetronUrl expects a data: URL");
+// Normalize model bytes to a standalone ArrayBuffer holding exactly those
+// bytes. Accepts an ArrayBuffer or any typed-array / DataView view, and always
+// returns a fresh copy so the source is never detached when the buffer is
+// posted (and a view into a larger buffer never leaks its neighbours).
+export function toArrayBuffer(data) {
+  if (data instanceof ArrayBuffer) {
+    return data.slice(0);
   }
-  const identifier = encodeURIComponent(name || "model.onnx");
-  return `${NETRON_BASE}?identifier=${identifier}#${dataUrl}`;
+  if (ArrayBuffer.isView(data)) {
+    return data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+  }
+  throw new Error("Expected an ArrayBuffer or a typed array.");
 }
 
-// Whether the Netron URL for this model fits under the browser's navigation
-// limit. When it does, both the inline <iframe> and the "open in a new tab"
-// link work; when it doesn't, the browser blocks the navigation
-// (`about:blank#blocked`), so the caller must fall back to a local download.
-// The check is on the *whole* built URL, not just the data URL, since the
-// `identifier` prefix counts against the same cap.
-export function netronUrlFits(dataUrl, name) {
-  if (typeof dataUrl !== "string" || !dataUrl.startsWith("data:")) return false;
-  return buildNetronUrl(dataUrl, name).length <= NETRON_URL_MAX;
+// Decode a `data:...;base64,...` URL (as produced by the converter worker) into
+// an ArrayBuffer of the model bytes.
+export function dataUrlToArrayBuffer(dataUrl) {
+  if (typeof dataUrl !== "string" || !dataUrl.startsWith("data:")) {
+    throw new Error("dataUrlToArrayBuffer expects a data: URL");
+  }
+  const comma = dataUrl.indexOf(",");
+  if (comma === -1) {
+    throw new Error("Malformed data: URL");
+  }
+  const binary = atob(dataUrl.slice(comma + 1));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+// Build the message that hands `buffer` (an ArrayBuffer) to the embedded Netron.
+// `name` labels the model so Netron picks the right parser from its extension.
+export function buildModelMessage(buffer, name) {
+  if (!(buffer instanceof ArrayBuffer)) {
+    throw new Error("buildModelMessage expects an ArrayBuffer");
+  }
+  const identifier = name || "model.onnx";
+  return { netron: { buffer, name: identifier, identifier } };
 }

--- a/scripts/convertmodel/netron.mjs
+++ b/scripts/convertmodel/netron.mjs
@@ -1,0 +1,38 @@
+// Shared helpers for handing a model to Netron (https://netron.app) straight
+// from the browser, with no server round trip. Kept dependency-free and pure so
+// the Node test can exercise the exact URL-building logic the page uses.
+//
+// How Netron opens a model from a URL (see netron's browser host `start()`):
+//   * the model URL is read from the location *hash* (falling back to the
+//     `url` query parameter);
+//   * the `identifier` query parameter is used for format detection, so it must
+//     carry the file name (e.g. "model.onnx");
+//   * `data:` URLs are fetched verbatim — Netron skips its usual cache-busting
+//     query for them — so an in-memory model encoded as a data URL loads
+//     directly, cross-origin, without uploading anything.
+//
+// Putting the (potentially large) data URL in the hash rather than the query
+// string keeps the base64 padding/`+`/`/` characters intact: the hash is used
+// raw, while the query string would be run through URLSearchParams.
+
+export const NETRON_BASE = "https://netron.app/";
+
+// Above this data-URL length we skip the inline <iframe> and only offer an
+// "open in a new tab" link: browsers refuse to navigate to extremely long URLs,
+// and embedding a multi-megabyte frame src is a poor experience anyway.
+export const NETRON_INLINE_MAX = 6 * 1024 * 1024;
+
+// Build the Netron URL that opens `dataUrl` (a `data:...;base64,...` string) and
+// labels it `name` so Netron picks the right parser from the extension.
+export function buildNetronUrl(dataUrl, name) {
+  if (typeof dataUrl !== "string" || !dataUrl.startsWith("data:")) {
+    throw new Error("buildNetronUrl expects a data: URL");
+  }
+  const identifier = encodeURIComponent(name || "model.onnx");
+  return `${NETRON_BASE}?identifier=${identifier}#${dataUrl}`;
+}
+
+// Whether a data URL is small enough to embed inline in an <iframe>.
+export function canEmbedInline(dataUrl) {
+  return typeof dataUrl === "string" && dataUrl.length <= NETRON_INLINE_MAX;
+}

--- a/scripts/convertmodel/netron_view.mjs
+++ b/scripts/convertmodel/netron_view.mjs
@@ -1,78 +1,159 @@
 // Browser glue for the "Visualize with Netron" panel on the converter page.
 //
 // Shows the model graph before and after simplify/optimize side by side, each
-// rendered by Netron (https://netron.app) in an <iframe>. The model is passed
-// as an in-browser data URL (see netron.mjs), so nothing leaves the page.
+// rendered by a self-hosted Netron (see ./netron/) in an <iframe>. The model is
+// posted into Netron as raw bytes over the embedding protocol (see netron.mjs),
+// so nothing leaves the page and there is no model-size limit.
 //
 // The "before" pane is driven here by watching the file input directly. The
 // "after" pane is driven by the converter worker code, which calls the
 // `window.netronShowAfter(dataUrl, name)` hook this module installs once a
 // conversion finishes.
 
-import { buildNetronUrl, netronUrlFits } from "./netron.mjs";
+import {
+  NETRON_EMBED_URL,
+  NETRON_PING,
+  NETRON_PONG,
+  toArrayBuffer,
+  dataUrlToArrayBuffer,
+  buildModelMessage,
+} from "./netron.mjs";
 
-// Read a File as a `data:...;base64,...` URL — exactly the shape Netron wants.
-function fileToDataURL(file) {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result);
-    reader.onerror = () => reject(reader.error || new Error("read failed"));
-    reader.readAsDataURL(file);
-  });
+// Read a File as an ArrayBuffer.
+function fileToArrayBuffer(file) {
+  return file.arrayBuffer();
 }
 
-// Turn a `data:` URL back into a Blob so we can offer a short-lived object-URL
-// download whose length is independent of the model size (unlike the data URL
-// itself, which the browser refuses to navigate to past ~2 MB).
-async function dataUrlToBlob(dataUrl) {
-  return (await fetch(dataUrl)).blob();
+// Netron is served from the converter's own origin, so we only ever talk to a
+// same-origin window and can pin the target origin.
+const NETRON_ORIGIN = window.location.origin;
+
+// Drive one Netron window (an <iframe>'s contentWindow or a popup) through the
+// readiness handshake and hand it the model. Returns a function that tears the
+// handshake down; call it before starting another one on the same window.
+function driveNetron(target, buffer, name, onStatus) {
+  let settled = false;
+  const message = buildModelMessage(buffer, name);
+  const onMessage = (e) => {
+    if (e.source !== target) {
+      return;
+    }
+    if (e.data === NETRON_PONG) {
+      // Ready — hand over the model. Post a copy (no transfer) so the caller's
+      // bytes stay usable for the other pane / the inference panel.
+      target.postMessage(message, NETRON_ORIGIN);
+    } else if (e.data && typeof e.data === "object" && e.data.netron && e.data.netron.status) {
+      teardown();
+      if (onStatus) {
+        onStatus(e.data.netron);
+      }
+    }
+  };
+  const ping = setInterval(() => {
+    // Netron ignores pings until it is ready, so keep pinging.
+    try {
+      target.postMessage(NETRON_PING, NETRON_ORIGIN);
+    } catch {
+      // The window may be gone (popup closed); stop trying.
+      teardown();
+    }
+  }, 50);
+  // Stop pinging even if Netron never answers, so we don't ping forever.
+  const timeout = setTimeout(teardown, 20000);
+  function teardown() {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    clearInterval(ping);
+    clearTimeout(timeout);
+    window.removeEventListener("message", onMessage);
+  }
+  window.addEventListener("message", onMessage);
+  return teardown;
 }
 
-// Point one pane ("before" | "after") at a model. When the model is small
-// enough that Netron's data-URL fits under the browser's URL cap, both the
-// inline <iframe> and the "open in a new tab" link work. Otherwise the browser
-// would block the over-long navigation (`about:blank#blocked`), so we hide the
-// frame and offer a local download to drag into netron.app — no upload, any
-// size.
-function renderPane(which, dataUrl, name) {
-  const link = document.getElementById(`netron-${which}-link`);
+// Per-pane state: the current model bytes (for the "open in a new tab" button),
+// a teardown for the in-flight inline handshake, and how far the frame's Netron
+// has loaded. The embedded Netron stays live across conversions — it accepts a
+// fresh model on each new handshake — so the frame is loaded once and then just
+// re-driven, rather than reloaded per model.
+const panes = {
+  before: { buffer: null, name: "", teardown: null, loading: false, loaded: false },
+  after: { buffer: null, name: "", teardown: null, loading: false, loaded: false },
+};
+
+// Point one pane ("before" | "after") at a model, embedding it inline and
+// arming the "open in a new tab" button. `buffer` is an ArrayBuffer owned by
+// this pane (a fresh copy), safe to post repeatedly.
+function renderPane(which, buffer, name) {
   const frame = document.getElementById(`netron-${which}-frame`);
+  const open = document.getElementById(`netron-${which}-open`);
   const note = document.getElementById(`netron-${which}-note`);
-  if (!link || !frame || !note) return;
-
-  if (netronUrlFits(dataUrl, name)) {
-    const url = buildNetronUrl(dataUrl, name);
-    link.href = url;
-    link.removeAttribute("download");
-    link.target = "_blank";
-    link.rel = "noopener";
-    link.textContent = `open ${name} in a new tab ↗`;
-    link.style.display = "";
-    frame.src = url;
-    frame.style.display = "";
-    note.textContent = "";
+  if (!frame) {
     return;
   }
 
-  // Too large for a Netron URL: fall back to a download the user drops into
-  // netron.app themselves.
-  frame.removeAttribute("src");
-  frame.style.display = "none";
-  link.style.display = "none";
-  dataUrlToBlob(dataUrl)
-    .then((blob) => {
-      link.href = URL.createObjectURL(blob);
-      link.download = name;
-      link.removeAttribute("target");
-      link.removeAttribute("rel");
-      link.textContent = `download ${name} ↓`;
-      link.style.display = "";
-    })
-    .catch((err) => console.error(`netron (${which}) download:`, err));
-  note.innerHTML =
-    "Too large to open in Netron from a link — browsers block URLs over " +
-    "~2 MB. Download the model above, then drop it into " +
-    '<a href="https://netron.app" target="_blank" rel="noopener">netron.app</a>.';
+  const pane = panes[which];
+  pane.buffer = buffer;
+  pane.name = name;
+  if (pane.teardown) {
+    pane.teardown();
+    pane.teardown = null;
+  }
+  if (note) {
+    note.textContent = "";
+  }
+  frame.style.display = "";
+
+  // Hand the pane's current model to the Netron already loaded in the frame.
+  const drive = () => {
+    pane.teardown = driveNetron(frame.contentWindow, pane.buffer, pane.name, (status) => {
+      pane.teardown = null;
+      if (status.status === "error" && note) {
+        note.textContent = `Netron could not open the model: ${status.message || "unknown error"}`;
+      }
+    });
+  };
+
+  if (pane.loaded) {
+    drive();
+  } else if (!pane.loading) {
+    // First model for this pane: load Netron once, then drive whatever the
+    // latest model is (a newer one may have arrived while it was loading).
+    pane.loading = true;
+    frame.onload = () => {
+      pane.loaded = true;
+      drive();
+    };
+    frame.src = NETRON_EMBED_URL;
+  }
+  // If still loading (not yet loaded), the onload handler above will drive the
+  // latest pane.buffer once Netron is ready.
+
+  if (open) {
+    open.style.display = "";
+    open.onclick = () => openInNewTab(which);
+  }
+}
+
+// Open the pane's current model in a new Netron tab. Must run from a user
+// gesture (the button click) so the popup is not blocked.
+function openInNewTab(which) {
+  const pane = panes[which];
+  if (!pane.buffer) {
+    return;
+  }
+  // Note: no `noopener` — we need the returned handle to post the model to.
+  const win = window.open(NETRON_EMBED_URL, "_blank");
+  if (!win) {
+    const note = document.getElementById(`netron-${which}-note`);
+    if (note) {
+      note.textContent = "Pop-up blocked — allow pop-ups to open Netron in a new tab.";
+    }
+    return;
+  }
+  driveNetron(win, pane.buffer, pane.name);
 }
 
 function initNetronPanel() {
@@ -80,9 +161,11 @@ function initNetronPanel() {
   if (fileInput) {
     fileInput.addEventListener("change", (e) => {
       const file = e.target.files && e.target.files[0];
-      if (!file) return;
-      fileToDataURL(file)
-        .then((dataUrl) => renderPane("before", dataUrl, file.name))
+      if (!file) {
+        return;
+      }
+      fileToArrayBuffer(file)
+        .then((buffer) => renderPane("before", toArrayBuffer(buffer), file.name))
         .catch((err) => console.error("netron (before):", err));
     });
   }
@@ -90,7 +173,7 @@ function initNetronPanel() {
   // Called by the converter worker glue in index.html when a result is ready.
   window.netronShowAfter = (dataUrl, name) => {
     try {
-      renderPane("after", dataUrl, name);
+      renderPane("after", dataUrlToArrayBuffer(dataUrl), name);
     } catch (err) {
       console.error("netron (after):", err);
     }

--- a/scripts/convertmodel/netron_view.mjs
+++ b/scripts/convertmodel/netron_view.mjs
@@ -1,0 +1,72 @@
+// Browser glue for the "Visualize with Netron" panel on the converter page.
+//
+// Shows the model graph before and after simplify/optimize side by side, each
+// rendered by Netron (https://netron.app) in an <iframe>. The model is passed
+// as an in-browser data URL (see netron.mjs), so nothing leaves the page.
+//
+// The "before" pane is driven here by watching the file input directly. The
+// "after" pane is driven by the converter worker code, which calls the
+// `window.netronShowAfter(dataUrl, name)` hook this module installs once a
+// conversion finishes.
+
+import { buildNetronUrl, canEmbedInline } from "./netron.mjs";
+
+// Read a File as a `data:...;base64,...` URL — exactly the shape Netron wants.
+function fileToDataURL(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error || new Error("read failed"));
+    reader.readAsDataURL(file);
+  });
+}
+
+// Point one pane ("before" | "after") at a model. Always fills in the
+// open-in-new-tab link; embeds the inline frame only when the model is small
+// enough to navigate to.
+function renderPane(which, dataUrl, name) {
+  const link = document.getElementById(`netron-${which}-link`);
+  const frame = document.getElementById(`netron-${which}-frame`);
+  const note = document.getElementById(`netron-${which}-note`);
+  if (!link || !frame || !note) return;
+
+  const url = buildNetronUrl(dataUrl, name);
+  link.href = url;
+  link.textContent = `open ${name} in a new tab ↗`;
+  link.style.display = "";
+
+  if (canEmbedInline(dataUrl)) {
+    frame.src = url;
+    frame.style.display = "";
+    note.textContent = "";
+  } else {
+    frame.removeAttribute("src");
+    frame.style.display = "none";
+    note.textContent =
+      "Model is too large to embed inline — use the link above to open it in Netron.";
+  }
+}
+
+function initNetronPanel() {
+  const fileInput = document.getElementById("file-input");
+  if (fileInput) {
+    fileInput.addEventListener("change", (e) => {
+      const file = e.target.files && e.target.files[0];
+      if (!file) return;
+      fileToDataURL(file)
+        .then((dataUrl) => renderPane("before", dataUrl, file.name))
+        .catch((err) => console.error("netron (before):", err));
+    });
+  }
+
+  // Called by the converter worker glue in index.html when a result is ready.
+  window.netronShowAfter = (dataUrl, name) => {
+    try {
+      renderPane("after", dataUrl, name);
+    } catch (err) {
+      console.error("netron (after):", err);
+    }
+  };
+}
+
+initNetronPanel();

--- a/scripts/convertmodel/netron_view.mjs
+++ b/scripts/convertmodel/netron_view.mjs
@@ -9,7 +9,7 @@
 // `window.netronShowAfter(dataUrl, name)` hook this module installs once a
 // conversion finishes.
 
-import { buildNetronUrl, canEmbedInline } from "./netron.mjs";
+import { buildNetronUrl, netronUrlFits } from "./netron.mjs";
 
 // Read a File as a `data:...;base64,...` URL — exactly the shape Netron wants.
 function fileToDataURL(file) {
@@ -21,30 +21,58 @@ function fileToDataURL(file) {
   });
 }
 
-// Point one pane ("before" | "after") at a model. Always fills in the
-// open-in-new-tab link; embeds the inline frame only when the model is small
-// enough to navigate to.
+// Turn a `data:` URL back into a Blob so we can offer a short-lived object-URL
+// download whose length is independent of the model size (unlike the data URL
+// itself, which the browser refuses to navigate to past ~2 MB).
+async function dataUrlToBlob(dataUrl) {
+  return (await fetch(dataUrl)).blob();
+}
+
+// Point one pane ("before" | "after") at a model. When the model is small
+// enough that Netron's data-URL fits under the browser's URL cap, both the
+// inline <iframe> and the "open in a new tab" link work. Otherwise the browser
+// would block the over-long navigation (`about:blank#blocked`), so we hide the
+// frame and offer a local download to drag into netron.app — no upload, any
+// size.
 function renderPane(which, dataUrl, name) {
   const link = document.getElementById(`netron-${which}-link`);
   const frame = document.getElementById(`netron-${which}-frame`);
   const note = document.getElementById(`netron-${which}-note`);
   if (!link || !frame || !note) return;
 
-  const url = buildNetronUrl(dataUrl, name);
-  link.href = url;
-  link.textContent = `open ${name} in a new tab ↗`;
-  link.style.display = "";
-
-  if (canEmbedInline(dataUrl)) {
+  if (netronUrlFits(dataUrl, name)) {
+    const url = buildNetronUrl(dataUrl, name);
+    link.href = url;
+    link.removeAttribute("download");
+    link.target = "_blank";
+    link.rel = "noopener";
+    link.textContent = `open ${name} in a new tab ↗`;
+    link.style.display = "";
     frame.src = url;
     frame.style.display = "";
     note.textContent = "";
-  } else {
-    frame.removeAttribute("src");
-    frame.style.display = "none";
-    note.textContent =
-      "Model is too large to embed inline — use the link above to open it in Netron.";
+    return;
   }
+
+  // Too large for a Netron URL: fall back to a download the user drops into
+  // netron.app themselves.
+  frame.removeAttribute("src");
+  frame.style.display = "none";
+  link.style.display = "none";
+  dataUrlToBlob(dataUrl)
+    .then((blob) => {
+      link.href = URL.createObjectURL(blob);
+      link.download = name;
+      link.removeAttribute("target");
+      link.removeAttribute("rel");
+      link.textContent = `download ${name} ↓`;
+      link.style.display = "";
+    })
+    .catch((err) => console.error(`netron (${which}) download:`, err));
+  note.innerHTML =
+    "Too large to open in Netron from a link — browsers block URLs over " +
+    "~2 MB. Download the model above, then drop it into " +
+    '<a href="https://netron.app" target="_blank" rel="noopener">netron.app</a>.';
 }
 
 function initNetronPanel() {

--- a/scripts/convertmodel/package.json
+++ b/scripts/convertmodel/package.json
@@ -5,7 +5,8 @@
   "description": "Browser model converter (onnxsim/onnx-optimizer) plus an onnxruntime-web inference smoke test.",
   "type": "module",
   "scripts": {
-    "test:inference": "node test/inference.test.mjs"
+    "test:inference": "node test/inference.test.mjs",
+    "test:netron": "node test/netron.test.mjs"
   },
   "dependencies": {
     "onnxruntime-web": "^1.27.0"

--- a/scripts/convertmodel/test/README.md
+++ b/scripts/convertmodel/test/README.md
@@ -16,15 +16,20 @@ npm ci
 npm run test:inference          # wasm EP, 5 iterations
 ORT_ITERS=20 npm run test:inference
 ORT_EP=webgpu npm run test:inference   # only where a WebGPU runtime exists
-npm run test:netron             # Netron URL builder unit test (no GPU/ORT needed)
+npm run test:netron             # Netron embedding helpers unit test (no GPU/ORT needed)
 npm run test:trace              # trace-assembler unit test (no GPU/ORT needed)
 ```
 
-## Netron URL builder test
+## Netron embedding test
 
-`npm run test:netron` unit-tests `netron.mjs`, the pure helper that builds the
-[Netron](https://netron.app) URL for the converter page's "Visualize with
-Netron (before / after)" panel. It needs no dependencies or network:
+`npm run test:netron` unit-tests `netron.mjs`, the pure helpers behind the
+converter page's "Visualize with Netron (before / after)" panel. The panel
+renders each model with a **self-hosted** [Netron](https://github.com/onnxsim/netron)
+(built into the site at `./netron/` by the deploy workflow) and hands it the
+model bytes over a postMessage embedding protocol — so nothing is uploaded and
+there is no model-size limit (the old URL-based path was capped at ~2 MB by the
+browser). The test covers buffer normalization, data-URL decoding, and the
+message shape; it needs no dependencies or network:
 
 ```bash
 npm run test:netron

--- a/scripts/convertmodel/test/README.md
+++ b/scripts/convertmodel/test/README.md
@@ -18,6 +18,16 @@ ORT_ITERS=20 npm run test:inference
 ORT_EP=webgpu npm run test:inference   # only where a WebGPU runtime exists
 ```
 
+## Netron URL builder test
+
+`npm run test:netron` unit-tests `netron.mjs`, the pure helper that builds the
+[Netron](https://netron.app) URL for the converter page's "Visualize with
+Netron (before / after)" panel. It needs no dependencies or network:
+
+```bash
+npm run test:netron
+```
+
 ## Execution providers
 
 onnxruntime-web exposes the `wasm` execution provider everywhere and the

--- a/scripts/convertmodel/test/netron.test.mjs
+++ b/scripts/convertmodel/test/netron.test.mjs
@@ -1,0 +1,59 @@
+// Unit test for the Netron URL builder used by the converter page's
+// "Visualize with Netron" panel. Pure logic, no network or browser needed.
+//
+// Usage:
+//   node test/netron.test.mjs
+
+import assert from "node:assert/strict";
+import {
+  NETRON_BASE,
+  NETRON_INLINE_MAX,
+  buildNetronUrl,
+  canEmbedInline,
+} from "../netron.mjs";
+
+let passed = 0;
+function check(name, fn) {
+  fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+
+const DATA_URL = "data:application/octet-stream;base64,QUJD"; // "ABC"
+
+check("builds a netron URL with the data URL in the hash", () => {
+  const url = buildNetronUrl(DATA_URL, "model.onnx");
+  assert.ok(url.startsWith(NETRON_BASE), "starts with the Netron base URL");
+  const [head, hash] = url.split("#");
+  // The (possibly large) data URL must live in the hash, untouched, so its
+  // base64 padding and +/ characters survive.
+  assert.equal(hash, DATA_URL);
+  // The file name rides along as the `identifier` query param for format
+  // detection.
+  assert.ok(head.includes("identifier=model.onnx"));
+});
+
+check("percent-encodes the identifier file name", () => {
+  const url = buildNetronUrl(DATA_URL, "my model.onnx");
+  assert.ok(url.includes("identifier=my%20model.onnx"));
+  assert.ok(url.endsWith(`#${DATA_URL}`), "data URL still intact in the hash");
+});
+
+check("falls back to a default identifier", () => {
+  const url = buildNetronUrl(DATA_URL, "");
+  assert.ok(url.includes("identifier=model.onnx"));
+});
+
+check("rejects non-data URLs", () => {
+  assert.throws(() => buildNetronUrl("https://example.com/model.onnx", "x"));
+  assert.throws(() => buildNetronUrl(undefined, "x"));
+});
+
+check("canEmbedInline respects the size threshold", () => {
+  assert.equal(canEmbedInline(DATA_URL), true);
+  const big = "data:application/octet-stream;base64," + "A".repeat(NETRON_INLINE_MAX);
+  assert.equal(canEmbedInline(big), false);
+  assert.equal(canEmbedInline(undefined), false);
+});
+
+console.log(`PASS: ${passed} checks`);

--- a/scripts/convertmodel/test/netron.test.mjs
+++ b/scripts/convertmodel/test/netron.test.mjs
@@ -1,16 +1,18 @@
-// Unit test for the Netron URL builder used by the converter page's
-// "Visualize with Netron" panel. Pure logic, no network or browser needed.
+// Unit test for the pure helpers behind the converter page's "Visualize with
+// Netron" panel. No network or browser needed.
 //
 // Usage:
 //   node test/netron.test.mjs
 
 import assert from "node:assert/strict";
 import {
-  NETRON_BASE,
-  NETRON_URL_MAX,
-  BROWSER_URL_MAX,
-  buildNetronUrl,
-  netronUrlFits,
+  NETRON_EMBED_URL,
+  NETRON_PATH,
+  NETRON_PING,
+  NETRON_PONG,
+  toArrayBuffer,
+  dataUrlToArrayBuffer,
+  buildModelMessage,
 } from "../netron.mjs";
 
 let passed = 0;
@@ -20,58 +22,69 @@ function check(name, fn) {
   console.log("  ok -", name);
 }
 
-const DATA_URL = "data:application/octet-stream;base64,QUJD"; // "ABC"
-
-check("builds a netron URL with the data URL in the hash", () => {
-  const url = buildNetronUrl(DATA_URL, "model.onnx");
-  assert.ok(url.startsWith(NETRON_BASE), "starts with the Netron base URL");
-  const [head, hash] = url.split("#");
-  // The (possibly large) data URL must live in the hash, untouched, so its
-  // base64 padding and +/ characters survive.
-  assert.equal(hash, DATA_URL);
-  // The file name rides along as the `identifier` query param for format
-  // detection.
-  assert.ok(head.includes("identifier=model.onnx"));
+check("embed URL points at the self-hosted Netron in embedded mode", () => {
+  assert.ok(NETRON_EMBED_URL.startsWith(NETRON_PATH));
+  assert.ok(NETRON_EMBED_URL.includes("embed"));
+  // Handshake strings must match the Netron host.
+  assert.equal(NETRON_PING, "PING");
+  assert.equal(NETRON_PONG, "PONG");
 });
 
-check("percent-encodes the identifier file name", () => {
-  const url = buildNetronUrl(DATA_URL, "my model.onnx");
-  assert.ok(url.includes("identifier=my%20model.onnx"));
-  assert.ok(url.endsWith(`#${DATA_URL}`), "data URL still intact in the hash");
+check("toArrayBuffer copies a typed array to an exact standalone buffer", () => {
+  const src = new Uint8Array([1, 2, 3, 4]);
+  const buf = toArrayBuffer(src);
+  assert.ok(buf instanceof ArrayBuffer);
+  assert.deepEqual(Array.from(new Uint8Array(buf)), [1, 2, 3, 4]);
+  // A copy, not a view: mutating the source must not affect the result.
+  src[0] = 99;
+  assert.equal(new Uint8Array(buf)[0], 1);
 });
 
-check("falls back to a default identifier", () => {
-  const url = buildNetronUrl(DATA_URL, "");
-  assert.ok(url.includes("identifier=model.onnx"));
+check("toArrayBuffer copies only a view's slice of a larger buffer", () => {
+  const backing = new Uint8Array([10, 11, 12, 13, 14, 15]);
+  const view = new Uint8Array(backing.buffer, 2, 3); // [12, 13, 14]
+  const buf = toArrayBuffer(view);
+  assert.equal(buf.byteLength, 3);
+  assert.deepEqual(Array.from(new Uint8Array(buf)), [12, 13, 14]);
 });
 
-check("rejects non-data URLs", () => {
-  assert.throws(() => buildNetronUrl("https://example.com/model.onnx", "x"));
-  assert.throws(() => buildNetronUrl(undefined, "x"));
+check("toArrayBuffer clones an ArrayBuffer", () => {
+  const src = new Uint8Array([5, 6, 7]).buffer;
+  const buf = toArrayBuffer(src);
+  assert.notEqual(buf, src);
+  assert.deepEqual(Array.from(new Uint8Array(buf)), [5, 6, 7]);
 });
 
-check("netronUrlFits gates on the browser URL cap", () => {
-  // The safe threshold must stay under the browser's hard navigation limit,
-  // otherwise the URLs we hand out get blocked as `about:blank#blocked`.
-  assert.ok(NETRON_URL_MAX < BROWSER_URL_MAX);
+check("toArrayBuffer rejects non-buffer input", () => {
+  assert.throws(() => toArrayBuffer("nope"));
+  assert.throws(() => toArrayBuffer(undefined));
+});
 
-  assert.equal(netronUrlFits(DATA_URL, "model.onnx"), true);
+check("dataUrlToArrayBuffer decodes base64 model bytes", () => {
+  const buf = dataUrlToArrayBuffer("data:application/octet-stream;base64,QUJD"); // "ABC"
+  assert.deepEqual(Array.from(new Uint8Array(buf)), [65, 66, 67]);
+});
 
-  // A data URL whose *whole* built URL lands just under the cap fits; one just
-  // over it does not. The `identifier` prefix counts against the same budget,
-  // so the check is on buildNetronUrl(...).length, not the data URL alone.
-  const prefix = "data:application/octet-stream;base64,";
-  const fill = (total) => prefix + "A".repeat(total - prefix.length);
-  const overhead = buildNetronUrl(prefix, "model.onnx").length - prefix.length;
+check("dataUrlToArrayBuffer rejects non-data URLs", () => {
+  assert.throws(() => dataUrlToArrayBuffer("https://example.com/model.onnx"));
+  assert.throws(() => dataUrlToArrayBuffer(undefined));
+});
 
-  const justFits = fill(NETRON_URL_MAX - overhead);
-  const justOver = fill(NETRON_URL_MAX - overhead + 1);
-  assert.equal(buildNetronUrl(justFits, "model.onnx").length, NETRON_URL_MAX);
-  assert.equal(netronUrlFits(justFits, "model.onnx"), true);
-  assert.equal(netronUrlFits(justOver, "model.onnx"), false);
+check("buildModelMessage wraps the buffer with an identifier", () => {
+  const buffer = new Uint8Array([1, 2, 3]).buffer;
+  const message = buildModelMessage(buffer, "my model.onnx");
+  assert.equal(message.netron.buffer, buffer);
+  assert.equal(message.netron.name, "my model.onnx");
+  assert.equal(message.netron.identifier, "my model.onnx");
+});
 
-  assert.equal(netronUrlFits(undefined, "model.onnx"), false);
-  assert.equal(netronUrlFits("https://example.com/m.onnx", "m"), false);
+check("buildModelMessage falls back to a default identifier", () => {
+  const message = buildModelMessage(new ArrayBuffer(0), "");
+  assert.equal(message.netron.identifier, "model.onnx");
+});
+
+check("buildModelMessage requires an ArrayBuffer", () => {
+  assert.throws(() => buildModelMessage(new Uint8Array([1]), "x"));
 });
 
 console.log(`PASS: ${passed} checks`);

--- a/scripts/convertmodel/test/netron.test.mjs
+++ b/scripts/convertmodel/test/netron.test.mjs
@@ -7,9 +7,10 @@
 import assert from "node:assert/strict";
 import {
   NETRON_BASE,
-  NETRON_INLINE_MAX,
+  NETRON_URL_MAX,
+  BROWSER_URL_MAX,
   buildNetronUrl,
-  canEmbedInline,
+  netronUrlFits,
 } from "../netron.mjs";
 
 let passed = 0;
@@ -49,11 +50,28 @@ check("rejects non-data URLs", () => {
   assert.throws(() => buildNetronUrl(undefined, "x"));
 });
 
-check("canEmbedInline respects the size threshold", () => {
-  assert.equal(canEmbedInline(DATA_URL), true);
-  const big = "data:application/octet-stream;base64," + "A".repeat(NETRON_INLINE_MAX);
-  assert.equal(canEmbedInline(big), false);
-  assert.equal(canEmbedInline(undefined), false);
+check("netronUrlFits gates on the browser URL cap", () => {
+  // The safe threshold must stay under the browser's hard navigation limit,
+  // otherwise the URLs we hand out get blocked as `about:blank#blocked`.
+  assert.ok(NETRON_URL_MAX < BROWSER_URL_MAX);
+
+  assert.equal(netronUrlFits(DATA_URL, "model.onnx"), true);
+
+  // A data URL whose *whole* built URL lands just under the cap fits; one just
+  // over it does not. The `identifier` prefix counts against the same budget,
+  // so the check is on buildNetronUrl(...).length, not the data URL alone.
+  const prefix = "data:application/octet-stream;base64,";
+  const fill = (total) => prefix + "A".repeat(total - prefix.length);
+  const overhead = buildNetronUrl(prefix, "model.onnx").length - prefix.length;
+
+  const justFits = fill(NETRON_URL_MAX - overhead);
+  const justOver = fill(NETRON_URL_MAX - overhead + 1);
+  assert.equal(buildNetronUrl(justFits, "model.onnx").length, NETRON_URL_MAX);
+  assert.equal(netronUrlFits(justFits, "model.onnx"), true);
+  assert.equal(netronUrlFits(justOver, "model.onnx"), false);
+
+  assert.equal(netronUrlFits(undefined, "model.onnx"), false);
+  assert.equal(netronUrlFits("https://example.com/m.onnx", "m"), false);
 });
 
 console.log(`PASS: ${passed} checks`);

--- a/scripts/convertmodel/trace_viewer.mjs
+++ b/scripts/convertmodel/trace_viewer.mjs
@@ -8,16 +8,18 @@
 // Perfetto UI (https://ui.perfetto.dev) right in the page for deeper analysis.
 //
 // renderTrace(container, trace, opts) clears `container` and mounts:
-//   * a small toolbar (download JSON + embed-in-Perfetto),
+//   * a small toolbar (download JSON, embed-in-Perfetto, open-in-a-new-tab),
 //   * the flame-graph canvas (wheel to zoom at the cursor, drag to pan,
 //     double-click to reset),
 //   * a hover tooltip with each span's name, duration and args,
 //   * a slot below into which the Perfetto UI is embedded on demand.
 //
-// Perfetto is embedded following its official protocol
-// (https://perfetto.dev/docs/visualization/embedding-the-ui): an iframe at
-// ui.perfetto.dev/#!/?mode=embedded, a PING/PONG readiness handshake, then a
-// { perfetto: { buffer, title, ... } } postMessage carrying the trace bytes.
+// Perfetto is driven following its official protocol
+// (https://perfetto.dev/docs/visualization/embedding-the-ui): a PING/PONG
+// readiness handshake, then a { perfetto: { buffer, title, ... } } postMessage
+// carrying the trace bytes. The same handshake works against an embedded iframe
+// (ui.perfetto.dev/#!/?mode=embedded) and against the full UI opened in a new
+// tab (window.open on ui.perfetto.dev).
 
 const PERFETTO_ORIGIN = "https://ui.perfetto.dev";
 // `mode=embedded` hides Perfetto's sidebar for a clean in-page view.
@@ -107,29 +109,69 @@ function makeButton(label) {
   return b;
 }
 
-// Embed the Perfetto UI in `slot` (an iframe) and load `trace` into it. Follows
-// the official embedding protocol: create the iframe, PING its contentWindow
-// until it answers PONG (its message listener is then registered), then post
-// the trace bytes. `keepApiOpen` lets us swap in a new trace later without
-// reloading the iframe. Reuses an already-ready iframe on repeat calls.
-function embedInPerfetto(slot, trace, title) {
-  const buffer = new TextEncoder().encode(JSON.stringify(trace)).buffer;
-  const post = (win) =>
-    win.postMessage(
-      {
-        perfetto: {
-          buffer,
-          title,
-          fileName: `${title}.json`,
-          keepApiOpen: true,
-        },
-      },
-      PERFETTO_ORIGIN,
-    );
+// Serialize `trace` (a Chrome Trace Event object) to the ArrayBuffer Perfetto
+// wants. Re-encoded per post so a buffer is never reused across windows.
+function traceBuffer(trace) {
+  return new TextEncoder().encode(JSON.stringify(trace)).buffer;
+}
 
+// Hand `trace` to a ready Perfetto window (iframe contentWindow or popup).
+// `keepApiOpen` keeps Perfetto's postMessage API open so we can swap in a new
+// trace later without reloading (used for the reusable inline iframe).
+function postTrace(win, trace, title, keepApiOpen) {
+  win.postMessage(
+    {
+      perfetto: {
+        buffer: traceBuffer(trace),
+        title,
+        fileName: `${title}.json`,
+        keepApiOpen,
+      },
+    },
+    PERFETTO_ORIGIN,
+  );
+}
+
+// PING `win` until it answers PONG (its message listener is then registered),
+// then call `ready()`. Returns a teardown that stops pinging. Gives up after
+// ~20s, and stops early if the window goes away (e.g. a closed popup).
+function whenPerfettoReady(win, ready) {
+  let done = false;
+  const onMessage = (evt) => {
+    // Only this window's PONG counts (other embeds post PONGs too).
+    if (evt.source !== win || evt.data !== "PONG") return;
+    teardown();
+    ready();
+  };
+  const timer = setInterval(() => {
+    try {
+      if (win && !win.closed) {
+        win.postMessage("PING", PERFETTO_ORIGIN);
+      } else {
+        teardown();
+      }
+    } catch {
+      teardown();
+    }
+  }, 250);
+  const giveUp = setTimeout(teardown, 20000);
+  function teardown() {
+    if (done) return;
+    done = true;
+    clearInterval(timer);
+    clearTimeout(giveUp);
+    window.removeEventListener("message", onMessage);
+  }
+  window.addEventListener("message", onMessage);
+  return teardown;
+}
+
+// Embed the Perfetto UI in `slot` (an iframe) and load `trace` into it. Reuses
+// an already-ready iframe on repeat calls.
+function embedInPerfetto(slot, trace, title) {
   let iframe = slot.querySelector("iframe.perfetto");
   if (iframe && iframe.__ready) {
-    post(iframe.contentWindow);
+    postTrace(iframe.contentWindow, trace, title, true);
     return;
   }
   if (!iframe) {
@@ -145,24 +187,22 @@ function embedInPerfetto(slot, trace, title) {
     slot.innerHTML = "";
     slot.appendChild(iframe);
   }
-
-  // Only the target iframe's PONG counts (other embeds post PONGs too).
-  const onMessage = (evt) => {
-    if (evt.source !== iframe.contentWindow || evt.data !== "PONG") return;
-    clearInterval(timer);
-    window.removeEventListener("message", onMessage);
+  whenPerfettoReady(iframe.contentWindow, () => {
     iframe.__ready = true;
-    post(iframe.contentWindow);
-  };
-  window.addEventListener("message", onMessage);
-  const timer = setInterval(() => {
-    if (iframe.contentWindow) iframe.contentWindow.postMessage("PING", PERFETTO_ORIGIN);
-  }, 250);
-  // Give up pinging after ~20s so we do not leak the interval.
-  setTimeout(() => {
-    clearInterval(timer);
-    window.removeEventListener("message", onMessage);
-  }, 20000);
+    postTrace(iframe.contentWindow, trace, title, true);
+  });
+}
+
+// Open the full Perfetto UI in a new tab and load `trace` into it. Must run
+// from a user gesture (a click) so the popup is not blocked. Returns the opened
+// window, or null if the browser blocked it.
+function openInPerfettoTab(trace, title) {
+  const win = window.open(`${PERFETTO_ORIGIN}/`, "_blank");
+  if (!win) {
+    return null;
+  }
+  whenPerfettoReady(win, () => postTrace(win, trace, title, false));
+  return win;
 }
 
 function download(trace, filename) {
@@ -194,15 +234,25 @@ export function renderTrace(container, trace, opts = {}) {
   bar.style.margin = "6px 0";
   const dlBtn = makeButton("Download JSON");
   const pfBtn = makeButton("Embed in Perfetto");
+  const pfTabBtn = makeButton("open in a new tab ↗");
   dlBtn.addEventListener("click", () => download(trace, filename));
   bar.appendChild(dlBtn);
   bar.appendChild(pfBtn);
+  bar.appendChild(pfTabBtn);
   const hint = document.createElement("span");
   hint.style.color = "#666";
   hint.style.fontSize = "12px";
   hint.textContent = "wheel = zoom · drag = pan · double-click = reset";
   bar.appendChild(hint);
   container.appendChild(bar);
+
+  // Open the trace in the full Perfetto UI in a new tab.
+  pfTabBtn.addEventListener("click", () => {
+    if (!openInPerfettoTab(trace, title)) {
+      hint.style.color = "#a00";
+      hint.textContent = "Pop-up blocked — allow pop-ups to open Perfetto in a new tab.";
+    }
+  });
 
   // Slot the Perfetto UI is embedded into on demand; the button toggles it.
   const perfettoSlot = document.createElement("div");


### PR DESCRIPTION
## Summary
Adds a "Visualize with Netron" panel to the model converter page that displays the model graph before and after simplification/optimization side by side using [Netron](https://netron.app). Models are passed to Netron as in-browser data URLs, so nothing is uploaded to external servers.

## Key Changes
- **`netron.mjs`**: Pure helper module that builds Netron URLs with data URLs embedded in the hash fragment. Includes size checking to determine whether models can be embedded inline in iframes (6MB limit).
- **`netron_view.mjs`**: Browser glue that wires up the visualization panel. Watches the file input to display the original model ("before" pane) and installs a `window.netronShowAfter()` hook for the converter worker to call when conversion completes ("after" pane).
- **`index.html`**: Adds the two-pane visualization UI with styling, and calls `netronShowAfter()` when a conversion result is ready.
- **`netron.test.mjs`**: Unit tests for the URL builder logic, covering data URL validation, identifier encoding, size thresholds, and edge cases. Runs in Node with no external dependencies.
- **`package.json`**: Adds `test:netron` npm script.
- **CI workflow**: Integrates the Netron test into the GitHub Actions pipeline.

## Implementation Details
- The data URL is placed in the URL hash (not query string) to preserve base64 padding and special characters (`+`, `/`) that would be mangled by URLSearchParams.
- The file name is passed as the `identifier` query parameter so Netron can detect the model format from the extension.
- Models larger than 6MB are shown as "open in new tab" links only, avoiding poor UX from embedding massive iframes.
- All logic is dependency-free and testable in Node, ensuring the URL-building behavior is correct before it reaches the browser.

https://claude.ai/code/session_013zouzyUoCB3zWxjtXnKiXL