### PR TITLE
Improve console output display with textarea and auto-scroll

### DIFF
--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -115,7 +115,7 @@
             <label>target opset version (simplify only, 0 = keep)</label>
             <input type="number" name="simplify_target_opset" id="id_simplify_target_opset" value="0">
             <br/>
-            <div id="pass-list" style="max-height: 300px; overflow-y: auto; border: 1px solid #ccc; padding: 4px; margin-top: 4px;"></div>
+            <div id="pass-list" style="height: 300px; overflow-y: auto; border: 1px solid #ccc; padding: 4px; margin-top: 4px;"></div>
         </div>
         <h2>Console outputs:</h2>
         <textarea id="log-output" readonly rows="20" style="width: 100%; box-sizing: border-box;"></textarea>

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -37,10 +37,12 @@
                 worker.onmessage = (e) => {
                     switch (e.data[0]) {
                         case "stdout":
-                            log_output.textContent += e.data[1] + "\n";
+                            log_output.value += e.data[1] + "\n";
+                            log_output.scrollTop = log_output.scrollHeight;
                             break;
                         case "stderr":
-                            log_output.textContent += e.data[1] + "\n";
+                            log_output.value += e.data[1] + "\n";
+                            log_output.scrollTop = log_output.scrollHeight;
                             break;
                         case "convert-done":
                             input.disabled = false;
@@ -115,7 +117,7 @@
             <br/>
         </div>
         <h2>Console outputs:</h2>
-        <pre id="log-output"></pre>
+        <textarea id="log-output" readonly rows="20" style="width: 100%; box-sizing: border-box;"></textarea>
         <h2>Run inference (onnxruntime-web)</h2>
         <p>
             Runs the selected model for a few iterations to check it executes,

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -7,7 +7,7 @@
                 to_ary = (vec) => {
                     return new Array(vec.size()).fill(0).map((_, id) => vec.get(id))
                 };
-                const passes = document.getElementById("passes");
+                const passes = document.getElementById("pass-list");
                 const checkboxes = {};
                 for (const p of to_ary(runtime.onnxoptimizer_passes()).sort()) {
                     const c = document.createElement("input");
@@ -115,6 +115,7 @@
             <label>target opset version (simplify only, 0 = keep)</label>
             <input type="number" name="simplify_target_opset" id="id_simplify_target_opset" value="0">
             <br/>
+            <div id="pass-list" style="max-height: 300px; overflow-y: auto; border: 1px solid #ccc; padding: 4px; margin-top: 4px;"></div>
         </div>
         <h2>Console outputs:</h2>
         <textarea id="log-output" readonly rows="20" style="width: 100%; box-sizing: border-box;"></textarea>


### PR DESCRIPTION
## Summary
Replaced the `<pre>` element with a `<textarea>` for console output display and added auto-scroll functionality to keep the latest output visible.

## Key Changes
- Changed log output element from `<pre>` to `<textarea>` with `readonly` attribute, 20 rows height, and full width styling
- Updated output appending from `textContent` property to `value` property to work with textarea element
- Added auto-scroll functionality that sets `scrollTop` to `scrollHeight` after each stdout/stderr message, ensuring new output is always visible

## Implementation Details
- The textarea is styled with `box-sizing: border-box` to ensure proper width calculation including padding and borders
- Auto-scroll is applied to both stdout and stderr message handlers
- The readonly attribute prevents user editing while maintaining the ability to select and copy output text

https://claude.ai/code/session_01CFrzhQqC7JJmCVa9du3n34