### PR TITLE
Add "Report an issue" button with pre-filled GitHub issue template

### DIFF
--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -28,11 +28,65 @@
                 }
             });
 
+            // The most recent conversion parameters, captured so that the
+            // "Report an issue" button can include them in the pre-filled report.
+            let last_run_info = null;
+
+            const build_issue_url = () => {
+                const repo = "https://github.com/onnxsim/onnxsim";
+                const lines = [];
+                lines.push("**Describe the bug**");
+                lines.push("<!-- A clear and concise description of what went wrong. -->");
+                lines.push("");
+                lines.push("**Model**");
+                lines.push("<!-- Please attach the model or a download link so the problem can be reproduced,");
+                lines.push("or send it to daquexian566@gmail.com -->");
+                lines.push("");
+                lines.push("**Environment (WASM converter)**");
+                lines.push("- Page: " + location.href);
+                lines.push("- User agent: " + navigator.userAgent);
+                if (last_run_info) {
+                    lines.push("- Optimizer: " + last_run_info.optimizer);
+                    lines.push("- File: " + last_run_info.file_name);
+                    lines.push("- constant fold: " + last_run_info.constant_fold);
+                    lines.push("- shape inference: " + last_run_info.shape_inference);
+                    lines.push("- tensor size threshold: " + last_run_info.tensor_size_threshold);
+                    lines.push("- target opset version: " + last_run_info.target_opset_version + " (0 = keep)");
+                    if (last_run_info.passes && last_run_info.passes.length) {
+                        const label = last_run_info.optimizer === "simplify" ? "Skipped passes" : "Target passes";
+                        lines.push("- " + label + ": " + last_run_info.passes.join(", "));
+                    }
+                } else {
+                    lines.push("- (no conversion has been run yet in this session)");
+                }
+                lines.push("");
+                lines.push("**Console output**");
+                const log_el = document.getElementById("log-output");
+                let log = ((log_el && log_el.textContent) || "").trim();
+                // Keep the URL within browser length limits; include the tail,
+                // which usually holds the error, and note when it was trimmed.
+                const MAX_LOG = 4000;
+                if (log.length > MAX_LOG) {
+                    log = "...(truncated, please paste the full log)...\n" + log.slice(log.length - MAX_LOG);
+                }
+                lines.push("```");
+                lines.push(log || "(no console output)");
+                lines.push("```");
+
+                const title = "[BUG] WASM converter: ";
+                return repo + "/issues/new?title=" + encodeURIComponent(title) +
+                    "&body=" + encodeURIComponent(lines.join("\n"));
+            };
+
             window.onload = () => {
                 const worker = new Worker("worker.js");
                 const log_output = document.getElementById("log-output");
                 const input = document.getElementById("file-input");
                 const dl_btn = document.getElementById("download-button");
+                const report_btn = document.getElementById("report-issue-button");
+                report_btn.onclick = () => {
+                    window.open(build_issue_url(), "_blank", "noopener");
+                };
                 let result_name = "";
                 worker.onmessage = (e) => {
                     switch (e.data[0]) {
@@ -77,6 +131,11 @@
                     const tensor_size_threshold = parseInt(document.getElementById("id_simplify_tensor_size_threshold").value);
                     // An empty / non-positive value means "keep the current opset version".
                     const target_opset_version = parseInt(document.getElementById("id_simplify_target_opset").value) || 0;
+                    last_run_info = {
+                        optimizer, passes, constant_fold, shape_inference,
+                        tensor_size_threshold, target_opset_version,
+                        file_name: file.name,
+                    };
                     worker.postMessage([optimizer, buf, passes, constant_fold, shape_inference, tensor_size_threshold, target_opset_version], [buf]);
                 });
             };
@@ -116,6 +175,15 @@
         </div>
         <h2>Console outputs:</h2>
         <pre id="log-output"></pre>
+        <div>
+            <button id="report-issue-button" type="button">Report an issue</button>
+            <span>
+                Opens a pre-filled
+                <a href="https://github.com/onnxsim/onnxsim/issues" target="_blank">GitHub issue</a>
+                with the selected options, browser info, and console output above.
+                Please also attach your model so the problem can be reproduced.
+            </span>
+        </div>
         <h2>Run inference (onnxruntime-web)</h2>
         <p>
             Runs the selected model for a few iterations to check it executes,


### PR DESCRIPTION
## Summary
This PR adds a "Report an issue" button to the WASM converter page that opens a pre-filled GitHub issue template with relevant debugging information, making it easier for users to report bugs with proper context.

## Key Changes
- Added `build_issue_url()` function that constructs a GitHub issue URL with pre-filled template including:
  - Page URL and user agent information
  - Conversion parameters (optimizer, file name, constant fold, shape inference, tensor size threshold, target opset version, and passes)
  - Console output (truncated to 4000 characters to stay within URL length limits)
- Added `last_run_info` variable to capture the most recent conversion parameters
- Populated `last_run_info` whenever a conversion is run with all relevant options
- Added "Report an issue" button to the UI that opens the pre-filled GitHub issue in a new tab
- Added explanatory text describing what the button does and reminding users to attach their model

## Implementation Details
- The console output is intelligently truncated when exceeding 4000 characters, preserving the tail (which typically contains the error) and noting when truncation occurred
- The issue template includes conditional logic to show different pass labels depending on whether the optimizer is "simplify" or another type
- The button uses `window.open()` with `noopener` flag for security
- If no conversion has been run yet, the template indicates this in the environment section

https://claude.ai/code/session_01JVQqXmQzkkMq7faZAvSSfS