### PR TITLE
Allow inference panel to run converted or original models

### DIFF
--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -110,6 +110,23 @@
                                 a.download = result_name;
                                 a.click();
                             };
+                            // Keep the converted model bytes around so the
+                            // "Run inference" panel can run them (not just the
+                            // original upload). Decode the base64 data URL back
+                            // into a Uint8Array and publish it for the panel.
+                            try {
+                                const b64 = data_url.slice(data_url.indexOf(",") + 1);
+                                const bin = atob(b64);
+                                const bytes = new Uint8Array(bin.length);
+                                for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+                                window.__onnxsimConverted = { bytes, name: result_name };
+                                window.dispatchEvent(new CustomEvent("onnxsim:converted", {
+                                    detail: { name: result_name },
+                                }));
+                            } catch (err) {
+                                log_output.value += "failed to keep converted model for inference: " + err + "\n";
+                                log_output.scrollTop = log_output.scrollHeight;
+                            }
                             // Render the onnxsim simplification profile, if one
                             // came back, as an inline flame graph.
                             if (trace_container) trace_container.innerHTML = "";
@@ -224,11 +241,18 @@
         <div id="simplify-trace"></div>
         <h2>Run inference (onnxruntime-web)</h2>
         <p>
-            Runs the selected model for a few iterations to check it executes,
-            using dummy inputs generated from the model's input shapes. WebGPU
-            falls back to WebAssembly when unavailable.
+            Runs a model for a few iterations to check it executes, using dummy
+            inputs generated from the model's input shapes. Pick whether to run
+            the <b>converted</b> result (the simplify/optimize output) or the
+            <b>original</b> upload, so you can compare the two. WebGPU falls back
+            to WebAssembly when unavailable.
         </p>
         <div>
+            <label for="inference-source">model</label>
+            <select id="inference-source">
+                <option value="converted">converted (simplify/optimize output)</option>
+                <option value="original">original (uploaded)</option>
+            </select>
             <label for="inference-ep">execution provider</label>
             <select id="inference-ep">
                 <option value="webgpu">WebGPU (fallback to WASM)</option>

--- a/scripts/convertmodel/inference_browser.mjs
+++ b/scripts/convertmodel/inference_browser.mjs
@@ -5,6 +5,11 @@
 // shared inference_core.mjs (the same code the Node smoke test drives). The
 // execution provider defaults to WebGPU and falls back to wasm when WebGPU is
 // unavailable, so it works on any browser.
+//
+// The panel can run either the original uploaded model or the converted
+// (simplify/optimize) result. The converter page publishes the converted bytes
+// on `window.__onnxsimConverted` (set in index.html when a conversion
+// finishes); "original" reads the file input directly.
 
 import { runInference } from "./inference_core.mjs";
 import { summarizeOrtTrace } from "./trace_build.mjs";
@@ -85,12 +90,35 @@ async function runOnModel(modelBytes, { iterations, preferWebGPU, profile }, log
   return res;
 }
 
+// Resolve the model bytes for the chosen source. "converted" uses the bytes the
+// converter page published on window.__onnxsimConverted; "original" reads the
+// file input. Returns { bytes, label } or throws with a user-facing message.
+async function resolveModelBytes(source, fileInput) {
+  if (source === "converted") {
+    const converted = window.__onnxsimConverted;
+    if (!converted || !converted.bytes) {
+      throw new Error(
+        "no converted model yet — pick a file above to run a conversion " +
+          "first, or switch the model dropdown to 'original'.",
+      );
+    }
+    return { bytes: converted.bytes, label: `converted (${converted.name})` };
+  }
+  const file = fileInput.files && fileInput.files[0];
+  if (!file) throw new Error("Pick an .onnx file first.");
+  return {
+    bytes: new Uint8Array(await file.arrayBuffer()),
+    label: `original (${file.name})`,
+  };
+}
+
 export function initInferencePanel() {
   const btn = document.getElementById("run-inference");
   const out = document.getElementById("inference-output");
   const fileInput = document.getElementById("file-input");
   const itersInput = document.getElementById("inference-iters");
   const epSelect = document.getElementById("inference-ep");
+  const sourceSelect = document.getElementById("inference-source");
   const profileChk = document.getElementById("inference-profile");
   const traceContainer = document.getElementById("inference-trace");
   if (!btn) return;
@@ -100,19 +128,16 @@ export function initInferencePanel() {
   };
 
   btn.addEventListener("click", async () => {
-    const file = fileInput.files && fileInput.files[0];
-    if (!file) {
-      out.textContent = "Pick an .onnx file first.\n";
-      return;
-    }
     btn.disabled = true;
     out.textContent = "";
     if (traceContainer) traceContainer.innerHTML = "";
     try {
+      const source = sourceSelect ? sourceSelect.value : "original";
+      const { bytes, label } = await resolveModelBytes(source, fileInput);
       const iterations = Math.max(1, parseInt(itersInput.value, 10) || 5);
       const preferWebGPU = epSelect.value === "webgpu";
       const profile = !profileChk || profileChk.checked;
-      const bytes = new Uint8Array(await file.arrayBuffer());
+      log(`running ${label}`);
       log(`loading onnxruntime-web ${ORT_VERSION}…`);
       const res = await runOnModel(
         bytes,


### PR DESCRIPTION
## Summary
This PR adds the ability to run inference on either the converted (simplified/optimized) model or the original uploaded model in the inference panel, allowing users to compare execution results between the two versions.

## Key Changes
- **New model source selector**: Added a dropdown in the inference panel to choose between "converted" and "original" models
- **Converted model persistence**: The converter now publishes converted model bytes to `window.__onnxsimConverted` after a successful conversion, making them available to the inference panel
- **Model resolution logic**: Introduced `resolveModelBytes()` function that handles fetching bytes from either the converter's published data or the file input, with appropriate error messages for each case
- **Updated UI and documentation**: 
  - Added a new `<select>` element for model source selection in the HTML
  - Updated the inference panel description to explain the new capability
  - Added inline comments documenting how the converted model bytes are shared between components

## Implementation Details
- The converter decodes the base64 data URL result back into a `Uint8Array` and stores it in `window.__onnxsimConverted` along with the model name
- A custom event `onnxsim:converted` is dispatched when conversion completes (for potential future use)
- The inference panel gracefully handles the case where no converted model is available yet, prompting the user to run a conversion first
- Both model sources are labeled with their name for clarity in the inference output logs

https://claude.ai/code/session_016o1mRVYkghBXu8NPYbjEUi