### PR TITLE
Add model info diff reporting across all bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 # configure onnx-optimizer after onnxruntime, because they both depend on onnx and onnxruntime has its own flags for onnx
 add_subdirectory(third_party/onnx-optimizer EXCLUDE_FROM_ALL)
 
-add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/contrib_schemas.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp)
+add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/contrib_schemas.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp)
 if (ONNXSIM_BUILTIN_ORT)
   target_include_directories(onnxsim PRIVATE ${ONNXRUNTIME_INCLUDE_DIR})
 endif()

--- a/onnxsim/bin/onnxsim_bin.cpp
+++ b/onnxsim/bin/onnxsim_bin.cpp
@@ -1,5 +1,7 @@
 #include <fstream>
+#include <iostream>
 
+#include "model_info.h"
 #include "onnx/common/file_utils.h"
 #include "onnxsim.h"
 #include "onnxsim_option.h"
@@ -18,7 +20,7 @@ int main(int argc, char** argv) {
   onnx::ModelProto model;
   onnx::LoadProtoFromPath(input_model_filename, model);
 
-  model = Simplify(
+  onnx::ModelProto simplified = Simplify(
       *GetBuiltinModelExecutor(), model,
       no_opt ? std::nullopt : std::make_optional<std::vector<std::string>>({}),
       !no_sim, !no_shape_inference, SIZE_MAX,
@@ -27,8 +29,13 @@ int main(int argc, char** argv) {
 
   std::ofstream ofs(output_model_filename,
                     std::ios::out | std::ios::trunc | std::ios::binary);
-  if (!model.SerializeToOstream(&ofs)) {
+  if (!simplified.SerializeToOstream(&ofs)) {
     throw std::invalid_argument("save model error");
   }
+
+  // Report the difference between the original and simplified models, matching
+  // the Python CLI's "Finish! Here is the difference:" output.
+  std::cout << "Finish! Here is the difference:\n";
+  std::cout << FormatSimplifyingInfo(model, simplified);
   return 0;
 }

--- a/onnxsim/capi/onnxsim_c_api.cpp
+++ b/onnxsim/capi/onnxsim_c_api.cpp
@@ -364,8 +364,7 @@ OnnxsimStatus onnxsim_model_info_diff(const void* original_data,
   }
   try {
     onnx::ModelProto original;
-    if (!ParseProtoFromBytes(&original,
-                             static_cast<const char*>(original_data),
+    if (!ParseProtoFromBytes(&original, static_cast<const char*>(original_data),
                              original_size)) {
       SetError(out_error, "failed to parse the original ONNX ModelProto");
       return ONNXSIM_ERROR;

--- a/onnxsim/capi/onnxsim_c_api.cpp
+++ b/onnxsim/capi/onnxsim_c_api.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "function_rewriter.h"
+#include "model_info.h"
 #include "onnx/proto_utils.h"
 #include "onnxoptimizer/optimize.h"
 #include "onnxsim.h"
@@ -343,6 +344,54 @@ char* onnxsim_list_optimizers(void) {
     return DupCString(joined);
   } catch (...) {
     return nullptr;
+  }
+}
+
+OnnxsimStatus onnxsim_model_info_diff(const void* original_data,
+                                      size_t original_size,
+                                      const void* simplified_data,
+                                      size_t simplified_size, char** out_text,
+                                      char** out_error) {
+  if (out_text != nullptr) {
+    *out_text = nullptr;
+  }
+  if (out_error != nullptr) {
+    *out_error = nullptr;
+  }
+  if (original_data == nullptr || simplified_data == nullptr) {
+    SetError(out_error, "onnxsim_model_info_diff: required argument is NULL");
+    return ONNXSIM_ERROR;
+  }
+  try {
+    onnx::ModelProto original;
+    if (!ParseProtoFromBytes(&original,
+                             static_cast<const char*>(original_data),
+                             original_size)) {
+      SetError(out_error, "failed to parse the original ONNX ModelProto");
+      return ONNXSIM_ERROR;
+    }
+    onnx::ModelProto simplified;
+    if (!ParseProtoFromBytes(&simplified,
+                             static_cast<const char*>(simplified_data),
+                             simplified_size)) {
+      SetError(out_error, "failed to parse the simplified ONNX ModelProto");
+      return ONNXSIM_ERROR;
+    }
+    if (out_text != nullptr) {
+      char* text = DupCString(FormatSimplifyingInfo(original, simplified));
+      if (text == nullptr) {
+        SetError(out_error, "out of memory while formatting the model diff");
+        return ONNXSIM_ERROR;
+      }
+      *out_text = text;
+    }
+    return ONNXSIM_OK;
+  } catch (const std::exception& e) {
+    SetError(out_error, e.what());
+    return ONNXSIM_ERROR;
+  } catch (...) {
+    SetError(out_error, "unknown error while computing the model diff");
+    return ONNXSIM_ERROR;
   }
 }
 

--- a/onnxsim/capi/onnxsim_c_api.h
+++ b/onnxsim/capi/onnxsim_c_api.h
@@ -157,19 +157,21 @@ ONNXSIM_C_API char* onnxsim_list_optimizers(void);
 /*
  * Render a human-readable diff between an original and a simplified model, both
  * given as serialized ONNX ModelProto bytes. The report is an ASCII table
- * comparing op counts and model size, the same information the Python CLI prints
- * as "the difference" after simplifying. It lets the non-Python bindings show a
- * before/after summary without re-implementing the analysis.
+ * comparing op counts and model size, the same information the Python CLI
+ * prints as "the difference" after simplifying. It lets the non-Python bindings
+ * show a before/after summary without re-implementing the analysis.
  *
  * On ONNXSIM_OK, *out_text receives a newly allocated, NUL-terminated string
  * holding the table; release it with onnxsim_free_string. On ONNXSIM_ERROR,
- * *out_error receives a newly allocated message; release it the same way. Either
- * out_* pointer may be NULL if the caller does not want that value.
+ * *out_error receives a newly allocated message; release it the same way.
+ * Either out_* pointer may be NULL if the caller does not want that value.
  */
-ONNXSIM_C_API OnnxsimStatus onnxsim_model_info_diff(
-    const void* original_data, size_t original_size,
-    const void* simplified_data, size_t simplified_size, char** out_text,
-    char** out_error);
+ONNXSIM_C_API OnnxsimStatus onnxsim_model_info_diff(const void* original_data,
+                                                    size_t original_size,
+                                                    const void* simplified_data,
+                                                    size_t simplified_size,
+                                                    char** out_text,
+                                                    char** out_error);
 
 /* Free a buffer returned via an out_data parameter. NULL is ignored. */
 ONNXSIM_C_API void onnxsim_free_buffer(void* data);

--- a/onnxsim/capi/onnxsim_c_api.h
+++ b/onnxsim/capi/onnxsim_c_api.h
@@ -154,6 +154,23 @@ ONNXSIM_C_API OnnxsimStatus onnxsim_simplify_path(
  */
 ONNXSIM_C_API char* onnxsim_list_optimizers(void);
 
+/*
+ * Render a human-readable diff between an original and a simplified model, both
+ * given as serialized ONNX ModelProto bytes. The report is an ASCII table
+ * comparing op counts and model size, the same information the Python CLI prints
+ * as "the difference" after simplifying. It lets the non-Python bindings show a
+ * before/after summary without re-implementing the analysis.
+ *
+ * On ONNXSIM_OK, *out_text receives a newly allocated, NUL-terminated string
+ * holding the table; release it with onnxsim_free_string. On ONNXSIM_ERROR,
+ * *out_error receives a newly allocated message; release it the same way. Either
+ * out_* pointer may be NULL if the caller does not want that value.
+ */
+ONNXSIM_C_API OnnxsimStatus onnxsim_model_info_diff(
+    const void* original_data, size_t original_size,
+    const void* simplified_data, size_t simplified_size, char** out_text,
+    char** out_error);
+
 /* Free a buffer returned via an out_data parameter. NULL is ignored. */
 ONNXSIM_C_API void onnxsim_free_buffer(void* data);
 

--- a/onnxsim/model_info.cpp
+++ b/onnxsim/model_info.cpp
@@ -12,9 +12,9 @@
 namespace {
 
 // Recursively tally op types, descending into every subgraph carried by a node
-// attribute (the ``g`` of e.g. an ``If`` branch, or the ``graphs`` of ``Loop``).
-// Every initializer of each graph is counted as a ``Constant``, matching the
-// Python ``ModelInfo.get_info``.
+// attribute (the ``g`` of e.g. an ``If`` branch, or the ``graphs`` of
+// ``Loop``). Every initializer of each graph is counted as a ``Constant``,
+// matching the Python ``ModelInfo.get_info``.
 void CountGraphOps(const onnx::GraphProto& graph,
                    std::map<std::string, int64_t>& op_nums) {
   for (const auto& node : graph.node()) {
@@ -50,9 +50,10 @@ int64_t TensorExternalSize(const onnx::TensorProto& tensor) {
   return 0;
 }
 
-// Total external-data bytes across every tensor a graph holds -- initializers as
-// well as tensors carried in node attributes -- recursing into subgraphs. This
-// mirrors Python's ``_external_data_size`` and never loads the data itself.
+// Total external-data bytes across every tensor a graph holds -- initializers
+// as well as tensors carried in node attributes -- recursing into subgraphs.
+// This mirrors Python's ``_external_data_size`` and never loads the data
+// itself.
 int64_t ExternalDataSize(const onnx::GraphProto& graph) {
   int64_t total = 0;
   for (const auto& initializer : graph.initializer()) {
@@ -82,7 +83,7 @@ int64_t ExternalDataSize(const onnx::GraphProto& graph) {
 std::string HumanReadableSize(int64_t num) {
   double value = static_cast<double>(num);
   static const char* const kUnits[] = {"",   "Ki", "Mi", "Gi",
-                                        "Ti", "Pi", "Ei", "Zi"};
+                                       "Ti", "Pi", "Ei", "Zi"};
   char buf[64];
   for (const char* unit : kUnits) {
     if (std::fabs(value) < 1024.0) {
@@ -136,8 +137,7 @@ std::string FormatSimplifyingInfo(const onnx::ModelProto& model_ori,
 
   std::string size_cell = HumanReadableSize(opt.model_size);
   if (opt.model_size < ori.model_size) size_cell += " *";
-  rows.push_back(
-      {"Model Size", HumanReadableSize(ori.model_size), size_cell});
+  rows.push_back({"Model Size", HumanReadableSize(ori.model_size), size_cell});
 
   std::array<size_t, 3> width = {0, 0, 0};
   for (const auto& row : rows) {

--- a/onnxsim/model_info.cpp
+++ b/onnxsim/model_info.cpp
@@ -1,0 +1,179 @@
+#include "model_info.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace {
+
+// Recursively tally op types, descending into every subgraph carried by a node
+// attribute (the ``g`` of e.g. an ``If`` branch, or the ``graphs`` of ``Loop``).
+// Every initializer of each graph is counted as a ``Constant``, matching the
+// Python ``ModelInfo.get_info``.
+void CountGraphOps(const onnx::GraphProto& graph,
+                   std::map<std::string, int64_t>& op_nums) {
+  for (const auto& node : graph.node()) {
+    op_nums[node.op_type()] += 1;
+    for (const auto& attr : node.attribute()) {
+      if (attr.has_g()) {
+        CountGraphOps(attr.g(), op_nums);
+      }
+      for (const auto& subgraph : attr.graphs()) {
+        CountGraphOps(subgraph, op_nums);
+      }
+    }
+  }
+  op_nums["Constant"] += graph.initializer_size();
+}
+
+// Bytes of a single tensor's data when it lives in an external file, read from
+// the ``length`` entry of its ``external_data`` record. Zero for tensors held
+// inline (whose bytes are already part of the graph's serialized size).
+int64_t TensorExternalSize(const onnx::TensorProto& tensor) {
+  if (tensor.data_location() != onnx::TensorProto::EXTERNAL) {
+    return 0;
+  }
+  for (const auto& entry : tensor.external_data()) {
+    if (entry.key() == "length") {
+      try {
+        return std::stoll(entry.value());
+      } catch (...) {
+        return 0;
+      }
+    }
+  }
+  return 0;
+}
+
+// Total external-data bytes across every tensor a graph holds -- initializers as
+// well as tensors carried in node attributes -- recursing into subgraphs. This
+// mirrors Python's ``_external_data_size`` and never loads the data itself.
+int64_t ExternalDataSize(const onnx::GraphProto& graph) {
+  int64_t total = 0;
+  for (const auto& initializer : graph.initializer()) {
+    total += TensorExternalSize(initializer);
+  }
+  for (const auto& node : graph.node()) {
+    for (const auto& attr : node.attribute()) {
+      if (attr.has_t()) {
+        total += TensorExternalSize(attr.t());
+      }
+      for (const auto& tensor : attr.tensors()) {
+        total += TensorExternalSize(tensor);
+      }
+      if (attr.has_g()) {
+        total += ExternalDataSize(attr.g());
+      }
+      for (const auto& subgraph : attr.graphs()) {
+        total += ExternalDataSize(subgraph);
+      }
+    }
+  }
+  return total;
+}
+
+// Format a byte count with 1024-based binary units, matching the Python
+// ``human_readable_size`` (e.g. 1536 -> "1.5KiB").
+std::string HumanReadableSize(int64_t num) {
+  double value = static_cast<double>(num);
+  static const char* const kUnits[] = {"",   "Ki", "Mi", "Gi",
+                                        "Ti", "Pi", "Ei", "Zi"};
+  char buf[64];
+  for (const char* unit : kUnits) {
+    if (std::fabs(value) < 1024.0) {
+      std::snprintf(buf, sizeof(buf), "%.1f%sB", value, unit);
+      return buf;
+    }
+    value /= 1024.0;
+  }
+  std::snprintf(buf, sizeof(buf), "%.1fYiB", value);
+  return buf;
+}
+
+int64_t OpCount(const std::map<std::string, int64_t>& op_nums,
+                const std::string& key) {
+  auto it = op_nums.find(key);
+  return it != op_nums.end() ? it->second : 0;
+}
+
+}  // namespace
+
+ModelInfo GetModelInfo(const onnx::ModelProto& model) {
+  ModelInfo info;
+  CountGraphOps(model.graph(), info.op_nums);
+  // ByteSizeLong() (not the 32-bit ByteSize()) so models above 2GB do not
+  // overflow; external tensor data is then added from metadata.
+  info.model_size = static_cast<int64_t>(model.graph().ByteSizeLong()) +
+                    ExternalDataSize(model.graph());
+  return info;
+}
+
+std::string FormatSimplifyingInfo(const onnx::ModelProto& model_ori,
+                                  const onnx::ModelProto& model_opt) {
+  const ModelInfo ori = GetModelInfo(model_ori);
+  const ModelInfo opt = GetModelInfo(model_opt);
+
+  // Each row is {name, original, simplified}; the simplified cell gets a
+  // trailing " *" when the metric improved (a smaller count / size).
+  std::vector<std::array<std::string, 3>> rows;
+  rows.push_back({"", "Original Model", "Simplified Model"});
+
+  std::set<std::string> keys;
+  for (const auto& entry : ori.op_nums) keys.insert(entry.first);
+  for (const auto& entry : opt.op_nums) keys.insert(entry.first);
+  for (const auto& key : keys) {
+    const int64_t o = OpCount(ori.op_nums, key);
+    const int64_t s = OpCount(opt.op_nums, key);
+    std::string simplified = std::to_string(s);
+    if (s < o) simplified += " *";
+    rows.push_back({key, std::to_string(o), simplified});
+  }
+
+  std::string size_cell = HumanReadableSize(opt.model_size);
+  if (opt.model_size < ori.model_size) size_cell += " *";
+  rows.push_back(
+      {"Model Size", HumanReadableSize(ori.model_size), size_cell});
+
+  std::array<size_t, 3> width = {0, 0, 0};
+  for (const auto& row : rows) {
+    for (size_t c = 0; c < 3; ++c) {
+      width[c] = std::max(width[c], row[c].size());
+    }
+  }
+
+  auto border = [&]() {
+    std::string line = "+";
+    for (size_t c = 0; c < 3; ++c) {
+      line.append(width[c] + 2, '-');
+      line.push_back('+');
+    }
+    line.push_back('\n');
+    return line;
+  };
+  auto render = [&](const std::array<std::string, 3>& row) {
+    std::string line = "|";
+    for (size_t c = 0; c < 3; ++c) {
+      line.push_back(' ');
+      line.append(row[c]);
+      line.append(width[c] - row[c].size(), ' ');
+      line.append(" |");
+    }
+    line.push_back('\n');
+    return line;
+  };
+
+  std::string out;
+  out += border();
+  out += render(rows.front());
+  out += border();
+  for (size_t i = 1; i < rows.size(); ++i) {
+    out += render(rows[i]);
+  }
+  out += border();
+  return out;
+}

--- a/onnxsim/model_info.h
+++ b/onnxsim/model_info.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <onnx/onnx_pb.h>
+
+#include <cstdint>
+#include <map>
+#include <string>
+
+// A lightweight, dependency-free counterpart to the Python ``ModelInfo`` for the
+// non-Python bindings (the CLI binary, the C ABI / Rust wrapper, and the WASM
+// converter). It reports the two metrics that can be derived from a
+// ``ModelProto`` alone, without ONNX shape inference:
+//
+//   * ``op_nums`` -- how many of each op type the model contains, recursing into
+//     control-flow subgraphs. Initializers are folded into the ``Constant``
+//     count, exactly as the Python ``ModelInfo`` does, so a weight tensor reads
+//     as a constant.
+//   * ``model_size`` -- the serialized byte size of the graph plus any tensor
+//     data kept in external files (read from the external-data metadata, so
+//     weights on disk are counted without being materialized).
+//
+// The heavier metrics the Python table also shows (MACs / FLOPs and the memory
+// figures) require full shape inference and a symbolic-math dependency, so they
+// are intentionally out of scope for these bindings.
+struct ModelInfo {
+  std::map<std::string, int64_t> op_nums;
+  int64_t model_size = 0;
+};
+
+// Compute the op counts and model size of ``model``.
+ModelInfo GetModelInfo(const onnx::ModelProto& model);
+
+// Render an ASCII table comparing an original and a simplified model, mirroring
+// the layout of the Python ``print_simplifying_info``: one row per op type (the
+// sorted union of both models' ops) followed by a ``Model Size`` row, with
+// columns for the original and simplified values. A metric that improved (a
+// dropped op count or a smaller model) is flagged with a trailing ``*``, since
+// these bindings print to plain terminals where the Python rich-text colouring
+// is unavailable. The returned string ends with a newline.
+std::string FormatSimplifyingInfo(const onnx::ModelProto& model_ori,
+                                  const onnx::ModelProto& model_opt);

--- a/onnxsim/model_info.h
+++ b/onnxsim/model_info.h
@@ -6,12 +6,13 @@
 #include <map>
 #include <string>
 
-// A lightweight, dependency-free counterpart to the Python ``ModelInfo`` for the
-// non-Python bindings (the CLI binary, the C ABI / Rust wrapper, and the WASM
-// converter). It reports the two metrics that can be derived from a
+// A lightweight, dependency-free counterpart to the Python ``ModelInfo`` for
+// the non-Python bindings (the CLI binary, the C ABI / Rust wrapper, and the
+// WASM converter). It reports the two metrics that can be derived from a
 // ``ModelProto`` alone, without ONNX shape inference:
 //
-//   * ``op_nums`` -- how many of each op type the model contains, recursing into
+//   * ``op_nums`` -- how many of each op type the model contains, recursing
+//   into
 //     control-flow subgraphs. Initializers are folded into the ``Constant``
 //     count, exactly as the Python ``ModelInfo`` does, so a weight tensor reads
 //     as a constant.

--- a/rust/README.md
+++ b/rust/README.md
@@ -69,6 +69,18 @@ for name in onnxsim::list_optimizers() {
 }
 ```
 
+Print the before/after difference, the same op-count and model-size summary the
+Python CLI shows after simplifying:
+
+```rust
+fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let model = std::fs::read("model.onnx")?;
+    let simplified = onnxsim::simplify(&model)?;
+    print!("{}", onnxsim::model_info_diff(&model, &simplified)?);
+    Ok(())
+}
+```
+
 ## Custom rewriter
 
 Run your own graph-rewriting logic inside the simplification fixed point — the

--- a/rust/onnxsim-sys/src/lib.rs
+++ b/rust/onnxsim-sys/src/lib.rs
@@ -135,6 +135,24 @@ extern "C" {
     /// Always safe to call; the returned pointer must be freed exactly once.
     pub fn onnxsim_list_optimizers() -> *mut c_char;
 
+    /// Render a human-readable diff (op counts + model size) between an original
+    /// and a simplified model, both serialized `ModelProto` bytes. On
+    /// `ONNXSIM_OK`, `out_text` owns a NUL-terminated string to free with
+    /// [`onnxsim_free_string`]; on `ONNXSIM_ERROR`, `out_error` owns a message.
+    ///
+    /// # Safety
+    /// `original_data`/`simplified_data` must each point to at least the matching
+    /// size in bytes; `out_text`/`out_error`, if non-null, receive owned strings
+    /// that must be freed exactly once.
+    pub fn onnxsim_model_info_diff(
+        original_data: *const c_void,
+        original_size: usize,
+        simplified_data: *const c_void,
+        simplified_size: usize,
+        out_text: *mut *mut c_char,
+        out_error: *mut *mut c_char,
+    ) -> c_int;
+
     /// Free a buffer produced by an `out_data` parameter. Null is ignored.
     ///
     /// # Safety

--- a/rust/onnxsim/examples/simplify.rs
+++ b/rust/onnxsim/examples/simplify.rs
@@ -17,9 +17,28 @@ fn main() -> ExitCode {
     let input = &args[1];
     let output = &args[2];
 
-    match onnxsim::simplify_path(input, output) {
-        Ok(()) => {
+    // Simplify in memory (rather than with `simplify_path`) so we still hold the
+    // original bytes and can print the before/after diff, mirroring the Python
+    // CLI's "here is the difference" output.
+    let model_bytes = match std::fs::read(input) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            eprintln!("error: cannot read {input}: {err}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match onnxsim::simplify(&model_bytes) {
+        Ok(simplified) => {
+            if let Err(err) = std::fs::write(output, &simplified) {
+                eprintln!("error: cannot write {output}: {err}");
+                return ExitCode::FAILURE;
+            }
             println!("simplified {input} -> {output}");
+            match onnxsim::model_info_diff(&model_bytes, &simplified) {
+                Ok(diff) => print!("{diff}"),
+                Err(err) => eprintln!("warning: could not compute model diff: {err}"),
+            }
             ExitCode::SUCCESS
         }
         Err(err) => {

--- a/rust/onnxsim/src/lib.rs
+++ b/rust/onnxsim/src/lib.rs
@@ -616,6 +616,51 @@ pub fn list_optimizers() -> Vec<String> {
         .collect()
 }
 
+/// Render a human-readable diff between an `original` and a `simplified` model,
+/// both serialized ONNX `ModelProto` bytes.
+///
+/// The report is an ASCII table comparing op counts and model size — the same
+/// "here is the difference" summary the Python CLI prints after simplifying — so
+/// a Rust caller can show a before/after view without decoding the models
+/// itself. A metric that improved is flagged with a trailing `*`.
+///
+/// ```no_run
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let model = std::fs::read("model.onnx")?;
+/// let simplified = onnxsim::simplify(&model)?;
+/// print!("{}", onnxsim::model_info_diff(&model, &simplified)?);
+/// # Ok(())
+/// # }
+/// ```
+pub fn model_info_diff(original: &[u8], simplified: &[u8]) -> Result<String, Error> {
+    let mut out_text: *mut c_char = ptr::null_mut();
+    let mut out_error: *mut c_char = ptr::null_mut();
+
+    let status = unsafe {
+        onnxsim_sys::onnxsim_model_info_diff(
+            original.as_ptr() as *const c_void,
+            original.len(),
+            simplified.as_ptr() as *const c_void,
+            simplified.len(),
+            &mut out_text,
+            &mut out_error,
+        )
+    };
+
+    if status == onnxsim_sys::ONNXSIM_OK {
+        if out_text.is_null() {
+            return Ok(String::new());
+        }
+        let text = unsafe { CStr::from_ptr(out_text) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { onnxsim_sys::onnxsim_free_string(out_text) };
+        Ok(text)
+    } else {
+        Err(take_error(out_error))
+    }
+}
+
 /// Owns the `CString`s and pointer array backing the `skip_optimizers` FFI
 /// arguments, keeping them alive for the duration of a call.
 struct FfiSkipOptimizers {

--- a/scripts/convertmodel/interface.cpp
+++ b/scripts/convertmodel/interface.cpp
@@ -1,10 +1,12 @@
 #include "onnxsim.h"
+#include "model_info.h"
 #include "onnxoptimizer/optimize.h"
 #include "onnx/checker.h"
 
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 #include <string>
 
@@ -94,6 +96,12 @@ em::val onnxsimplify_export(const std::string& data, em::val skip_optimizers, bo
         return em::val::null();
     }
     std::cerr << "simplify end" << std::endl;
+
+    // Print the before/after diff (op counts + model size) to stdout so the page
+    // surfaces it in the log, mirroring the Python CLI's "here is the difference"
+    // output. std::cout is routed to the worker's `print` handler.
+    std::cout << "Finish! Here is the difference:\n"
+              << FormatSimplifyingInfo(xmodel, optimized) << std::flush;
 
     // Collect the trace right after Simplify() (the profiler has flushed it by
     // now) and turn profiling back off, so a later check/serialize failure


### PR DESCRIPTION
## Summary
This PR adds the ability to generate human-readable before/after comparison reports (op counts and model size) across all onnxsim bindings: C API, Rust, CLI binary, and WASM converter. This mirrors the Python CLI's "here is the difference" output that users see after simplification.

## Key Changes

- **New `model_info.h/cpp`**: Implements lightweight model analysis without external dependencies
  - `GetModelInfo()`: Extracts op type counts and model size from a ModelProto
  - `FormatSimplifyingInfo()`: Renders an ASCII table comparing original vs. simplified models
  - Recursively counts ops in control-flow subgraphs (If, Loop, etc.)
  - Handles external tensor data by reading metadata without materializing weights
  - Formats byte sizes with binary units (KiB, MiB, etc.) matching Python's output

- **C API** (`onnxsim_c_api.h/cpp`):
  - New `onnxsim_model_info_diff()` function accepting serialized ModelProto bytes
  - Returns formatted diff table or error message

- **Rust bindings** (`rust/onnxsim/src/lib.rs`):
  - New `model_info_diff()` function wrapping the C API
  - Updated example to show before/after diff after simplification

- **CLI binary** (`onnxsim/bin/onnxsim_bin.cpp`):
  - Now prints "Finish! Here is the difference:" followed by the diff table
  - Matches Python CLI's user-facing output

- **WASM converter** (`scripts/convertmodel/interface.cpp`):
  - Prints diff to stdout so it appears in the web UI logs

- **Build system** (`CMakeLists.txt`):
  - Added `model_info.cpp` to the onnxsim library

## Implementation Details

- The implementation is dependency-free and works with protobuf alone, making it suitable for all bindings
- Op counting treats initializers as "Constant" ops, matching Python's ModelInfo behavior
- External tensor data sizes are read from metadata without loading actual files
- Improved metrics are flagged with a trailing `*` in the ASCII table (since non-Python bindings lack rich-text coloring)
- The table format is consistent across all bindings for a unified user experience

https://claude.ai/code/session_01GTQxS8MosXwwCNS2ac57kN