### PR TITLE
Fold deterministic function-body ops (Range) and Conv→Mul→Add affine tails

### DIFF
--- a/bench/RESULTS_onnxslim_comparison.md
+++ b/bench/RESULTS_onnxslim_comparison.md
@@ -53,15 +53,15 @@ chain. onnxslim folds it; onnxsim did not.
 
 ## The fix
 
-`IsDeterministic` now folds every default-domain op **except** an explicit
-denylist of the genuinely non-deterministic (random/stateful) generators —
-`RandomNormal`, `RandomNormalLike`, `RandomUniform`, `RandomUniformLike`,
-`Multinomial`, `Bernoulli`, `Dropout`, `SequenceMap`. This mirrors the set ONNX
-annotates with `SetNodeDeterminism(NonDeterministic)` on the operator's *own*
-schema (as opposed to the value it *infers* for function bodies), and matches
-the behaviour onnxsim had before it switched to the schema attribute. Subgraph
-carriers (`If`/`Loop`/`Scan`) remain excluded by the existing `!HasSubgraph`
-guard at the call site.
+Rather than second-guess the determinism query in `IsDeterministic` (which stays
+the ordinary `GetNodeDeterminism() == Deterministic` check), onnxsim corrects the
+mis-annotated source data. `FixupSchemaDeterminism()` marks the affected ops —
+currently `Range` — as `Deterministic` on their registered schemas (every
+version in the registry's history), and `Simplify()` calls it once before
+folding. The ONNX registry hands back pointers into its own storage, so the
+metadata is corrected in place and the normal folding check then picks `Range`
+up. Genuinely non-deterministic generators keep their explicit
+`SetNodeDeterminism(NonDeterministic)` and are still never folded.
 
 ## Swin-S: where the 213 nodes went
 
@@ -84,6 +84,34 @@ The remaining ~24-node difference vs onnxslim is mostly onnxslim rewriting the
 3-D transformer linears `MatMul(x, W) + b` into `Reshape → Gemm → Reshape`
 (1 → 97 `Gemm`), a representation change that trades node count for a fused-bias
 GEMM kernel; it is orthogonal to the folding fix here.
+
+## FasterRCNN-10: cause of the remaining gap (onnxsim 2824 vs onnxslim 2622)
+
+The determinism fix does not change FasterRCNN-10 (it is opset 10, and `Range`
+did not exist until opset 11, so there is nothing to unblock). The 202-node gap
+to onnxslim is a **different, fusion-level** gap, not a folding one:
+
+| op | onnxsim | onnxslim | Δ | cause |
+|---|---:|---:|---:|---|
+| Mul | 119 | 59 | +60 | Conv scale not fused |
+| Add | 127 | 74 | +53 | Conv bias not fused |
+| Unsqueeze | 379 | 310 | +69 | dynamic-shape plumbing |
+| Gather/Slice/… | — | — | +20 | dynamic-shape plumbing |
+
+* **~106 nodes — decomposed BatchNorm (`Conv → Mul → Add`).** onnxsim's output
+  contains **53** `Conv → Mul(scale) → Add(bias)` chains where `scale`/`bias` are
+  per-channel `(1, C, 1, 1)` constants (a BatchNorm exported as an affine pair);
+  onnxslim has **0** — it folds the scale into the Conv weights and the bias into
+  the Conv bias. onnxoptimizer has `fuse_bn_into_conv` (for an actual
+  `BatchNormalization` node) and `fuse_add_bias_into_conv`, but no pass that
+  folds a per-channel `Mul` sitting between a `Conv` and its bias `Add`, so
+  neither the `Mul` nor the now-not-adjacent `Add` fuses. Closing this would be
+  an **onnxoptimizer** change (a `fuse_mul_into_conv`-style pass), not an onnxsim
+  one.
+* **~90 nodes — dynamic-shape plumbing.** The rest is `Gather`-from-`Shape` →
+  `Unsqueeze` → `Concat` shape arithmetic for the dynamic `height`/`width`
+  input. These depend on the runtime shape and so cannot be constant-folded;
+  onnxslim collapses more of them with dedicated shape-graph simplifications.
 
 ## Verification
 

--- a/bench/RESULTS_onnxslim_comparison.md
+++ b/bench/RESULTS_onnxslim_comparison.md
@@ -1,0 +1,106 @@
+# onnxsim vs onnxslim on `swin_s_Opset18` and `FasterRCNN-10`
+
+**Models:** [`onnxmodelzoo/swin_s_Opset18`](https://huggingface.co/onnxmodelzoo/swin_s_Opset18)
+and [`onnxmodelzoo/FasterRCNN-10`](https://huggingface.co/onnxmodelzoo/FasterRCNN-10)
+(Hugging Face).
+**Reproduce:** `python bench/onnxslim_comparison.py swin_s_Opset18 FasterRCNN-10`
+**Tools:** onnxsim (this repo), onnxslim `0.1.94`, onnxruntime `1.28`, onnx `1.22`.
+
+## TL;DR
+
+Comparing the two simplifiers surfaced a concrete constant-folding gap in
+onnxsim, now fixed in `onnxsim/onnxsim.cpp` (`IsDeterministic`):
+
+| Model | orig | onnxsim (before) | **onnxsim (after fix)** | onnxslim |
+|---|---:|---:|---:|---:|
+| `swin_s_Opset18` | 12830 | 1295 | **1082** | 1058 |
+| `FasterRCNN-10`  | 6370  | 2824 | **2824** | 2622 |
+
+The fix removes **213 nodes (−16 %)** from Swin-S and closes almost the entire
+gap to onnxslim (1082 vs 1058), with the simplified model **numerically
+identical** to the original (max abs diff `0.0` over random inputs). FasterRCNN
+is unchanged (no regression). Genuinely non-deterministic ops (`RandomNormal`,
+`RandomUniform`, `Multinomial`, `Bernoulli`, `Dropout`, …) are still never
+folded.
+
+## Root cause
+
+onnxsim's constant folder only folds a node when every input is constant **and**
+the op is considered deterministic. Determinism was decided by
+`schema->GetNodeDeterminism() == Deterministic`.
+
+That test is wrong for a whole class of deterministic ops. ONNX describes some
+ops through a **function body**, and `GetNodeDeterminism()` infers a function
+op's determinism from its constituent ops — reporting `NonDeterministic` for any
+constituent that merely *carries a subgraph* (`Loop`/`If`/`Scan`), and
+`Unknown` for context-dependent functions. `Range` is the canonical victim: its
+body is a `Loop` (opset < 27) or a context-dependent function (opset ≥ 27), so
+its schema determinism is **not** `Deterministic` even though `Range` is a pure
+function of its inputs.
+
+Because folding propagates constness through the graph, a single unfoldable
+`Range` **poisons an entire otherwise-constant subgraph**. In Swin-S the static
+attention-mask construction
+
+```
+Range → Slice → Reshape → Expand → Unsqueeze → Concat        (× windows)
+ScatterND → ScatterND → … (chained, initializer-fed)
+```
+
+is fully determined by the (static) input size and the model's initializers, so
+it *should* collapse to constants — but the leading `Range` blocked the whole
+chain. onnxslim folds it; onnxsim did not.
+
+## The fix
+
+`IsDeterministic` now folds every default-domain op **except** an explicit
+denylist of the genuinely non-deterministic (random/stateful) generators —
+`RandomNormal`, `RandomNormalLike`, `RandomUniform`, `RandomUniformLike`,
+`Multinomial`, `Bernoulli`, `Dropout`, `SequenceMap`. This mirrors the set ONNX
+annotates with `SetNodeDeterminism(NonDeterministic)` on the operator's *own*
+schema (as opposed to the value it *infers* for function bodies), and matches
+the behaviour onnxsim had before it switched to the schema attribute. Subgraph
+carriers (`If`/`Loop`/`Scan`) remain excluded by the existing `!HasSubgraph`
+guard at the call site.
+
+## Swin-S: where the 213 nodes went
+
+Op-type counts after simplification (ops that changed):
+
+| op | orig | onnxsim before | onnxsim after | onnxslim |
+|---|---:|---:|---:|---:|
+| Unsqueeze | 988 | 63 | **0** | 0 |
+| Expand | 297 | 54 | **0** | 0 |
+| Range | 198 | 3 | **0** | 0 |
+| Where | 220 | 6 | **0** | 0 |
+| Equal | 220 | 3 | **0** | 0 |
+| ScatterND | 99 | 27 | **0** | 0 |
+| Sub | 86 | 3 | **0** | 0 |
+| Concat | 525 | 74 | **47** | 47 |
+| Slice | 676 | 133 | **124** | 100 |
+| Reshape | 440 | 181 | **166** | 262 |
+
+The remaining ~24-node difference vs onnxslim is mostly onnxslim rewriting the
+3-D transformer linears `MatMul(x, W) + b` into `Reshape → Gemm → Reshape`
+(1 → 97 `Gemm`), a representation change that trades node count for a fused-bias
+GEMM kernel; it is orthogonal to the folding fix here.
+
+## Verification
+
+* **Numerical equivalence (Swin-S):** original vs simplified, random input,
+  onnxruntime with all graph optimizations disabled → **max abs diff `0.0`**.
+* **No regression (FasterRCNN):** identical output (2824 nodes) before and after
+  the fix; `onnxsim.simplify(..)` still returns `check_ok=True`.
+* **Random ops preserved:** `RandomUniform`/`RandomNormal` graphs are returned
+  unfolded.
+* **Tests:** `tests/test_constant_fold_determinism.py` (new, torch-free) plus the
+  existing `tests/test_simple.py` suite pass.
+
+## Side note: FasterRCNN-10 fails onnxruntime's load-time shape inference
+
+Independently of this change, onnxsim's `FasterRCNN-10` output (both before and
+after the fix) fails to load in onnxruntime with a static
+`Reshape [ShapeInferenceError]` on the dynamic `3×height×width` input, whereas
+onnxslim's output loads. onnxsim's own correctness check passes because it runs
+with concrete test shapes. This is a separate, pre-existing issue for
+dynamic-shape detection models and is **not** addressed here.

--- a/bench/RESULTS_onnxslim_comparison.md
+++ b/bench/RESULTS_onnxslim_comparison.md
@@ -99,19 +99,28 @@ to onnxslim is a **different, fusion-level** gap, not a folding one:
 | Gather/Slice/… | — | — | +20 | dynamic-shape plumbing |
 
 * **~106 nodes — decomposed BatchNorm (`Conv → Mul → Add`).** onnxsim's output
-  contains **53** `Conv → Mul(scale) → Add(bias)` chains where `scale`/`bias` are
+  contained **53** `Conv → Mul(scale) → Add(bias)` chains where `scale`/`bias` are
   per-channel `(1, C, 1, 1)` constants (a BatchNorm exported as an affine pair);
   onnxslim has **0** — it folds the scale into the Conv weights and the bias into
   the Conv bias. onnxoptimizer has `fuse_bn_into_conv` (for an actual
-  `BatchNormalization` node) and `fuse_add_bias_into_conv`, but no pass that
+  `BatchNormalization` node) and `fuse_add_bias_into_conv`, but had no pass that
   folds a per-channel `Mul` sitting between a `Conv` and its bias `Add`, so
-  neither the `Mul` nor the now-not-adjacent `Add` fuses. Closing this would be
-  an **onnxoptimizer** change (a `fuse_mul_into_conv`-style pass), not an onnxsim
-  one.
-* **~90 nodes — dynamic-shape plumbing.** The rest is `Gather`-from-`Shape` →
-  `Unsqueeze` → `Concat` shape arithmetic for the dynamic `height`/`width`
-  input. These depend on the runtime shape and so cannot be constant-folded;
-  onnxslim collapses more of them with dedicated shape-graph simplifications.
+  neither the `Mul` nor the now-not-adjacent `Add` fused.
+
+  This is now fixed by a **`fuse_mul_into_conv`** pass added to onnx-optimizer
+  (the `onnxsim/optimizer` companion repo). Once the `fuse_mul_into_conv` folds
+  the scale into the weights, the existing `fuse_add_bias_into_conv` absorbs the
+  bias, collapsing the whole affine tail. With that pass, FasterRCNN-10 drops
+  from **2824 → 2718** nodes (all 53 chains fused: `Mul` 119 → 66, `Add` 127 →
+  74), numerically identical to the original. It takes effect in onnxsim once the
+  bundled `third_party/onnx-optimizer` submodule is updated to include the pass.
+* **~90 nodes — dynamic-shape plumbing (kept on purpose).** The rest is
+  `Gather`-from-`Shape` → `Unsqueeze` → `Concat` shape arithmetic that carries
+  the input's `dim_param`s (`height`, `width`, and the data-dependent `nbox`).
+  These depend on the runtime shape and so **must not** be constant-folded —
+  folding them would hard-code one resolution. onnxsim correctly keeps them;
+  onnxslim collapses a few more with dedicated symbolic shape-graph rewrites, but
+  the remaining difference here is dynamic-shape bookkeeping, not dead weight.
 
 ## Verification
 

--- a/bench/onnxslim_comparison.py
+++ b/bench/onnxslim_comparison.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Compare onnxsim against onnxslim on public models and print node-count deltas.
+
+Usage:
+    python bench/onnxslim_comparison.py swin_s_Opset18 FasterRCNN-10
+
+Each argument is a model name from the Hugging Face ``onnxmodelzoo`` org
+(``onnxmodelzoo/<name>`` containing ``<name>.onnx``) or a path to a local
+``.onnx`` file. For every model the script runs both simplifiers, prints the
+total node count before/after and the per-op-type differences, and (best effort)
+reports whether each simplified model loads in onnxruntime.
+
+Dependencies: ``onnxsim``, ``onnxslim``, ``onnx``, ``onnxruntime`` and
+``huggingface_hub`` (only when fetching from the model zoo).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from collections import Counter
+
+import onnx
+
+
+def _resolve(name: str) -> str:
+    if os.path.exists(name):
+        return name
+    if os.path.exists(f"{name}.onnx"):
+        return f"{name}.onnx"
+    from huggingface_hub import hf_hub_download
+
+    return hf_hub_download(repo_id=f"onnxmodelzoo/{name}", filename=f"{name}.onnx")
+
+
+def _counts(model: onnx.ModelProto) -> Counter:
+    return Counter(n.op_type for n in model.graph.node)
+
+
+def _run_onnxsim(path: str):
+    import onnxsim
+
+    t = time.time()
+    sim, ok = onnxsim.simplify(onnx.load(path))
+    return sim, ok, time.time() - t
+
+
+def _run_onnxslim(path: str):
+    import onnxslim
+
+    t = time.time()
+    sim = onnxslim.slim(path)
+    return sim, True, time.time() - t
+
+
+def _loads(model: onnx.ModelProto) -> str:
+    try:
+        import onnxruntime as ort
+
+        so = ort.SessionOptions()
+        so.log_severity_level = 3
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as f:
+            onnx.save(model, f.name)
+            ort.InferenceSession(f.name, so, providers=["CPUExecutionProvider"])
+        return "loads"
+    except Exception as e:  # noqa: BLE001
+        return f"load-fail: {str(e)[:60]}"
+
+
+def compare(name: str) -> None:
+    path = _resolve(name)
+    orig = onnx.load(path)
+    oc = _counts(orig)
+    print(f"\n===== {name} ({len(orig.graph.node)} nodes) =====")
+    results = {}
+    for tool, runner in (("onnxsim", _run_onnxsim), ("onnxslim", _run_onnxslim)):
+        try:
+            sim, ok, dt = runner(path)
+        except Exception as e:  # noqa: BLE001
+            print(f"[{tool}] FAILED: {type(e).__name__}: {str(e)[:80]}")
+            continue
+        results[tool] = _counts(sim)
+        print(
+            f"[{tool}] {len(orig.graph.node)} -> {len(sim.graph.node)} nodes "
+            f"(ok={ok}, {dt:.0f}s, {_loads(sim)})"
+        )
+    if "onnxsim" in results and "onnxslim" in results:
+        sim_c, slim_c = results["onnxsim"], results["onnxslim"]
+        keys = set(oc) | set(sim_c) | set(slim_c)
+        rows = [
+            (k, oc.get(k, 0), sim_c.get(k, 0), slim_c.get(k, 0))
+            for k in keys
+            if sim_c.get(k, 0) != slim_c.get(k, 0)
+        ]
+        if rows:
+            print(f"  {'op':18s} {'orig':>6s} {'onnxsim':>8s} {'onnxslim':>9s}")
+            for k, o, a, b in sorted(rows, key=lambda r: -(abs(r[2] - r[3]))):
+                print(f"  {k:18s} {o:6d} {a:8d} {b:9d}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("models", nargs="+", help="model name(s) or path(s)")
+    args = ap.parse_args()
+    for name in args.models:
+        compare(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -64,12 +64,8 @@ bool IsOfficialOp(const std::string& domain, const std::string& op) {
 
 bool IsDeterministic(const std::string& domain, const std::string& op,
                      int opset_version) {
-  // Query the determinism attribute of the operator schema instead of
-  // maintaining a hardcoded list of non-deterministic ops. See
-  // https://github.com/onnx/onnx/pull/7176.
-  //
-  // The ONNX operator schema registry stores the default ONNX domain as an
-  // empty string.
+  // Whether a node may be constant-folded (given constant inputs). The ONNX
+  // operator schema registry stores the default ONNX domain as an empty string.
   const std::string& lookup_domain = domain == "ai.onnx" ? "" : domain;
   const auto* schema =
       onnx::OpSchemaRegistry::Schema(op, opset_version, lookup_domain);
@@ -77,11 +73,45 @@ bool IsDeterministic(const std::string& domain, const std::string& op,
     // Unknown op. Assume it is not deterministic.
     return false;
   }
-  // Only fold ops that are known to be deterministic. Ops whose determinism
-  // cannot be statically determined (e.g. context-dependent functions) are
-  // treated as non-deterministic to be safe.
-  return schema->GetNodeDeterminism() ==
-         onnx::OpSchema::NodeDeterminism::Deterministic;
+  // Fold every default-domain op except those that are genuinely
+  // non-deterministic (the random/stateful generators below).
+  //
+  // We deliberately do NOT trust ``schema->GetNodeDeterminism()`` here. That
+  // attribute has three states (``Deterministic``/``NonDeterministic``/
+  // ``Unknown``) and, for the purpose of constant folding, mislabels many
+  // perfectly foldable ops:
+  //
+  //   * Ops ONNX defines through a *function body* inherit their determinism
+  //     from the constituent ops of that body, and any constituent that carries
+  //     a subgraph (``Loop``/``If``/``Scan``) is reported ``NonDeterministic``
+  //     purely because it has a subgraph -- not because it is random. ``Range``,
+  //     for instance, is a function whose body contains a ``Loop`` (opset < 27)
+  //     or a context-dependent function (opset >= 27), so it resolves to
+  //     ``NonDeterministic`` / ``Unknown`` even though its output is a pure
+  //     function of its constant inputs.
+  //   * A single such op left unfolded poisons an entire otherwise-constant
+  //     subgraph: in Swin-style models the static attention-mask construction
+  //     ``Range -> Slice -> Reshape -> Expand -> Unsqueeze -> Concat`` (and the
+  //     ``ScatterND`` chains beside it) all depend on ``Range``, so hundreds of
+  //     constant nodes survive that onnxslim and other simplifiers fold away.
+  //
+  // Instead we keep an explicit denylist of the ops that actually produce
+  // different values on different runs. It mirrors the set ONNX itself annotates
+  // with ``SetNodeDeterminism(NonDeterministic)`` on the operator's own schema
+  // (as opposed to the value it *infers* for function bodies), so it stays in
+  // step with the standard while side-stepping the function-body inference. The
+  // subgraph carriers (``If``/``Loop``/``Scan``/``SequenceMap``) are already
+  // excluded by the ``!HasSubgraph`` guard at the call site.
+  if (lookup_domain.empty()) {
+    static const std::set<std::string> non_deterministic_ops = {
+        "RandomNormal",     "RandomNormalLike", "RandomUniform",
+        "RandomUniformLike", "Multinomial",     "Bernoulli",
+        "Dropout",          "SequenceMap"};
+    return non_deterministic_ops.find(op) == non_deterministic_ops.end();
+  }
+  // For non-default domains (e.g. onnx-ml) there is no random-op concern for the
+  // ops onnxsim folds, so treat schema-backed ops as deterministic.
+  return true;
 }
 
 bool IsQDQ(const std::string& domain, const std::string& op) {

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <fstream>
 #include <functional>
+#include <mutex>
 #include <numeric>
 #include <set>
 #include <string>
@@ -62,10 +63,59 @@ bool IsOfficialOp(const std::string& domain, const std::string& op) {
   return experimental_ops.find(op) == experimental_ops.end();
 }
 
+// Correct the determinism metadata of operators ONNX mis-annotates, so the
+// ordinary ``IsDeterministic`` check below can fold them.
+//
+// ``OpSchema::GetNodeDeterminism`` infers a *function* op's determinism from
+// the ops in its function body, and reports ``NonDeterministic`` for a body
+// that contains a subgraph-carrying op (``Loop``/``If``/``Scan``) and
+// ``Unknown`` for a context-dependent function -- neither of which means the op
+// is actually random. ``Range`` is the canonical victim: its body is a ``Loop``
+// (opset < 27) or a context-dependent function (opset >= 27), so it is reported
+// non-deterministic even though its output is a pure function of its inputs. It
+// is then never constant-folded, which in turn strands whole static subgraphs
+// built on top of it -- e.g. the ``Range -> Slice -> Reshape -> Expand ->
+// Unsqueeze -> Concat`` attention-mask construction (and the neighbouring
+// ``ScatterND`` chains) in Swin-style models, leaving hundreds of constant
+// nodes that other simplifiers fold away.
+//
+// Rather than second-guess the determinism query in ``IsDeterministic``, fix
+// the source data: mark these genuinely-deterministic ops ``Deterministic`` on
+// their registered schemas (every version in the registry's history). The
+// registry returns pointers into its own storage, so this updates the metadata
+// in place.
+void FixupSchemaDeterminism() {
+  static std::once_flag once;
+  std::call_once(once, [] {
+    // Deterministic default-domain ops whose schema determinism ONNX infers
+    // (incorrectly, for folding purposes) from a function body.
+    static const std::set<std::string> deterministic_ops = {"Range"};
+    for (const auto& schema :
+         onnx::OpSchemaRegistry::get_all_schemas_with_history()) {
+      if (!schema.domain().empty() || !deterministic_ops.count(schema.Name())) {
+        continue;
+      }
+      const onnx::OpSchema* registered = onnx::OpSchemaRegistry::Schema(
+          schema.Name(), schema.since_version(), schema.domain());
+      if (registered != nullptr) {
+        const_cast<onnx::OpSchema*>(registered)
+            ->SetNodeDeterminism(
+                onnx::OpSchema::NodeDeterminism::Deterministic);
+      }
+    }
+  });
+}
+
 bool IsDeterministic(const std::string& domain, const std::string& op,
                      int opset_version) {
-  // Whether a node may be constant-folded (given constant inputs). The ONNX
-  // operator schema registry stores the default ONNX domain as an empty string.
+  // Query the determinism attribute of the operator schema instead of
+  // maintaining a hardcoded list of non-deterministic ops. See
+  // https://github.com/onnx/onnx/pull/7176. Operators ONNX mis-annotates for
+  // constant-folding purposes (e.g. ``Range``) have their metadata corrected by
+  // FixupSchemaDeterminism(), which Simplify() runs before folding.
+  //
+  // The ONNX operator schema registry stores the default ONNX domain as an
+  // empty string.
   const std::string& lookup_domain = domain == "ai.onnx" ? "" : domain;
   const auto* schema =
       onnx::OpSchemaRegistry::Schema(op, opset_version, lookup_domain);
@@ -73,45 +123,11 @@ bool IsDeterministic(const std::string& domain, const std::string& op,
     // Unknown op. Assume it is not deterministic.
     return false;
   }
-  // Fold every default-domain op except those that are genuinely
-  // non-deterministic (the random/stateful generators below).
-  //
-  // We deliberately do NOT trust ``schema->GetNodeDeterminism()`` here. That
-  // attribute has three states (``Deterministic``/``NonDeterministic``/
-  // ``Unknown``) and, for the purpose of constant folding, mislabels many
-  // perfectly foldable ops:
-  //
-  //   * Ops ONNX defines through a *function body* inherit their determinism
-  //     from the constituent ops of that body, and any constituent that carries
-  //     a subgraph (``Loop``/``If``/``Scan``) is reported ``NonDeterministic``
-  //     purely because it has a subgraph -- not because it is random.
-  //     ``Range``, for instance, is a function whose body contains a ``Loop``
-  //     (opset < 27) or a context-dependent function (opset >= 27), so it
-  //     resolves to ``NonDeterministic`` / ``Unknown`` even though its output
-  //     is a pure function of its constant inputs.
-  //   * A single such op left unfolded poisons an entire otherwise-constant
-  //     subgraph: in Swin-style models the static attention-mask construction
-  //     ``Range -> Slice -> Reshape -> Expand -> Unsqueeze -> Concat`` (and the
-  //     ``ScatterND`` chains beside it) all depend on ``Range``, so hundreds of
-  //     constant nodes survive that onnxslim and other simplifiers fold away.
-  //
-  // Instead we keep an explicit denylist of the ops that actually produce
-  // different values on different runs. It mirrors the set ONNX itself
-  // annotates with ``SetNodeDeterminism(NonDeterministic)`` on the operator's
-  // own schema (as opposed to the value it *infers* for function bodies), so it
-  // stays in step with the standard while side-stepping the function-body
-  // inference. The subgraph carriers (``If``/``Loop``/``Scan``/``SequenceMap``)
-  // are already excluded by the ``!HasSubgraph`` guard at the call site.
-  if (lookup_domain.empty()) {
-    static const std::set<std::string> non_deterministic_ops = {
-        "RandomNormal",      "RandomNormalLike", "RandomUniform",
-        "RandomUniformLike", "Multinomial",      "Bernoulli",
-        "Dropout",           "SequenceMap"};
-    return non_deterministic_ops.find(op) == non_deterministic_ops.end();
-  }
-  // For non-default domains (e.g. onnx-ml) there is no random-op concern for
-  // the ops onnxsim folds, so treat schema-backed ops as deterministic.
-  return true;
+  // Only fold ops that are known to be deterministic. Ops whose determinism
+  // cannot be statically determined (e.g. context-dependent functions) are
+  // treated as non-deterministic to be safe.
+  return schema->GetNodeDeterminism() ==
+         onnx::OpSchema::NodeDeterminism::Deterministic;
 }
 
 bool IsQDQ(const std::string& domain, const std::string& op) {
@@ -1630,6 +1646,9 @@ onnx::ModelProto Simplify(
   // Make shape inference aware of ONNX Runtime's quantized contrib operators
   // (QLinearAdd and friends) so shape deduction does not stop at them.
   onnxsim::RegisterContribOpSchemas();
+  // Correct the determinism metadata of ops ONNX mis-annotates (e.g. Range) so
+  // constant folding does not skip them.
+  FixupSchemaDeterminism();
   // Register permissive placeholder schemas for custom ops exported into the
   // default ONNX domain (e.g. TensorRT plugins such as BatchedNMS_TRT) so the
   // checker below does not reject the model (GitHub issues #107, #220).

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -84,11 +84,11 @@ bool IsDeterministic(const std::string& domain, const std::string& op,
   //   * Ops ONNX defines through a *function body* inherit their determinism
   //     from the constituent ops of that body, and any constituent that carries
   //     a subgraph (``Loop``/``If``/``Scan``) is reported ``NonDeterministic``
-  //     purely because it has a subgraph -- not because it is random. ``Range``,
-  //     for instance, is a function whose body contains a ``Loop`` (opset < 27)
-  //     or a context-dependent function (opset >= 27), so it resolves to
-  //     ``NonDeterministic`` / ``Unknown`` even though its output is a pure
-  //     function of its constant inputs.
+  //     purely because it has a subgraph -- not because it is random.
+  //     ``Range``, for instance, is a function whose body contains a ``Loop``
+  //     (opset < 27) or a context-dependent function (opset >= 27), so it
+  //     resolves to ``NonDeterministic`` / ``Unknown`` even though its output
+  //     is a pure function of its constant inputs.
   //   * A single such op left unfolded poisons an entire otherwise-constant
   //     subgraph: in Swin-style models the static attention-mask construction
   //     ``Range -> Slice -> Reshape -> Expand -> Unsqueeze -> Concat`` (and the
@@ -96,21 +96,21 @@ bool IsDeterministic(const std::string& domain, const std::string& op,
   //     constant nodes survive that onnxslim and other simplifiers fold away.
   //
   // Instead we keep an explicit denylist of the ops that actually produce
-  // different values on different runs. It mirrors the set ONNX itself annotates
-  // with ``SetNodeDeterminism(NonDeterministic)`` on the operator's own schema
-  // (as opposed to the value it *infers* for function bodies), so it stays in
-  // step with the standard while side-stepping the function-body inference. The
-  // subgraph carriers (``If``/``Loop``/``Scan``/``SequenceMap``) are already
-  // excluded by the ``!HasSubgraph`` guard at the call site.
+  // different values on different runs. It mirrors the set ONNX itself
+  // annotates with ``SetNodeDeterminism(NonDeterministic)`` on the operator's
+  // own schema (as opposed to the value it *infers* for function bodies), so it
+  // stays in step with the standard while side-stepping the function-body
+  // inference. The subgraph carriers (``If``/``Loop``/``Scan``/``SequenceMap``)
+  // are already excluded by the ``!HasSubgraph`` guard at the call site.
   if (lookup_domain.empty()) {
     static const std::set<std::string> non_deterministic_ops = {
-        "RandomNormal",     "RandomNormalLike", "RandomUniform",
-        "RandomUniformLike", "Multinomial",     "Bernoulli",
-        "Dropout",          "SequenceMap"};
+        "RandomNormal",      "RandomNormalLike", "RandomUniform",
+        "RandomUniformLike", "Multinomial",      "Bernoulli",
+        "Dropout",           "SequenceMap"};
     return non_deterministic_ops.find(op) == non_deterministic_ops.end();
   }
-  // For non-default domains (e.g. onnx-ml) there is no random-op concern for the
-  // ops onnxsim folds, so treat schema-backed ops as deterministic.
+  // For non-default domains (e.g. onnx-ml) there is no random-op concern for
+  // the ops onnxsim folds, so treat schema-backed ops as deterministic.
   return true;
 }
 

--- a/tests/test_constant_fold_determinism.py
+++ b/tests/test_constant_fold_determinism.py
@@ -73,9 +73,7 @@ def test_range_rooted_subgraph_is_fully_folded():
     assert ok
     assert len(sim.graph.node) == 0, _op_types(sim)
     # The baked value is correct.
-    (folded,) = [
-        t for t in sim.graph.initializer if t.name == "out"
-    ]
+    (folded,) = [t for t in sim.graph.initializer if t.name == "out"]
     np.testing.assert_array_equal(
         onnx.numpy_helper.to_array(folded),
         np.arange(0, 6) + np.array([10, 20, 30, 40, 50, 60]),

--- a/tests/test_constant_fold_determinism.py
+++ b/tests/test_constant_fold_determinism.py
@@ -1,0 +1,97 @@
+"""Constant folding of deterministic ops that ONNX defines via function bodies.
+
+Regression tests for the folding-eligibility rule in ``IsDeterministic``
+(onnxsim/onnxsim.cpp). Ops such as ``Range`` are perfectly deterministic but
+ONNX describes them through a function body that contains a subgraph-carrying op
+(``Loop``) or a context-dependent function, so the schema's inferred determinism
+is ``NonDeterministic``/``Unknown``. onnxsim must still fold them when their
+inputs are constant; otherwise a single unfolded ``Range`` poisons whole static
+subgraphs (e.g. the attention-mask construction in Swin-style models). At the
+same time, genuinely non-deterministic ops (the random generators) must never be
+folded.
+
+These tests use only the ``onnx`` Python API, so they run without torch.
+"""
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper
+
+import onnxsim
+
+
+def _make_model(nodes, outputs, initializers, inputs=None, opset=18):
+    graph = helper.make_graph(nodes, "g", inputs or [], outputs, initializers)
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", opset)])
+    model.ir_version = 8
+    return model
+
+
+def _op_types(model):
+    return [n.op_type for n in model.graph.node]
+
+
+def test_range_on_constants_is_folded():
+    # Range is a deterministic op that ONNX defines through a function body
+    # (a Loop for opset < 27, a context-dependent function for opset >= 27), so
+    # its schema determinism is not reported as ``Deterministic``. With constant
+    # inputs it must still fold away.
+    inits = [
+        helper.make_tensor("start", TensorProto.INT64, [], [0]),
+        helper.make_tensor("limit", TensorProto.INT64, [], [8]),
+        helper.make_tensor("delta", TensorProto.INT64, [], [1]),
+    ]
+    nodes = [helper.make_node("Range", ["start", "limit", "delta"], ["out"])]
+    outputs = [helper.make_tensor_value_info("out", TensorProto.INT64, [8])]
+    model = _make_model(nodes, outputs, inits)
+
+    sim, ok = onnxsim.simplify(model)
+
+    assert ok
+    assert "Range" not in _op_types(sim), _op_types(sim)
+
+
+def test_range_rooted_subgraph_is_fully_folded():
+    # Range -> Add(range, bias): the whole chain is constant and should collapse
+    # to a single initializer. Before the fix the unfoldable Range left both
+    # nodes in the graph.
+    inits = [
+        helper.make_tensor("start", TensorProto.INT64, [], [0]),
+        helper.make_tensor("limit", TensorProto.INT64, [], [6]),
+        helper.make_tensor("delta", TensorProto.INT64, [], [1]),
+        helper.make_tensor("bias", TensorProto.INT64, [6], [10, 20, 30, 40, 50, 60]),
+    ]
+    nodes = [
+        helper.make_node("Range", ["start", "limit", "delta"], ["r"]),
+        helper.make_node("Add", ["r", "bias"], ["out"]),
+    ]
+    outputs = [helper.make_tensor_value_info("out", TensorProto.INT64, [6])]
+    model = _make_model(nodes, outputs, inits)
+
+    sim, ok = onnxsim.simplify(model)
+
+    assert ok
+    assert len(sim.graph.node) == 0, _op_types(sim)
+    # The baked value is correct.
+    (folded,) = [
+        t for t in sim.graph.initializer if t.name == "out"
+    ]
+    np.testing.assert_array_equal(
+        onnx.numpy_helper.to_array(folded),
+        np.arange(0, 6) + np.array([10, 20, 30, 40, 50, 60]),
+    )
+
+
+def test_random_ops_are_not_folded():
+    # Genuinely non-deterministic generators must be preserved even though all
+    # their (attribute) inputs are "constant".
+    for op, extra in [
+        ("RandomUniform", {"shape": [4]}),
+        ("RandomNormal", {"shape": [4]}),
+    ]:
+        nodes = [helper.make_node(op, [], ["out"], **extra)]
+        outputs = [helper.make_tensor_value_info("out", TensorProto.FLOAT, [4])]
+        model = _make_model(nodes, outputs, [])
+        sim, ok = onnxsim.simplify(model)
+        assert ok
+        assert op in _op_types(sim), (op, _op_types(sim))


### PR DESCRIPTION
## Summary

Two constant-folding / fusion gaps surfaced by comparing onnxsim with onnxslim on `swin_s_Opset18` and `FasterRCNN-10` (from Hugging Face `onnxmodelzoo`), plus the reproducible comparison itself:

| Model | orig | onnxsim before | **onnxsim after** | onnxslim |
|---|---:|---:|---:|---:|
| `swin_s_Opset18` | 12830 | 1295 | **1082** | 1058 |
| `FasterRCNN-10`  | 6370  | 2824 | **2718** | 2622 |

Both results are numerically equivalent to the originals.

## 1. Fold deterministic ops that ONNX defines via a function body (`Range`)

onnxsim's constant folder only folds an op when all inputs are constant **and** the op is deterministic, and determinism was read from `schema->GetNodeDeterminism() == Deterministic`. That mislabels a whole class of foldable ops: ONNX describes some ops through a **function body**, and `GetNodeDeterminism()` infers a function op's determinism from its constituents — reporting `NonDeterministic`/`Unknown` for any body that carries a subgraph (`Loop`/`If`/`Scan`) or is a context-dependent function. `Range` is the canonical victim (a `Loop` body for opset < 27, a context-dependent function for opset ≥ 27), so it never folded — and since folding propagates constness, a single unfoldable `Range` stranded whole static subgraphs (the `Range → Slice → Reshape → Expand → Unsqueeze → Concat` attention-mask construction, and neighbouring `ScatterND` chains, in Swin-style models).

**Fix** (`onnxsim/onnxsim.cpp`): keep the ordinary `GetNodeDeterminism() == Deterministic` check, but first correct the mis-annotated metadata. A new `FixupSchemaDeterminism()` marks the affected ops (currently `Range`) as `Deterministic` on their registered schemas — every version in the registry's history — and `Simplify()` runs it once before folding. This is narrower than a denylist: only the demonstrably-mislabelled op changes behaviour, and the genuinely non-deterministic generators (`RandomNormal`, `RandomUniform`, `Multinomial`, `Bernoulli`, `Dropout`, …) keep their explicit `NonDeterministic` annotation and are still never folded.

Effect: `swin_s_Opset18` **1295 → 1082** nodes (−16 %), numerically identical to the original (max abs diff `0.0`); `Range`/`Unsqueeze`/`Expand`/`Where`/`ScatterND` all fold to `0`.

## 2. Fold a `Conv → Mul → Add` affine tail into the Conv (onnx-optimizer bump)

`FasterRCNN-10` (opset 10, no `Range`) carried **53** `Conv → Mul(scale) → Add(bias)` chains — a BatchNorm exported as a per-channel affine pair — that onnxslim folds into the Conv but onnxsim did not. A new **`fuse_mul_into_conv`** pass in the companion `onnx-optimizer` repo folds a per-channel (or scalar) constant `Mul` after a `Conv` into the weights (`Conv(X, W) * S → Conv(X, W*S)`); the existing `fuse_add_bias_into_conv` then absorbs the trailing bias `Add`. This PR **bumps the vendored `third_party/onnx-optimizer`** to include that pass (rebased onto the maintainer's latest optimizer commit, so it coexists with the newly added `fuse_consecutive_mul` / batched `MatMul+Add→Gemm` passes).

Effect: `FasterRCNN-10` **2824 → 2718** nodes (all 53 chains fused, `Mul` 119 → 66, `Add` 127 → 74), numerically equivalent. The remaining gap to onnxslim is dynamic-shape plumbing carrying the input's `dim_param`s (`height`/`width`/`nbox`), which must stay symbolic and is correctly left untouched.

## Changes

- `onnxsim/onnxsim.cpp` — `FixupSchemaDeterminism()` + the reverted-to-strict `IsDeterministic`.
- `tests/test_constant_fold_determinism.py` — torch-free tests: `Range` folds, constant `Range`-rooted subgraphs collapse, random ops preserved.
- `bench/onnxslim_comparison.py`, `bench/RESULTS_onnxslim_comparison.md` — reproducible onnxsim-vs-onnxslim comparison and the analysis above.
- `third_party/onnx-optimizer` — submodule bump to include `fuse_mul_into_conv`.

## Verification

- swin_s: original vs simplified, random input, onnxruntime with all graph optimizations disabled → **max abs diff 0.0**.
- FasterRCNN-10: `simplify(..)` returns `check_ok=True`; the `fuse_mul_into_conv` pass is unit-tested against onnxruntime (per-channel `[1,C,1,1]`/`[C,1,1]` and scalar scales, with/without bias; a per-pixel scale is correctly not fused).
- Existing `tests/test_simple.py` suite and the optimizer conv-fusion tests pass.

## Note for merging

`third_party/onnx-optimizer` currently pins a commit on the optimizer's companion feature branch (`fuse_mul_into_conv` rebased onto the latest optimizer `master`). For a clean landing, merge the optimizer-side change first, then re-pin this submodule to that merged SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)