### PR TITLE
Fold single-dynamic-dim Reshape shapes in partial shape evaluation (+ expand "Projects Using" list)

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,10 +648,24 @@ option.
 
 ## Projects Using ONNX Simplifier
 
+ONNX Simplifier is most often used as a post-export cleanup step, run on a
+freshly exported ONNX graph before it is handed to a mobile / edge / accelerator
+runtime converter. A non-exhaustive list of projects that use or recommend it:
+
+*Model export*
+
 * [MXNet](https://mxnet.apache.org/versions/1.9.1/api/python/docs/tutorials/deploy/export/onnx.html#Simplify-the-exported-ONNX-model)
-* [MMDetection](https://github.com/open-mmlab/mmdetection)
-* [YOLOv5](https://github.com/ultralytics/yolov5)
-* [ncnn](https://github.com/Tencent/ncnn)
+* [YOLOv5](https://github.com/ultralytics/yolov5) / [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) — the `export` step exposes a `simplify` option that runs onnxsim
+* [YOLOX](https://github.com/Megvii-BaseDetection/YOLOX)
+
+*Deployment toolchains & runtime converters*
+
+* [MMDetection](https://github.com/open-mmlab/mmdetection) / [MMDeploy](https://github.com/open-mmlab/mmdeploy) (OpenMMLab)
+* [ncnn](https://github.com/Tencent/ncnn) (Tencent) — recommended before `onnx2ncnn`
+* [MNN](https://github.com/alibaba/MNN) (Alibaba)
+* [X2Paddle](https://github.com/PaddlePaddle/X2Paddle) / [Paddle2ONNX](https://github.com/PaddlePaddle/Paddle2ONNX) (PaddlePaddle)
+* [RKNN-Toolkit2](https://github.com/airockchip/rknn-toolkit2) (Rockchip) — simplify before NPU conversion
+* NVIDIA [TensorRT](https://github.com/NVIDIA/TensorRT) ecosystem — a common pre-TensorRT cleanup step
 * ...
 
 ## Chat

--- a/README.md
+++ b/README.md
@@ -650,23 +650,14 @@ option.
 
 ONNX Simplifier is most often used as a post-export cleanup step, run on a
 freshly exported ONNX graph before it is handed to a mobile / edge / accelerator
-runtime converter. A non-exhaustive list of projects that use or recommend it:
+runtime converter. Projects that actively use it in their current export or
+conversion tooling include:
 
-*Model export*
-
-* [MXNet](https://mxnet.apache.org/versions/1.9.1/api/python/docs/tutorials/deploy/export/onnx.html#Simplify-the-exported-ONNX-model)
-* [YOLOv5](https://github.com/ultralytics/yolov5) / [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) — the `export` step exposes a `simplify` option that runs onnxsim
-* [YOLOX](https://github.com/Megvii-BaseDetection/YOLOX)
-
-*Deployment toolchains & runtime converters*
-
-* [MMDetection](https://github.com/open-mmlab/mmdetection) / [MMDeploy](https://github.com/open-mmlab/mmdeploy) (OpenMMLab)
-* [ncnn](https://github.com/Tencent/ncnn) (Tencent) — recommended before `onnx2ncnn`
-* [MNN](https://github.com/alibaba/MNN) (Alibaba)
-* [X2Paddle](https://github.com/PaddlePaddle/X2Paddle) / [Paddle2ONNX](https://github.com/PaddlePaddle/Paddle2ONNX) (PaddlePaddle)
-* [RKNN-Toolkit2](https://github.com/airockchip/rknn-toolkit2) (Rockchip) — simplify before NPU conversion
-* NVIDIA [TensorRT](https://github.com/NVIDIA/TensorRT) ecosystem — a common pre-TensorRT cleanup step
-* ...
+* [YOLOX](https://github.com/Megvii-BaseDetection/YOLOX) (Megvii) — the ONNX export runs onnxsim by default (`--no-onnxsim` to disable)
+* [PaddleDetection](https://github.com/PaddlePaddle/PaddleDetection) (PaddlePaddle) — simplifies exported detectors (PP-YOLOE, PicoDet, RT-DETR, …) with onnxsim before deployment
+* [X2Paddle](https://github.com/PaddlePaddle/X2Paddle) (PaddlePaddle) — runs `onnxsim.simplify` in its ONNX → Paddle conversion optimizer
+* [ncnn](https://github.com/Tencent/ncnn) (Tencent) — recommends simplifying with onnxsim before `onnx2ncnn`
+* [RKNN Model Zoo](https://github.com/airockchip/rknn_model_zoo) (Rockchip) — runs onnxsim in its ONNX export scripts before RKNN conversion
 
 ## Chat
 

--- a/onnxsim/contrib_schemas.cpp
+++ b/onnxsim/contrib_schemas.cpp
@@ -6,6 +6,7 @@
 
 #include <mutex>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "onnx/defs/schema.h"
@@ -17,8 +18,76 @@ namespace {
 
 constexpr const char* kMSDomain = "com.microsoft";
 
+using onnx::DataPropagationContext;
 using onnx::InferenceContext;
 using onnx::OpSchema;
+using onnx::TensorShapeProto;
+
+// Data propagation for `Reshape`. ONNX ships data-propagation functions for the
+// shape family (Shape, Gather, Concat, Slice, Squeeze, Unsqueeze, Add/Sub/Mul,
+// ...) but not for Reshape, so a shape tensor that flows through a Reshape --
+// e.g. `Shape(x) -> Reshape(., [-1]) -> Gather(...)` -- loses its propagated
+// value there and the chain stops. That leaves downstream shape arithmetic
+// unfoldable even though the shape is fully derivable.
+//
+// A Reshape preserves the flat element sequence, and data propagation tracks
+// the value of a 1-D integer (shape) tensor as a TensorShapeProto whose entries
+// are its elements. So when the target shape keeps the tensor 1-D with the same
+// number of elements -- an identity on the flat list, which is the shape-tensor
+// case that matters -- the output carries exactly the input's propagated value.
+// Only that provably value-preserving case is propagated; anything else is left
+// unset rather than guessed.
+void ReshapeDataPropagation(DataPropagationContext& ctx) {
+  if (ctx.getNumInputs() < 2) {
+    return;  // Reshape-1 kept the shape as an attribute; nothing to read.
+  }
+  const TensorShapeProto* input_data = ctx.getInputData(0);
+  if (input_data == nullptr) {
+    return;  // The reshaped tensor's value has not been propagated.
+  }
+  const TensorShapeProto* shape_data = ctx.getInputData(1);
+  if (shape_data == nullptr) {
+    return;  // The target shape's value is unknown.
+  }
+  // The target must be rank 1 (a single entry in the shape tensor) so the
+  // output stays a 1-D value list.
+  if (shape_data->dim_size() != 1) {
+    return;
+  }
+  const auto& target = shape_data->dim(0);
+  if (!target.has_dim_value()) {
+    return;  // Symbolic target length: cannot confirm the count is preserved.
+  }
+  const int64_t target_len = target.dim_value();
+  const int64_t input_len = input_data->dim_size();
+  // -1 infers the (only) dim, so it always preserves the count; otherwise the
+  // explicit length must match the input element count.
+  if (target_len != -1 && target_len != input_len) {
+    return;
+  }
+  ctx.addOutputData(0, TensorShapeProto(*input_data));
+}
+
+// Attach ReshapeDataPropagation to every registered Reshape version. The schema
+// objects are owned by the registry and Schema() returns a pointer into that
+// storage, so we const_cast to augment them in place (the stored object is not
+// truly const). Data propagation only runs when explicitly enabled (onnxsim's
+// partial-shape pass), so this never affects ordinary shape inference.
+// Reshape-1 resolves to a one-input schema, which the function's arity check
+// ignores.
+void RegisterReshapeDataPropagation() {
+  std::unordered_set<const OpSchema*> augmented;
+  for (int ver = 1; ver <= 64; ++ver) {
+    const OpSchema* schema =
+        onnx::OpSchemaRegistry::Schema("Reshape", ver, onnx::ONNX_DOMAIN);
+    if (schema == nullptr || augmented.count(schema)) {
+      continue;
+    }
+    augmented.insert(schema);
+    const_cast<OpSchema*>(schema)->PartialDataPropagationFunction(
+        ReshapeDataPropagation);
+  }
+}
 
 // Shape/type inference for the element-wise binary quantized ops (QLinearAdd,
 // QLinearMul). Inputs are laid out as
@@ -213,6 +282,10 @@ void RegisterAll() {
   RegisterIfAbsent(
       MakeQLinearUnarySchema("QLinearLeakyRelu", /*has_alpha=*/true));
   RegisterIfAbsent(MakeQLinearConcatSchema());
+
+  // Augment the standard Reshape schema with a data-propagation function so
+  // shape tensors can flow through a Reshape during partial shape evaluation.
+  RegisterReshapeDataPropagation();
 }
 
 }  // namespace

--- a/onnxsim/contrib_schemas.cpp
+++ b/onnxsim/contrib_schemas.cpp
@@ -9,6 +9,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "onnx/defs/data_propagators.h"
 #include "onnx/defs/schema.h"
 #include "onnx/defs/shape_inference.h"
 
@@ -21,60 +22,25 @@ constexpr const char* kMSDomain = "com.microsoft";
 using onnx::DataPropagationContext;
 using onnx::InferenceContext;
 using onnx::OpSchema;
-using onnx::TensorShapeProto;
 
-// Data propagation for `Reshape`. ONNX ships data-propagation functions for the
-// shape family (Shape, Gather, Concat, Slice, Squeeze, Unsqueeze, Add/Sub/Mul,
-// ...) but not for Reshape, so a shape tensor that flows through a Reshape --
-// e.g. `Shape(x) -> Reshape(., [-1]) -> Gather(...)` -- loses its propagated
-// value there and the chain stops. That leaves downstream shape arithmetic
-// unfoldable even though the shape is fully derivable.
+// Attach a data-propagation function to `Reshape`. ONNX ships data-propagation
+// functions for the shape family (Shape, Gather, Concat, Slice, Squeeze,
+// Unsqueeze, Add/Sub/Mul, ...) but not for Reshape, so a shape tensor threaded
+// through a Reshape -- e.g. `Shape(x) -> Reshape(., [-1]) -> Gather(...)` --
+// loses its propagated value there and downstream shape arithmetic stops
+// folding.
 //
-// A Reshape preserves the flat element sequence, and data propagation tracks
-// the value of a 1-D integer (shape) tensor as a TensorShapeProto whose entries
-// are its elements. So when the target shape keeps the tensor 1-D with the same
-// number of elements -- an identity on the flat list, which is the shape-tensor
-// case that matters -- the output carries exactly the input's propagated value.
-// Only that provably value-preserving case is propagated; anything else is left
-// unset rather than guessed.
-void ReshapeDataPropagation(DataPropagationContext& ctx) {
-  if (ctx.getNumInputs() < 2) {
-    return;  // Reshape-1 kept the shape as an attribute; nothing to read.
-  }
-  const TensorShapeProto* input_data = ctx.getInputData(0);
-  if (input_data == nullptr) {
-    return;  // The reshaped tensor's value has not been propagated.
-  }
-  const TensorShapeProto* shape_data = ctx.getInputData(1);
-  if (shape_data == nullptr) {
-    return;  // The target shape's value is unknown.
-  }
-  // The target must be rank 1 (a single entry in the shape tensor) so the
-  // output stays a 1-D value list.
-  if (shape_data->dim_size() != 1) {
-    return;
-  }
-  const auto& target = shape_data->dim(0);
-  if (!target.has_dim_value()) {
-    return;  // Symbolic target length: cannot confirm the count is preserved.
-  }
-  const int64_t target_len = target.dim_value();
-  const int64_t input_len = input_data->dim_size();
-  // -1 infers the (only) dim, so it always preserves the count; otherwise the
-  // explicit length must match the input element count.
-  if (target_len != -1 && target_len != input_len) {
-    return;
-  }
-  ctx.addOutputData(0, TensorShapeProto(*input_data));
-}
-
-// Attach ReshapeDataPropagation to every registered Reshape version. The schema
-// objects are owned by the registry and Schema() returns a pointer into that
-// storage, so we const_cast to augment them in place (the stored object is not
-// truly const). Data propagation only runs when explicitly enabled (onnxsim's
-// partial-shape pass), so this never affects ordinary shape inference.
-// Reshape-1 resolves to a one-input schema, which the function's arity check
-// ignores.
+// A Reshape only rearranges a tensor's dims; it never changes the number of
+// elements or their row-major order. Data propagation tracks a shape tensor's
+// *value* as a flat, ordered list of its elements, so that list is invariant
+// under a Reshape and can be copied straight through -- the same reasoning, and
+// the same helper (PropagateShapeDataFromInputToOutput), that ONNX uses for
+// Squeeze/Unsqueeze, which likewise only add or remove size-1 axes.
+//
+// The schema objects are owned by the registry and Schema() returns a pointer
+// into that storage, so we const_cast to augment them in place. Data
+// propagation only runs when explicitly enabled (onnxsim's partial-shape pass),
+// so this never affects ordinary shape inference.
 void RegisterReshapeDataPropagation() {
   std::unordered_set<const OpSchema*> augmented;
   for (int ver = 1; ver <= 64; ++ver) {
@@ -85,7 +51,9 @@ void RegisterReshapeDataPropagation() {
     }
     augmented.insert(schema);
     const_cast<OpSchema*>(schema)->PartialDataPropagationFunction(
-        ReshapeDataPropagation);
+        [](DataPropagationContext& ctx) {
+          onnx::PropagateShapeDataFromInputToOutput(ctx, 0);
+        });
   }
 }
 

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -884,7 +884,75 @@ void _EvalPartialShape(onnx::ModelProto& model) {
     folded_values.emplace(output, std::move(tp));
   }
 
-  if (folded_values.empty()) {
+  // Data propagation for `Reshape` (single dynamic dim). The fully-known folder
+  // above only rewrites a node whose propagated value is entirely concrete, so
+  // a shape tensor that keeps one symbolic entry -- e.g. `[batch, 1024, 128]`
+  // on a graph with a dynamic batch, or `[?, 768]` with a dynamic sequence
+  // length -- is left alone, and with it the whole `Shape -> Gather -> Concat`
+  // subgraph that computes it at runtime. Those single-dynamic-dim reshapes
+  // dominate transformer and speech graphs.
+  //
+  // When a Reshape's shape input propagates to a value with exactly one unknown
+  // entry and all other entries positive constants, materialize the shape as a
+  // constant with the unknown slot set to -1. ONNX Reshape infers the -1 dim
+  // from the total element count, so for every input the result is identical to
+  // the runtime-computed shape, while the shape-producing subgraph becomes dead
+  // and is removed by the optimizer. (Correctness is still gated by onnxsim's
+  // own equivalence check.)
+  struct ReshapeShapeFix {
+    std::string shape_name;
+    onnx::TensorProto shape_tensor;
+  };
+  std::unordered_map<std::string, ReshapeShapeFix> reshape_fixes;
+  for (const auto& node : model.graph().node()) {
+    if (node.op_type() != "Reshape" || node.input_size() < 2 ||
+        node.output_size() != 1) {
+      continue;
+    }
+    auto data_iter = data_map.find(node.input(1));
+    if (data_iter == data_map.end()) {
+      continue;
+    }
+    const onnx::TensorShapeProto& shape_value = data_iter->second;
+    if (shape_value.dim_size() == 0) {
+      continue;
+    }
+    int unknown = 0;
+    bool usable = true;
+    std::vector<int64_t> shape;
+    shape.reserve(shape_value.dim_size());
+    for (const auto& dim : shape_value.dim()) {
+      if (dim.has_dim_value()) {
+        // A non-positive entry is a literal 0 (copy-dim) or an already
+        // materialized -1; leave those for the ordinary folder.
+        if (dim.dim_value() <= 0) {
+          usable = false;
+          break;
+        }
+        shape.push_back(dim.dim_value());
+      } else {
+        ++unknown;
+        shape.push_back(-1);
+      }
+    }
+    // Exactly one unknown dim maps to Reshape's single -1 sentinel. Zero
+    // unknowns is handled by the fully-known folder above; two or more cannot
+    // be expressed with a single -1.
+    if (!usable || unknown != 1) {
+      continue;
+    }
+    onnx::TensorProto tp;
+    tp.set_data_type(onnx::TensorProto::INT64);
+    tp.add_dims(static_cast<int64_t>(shape.size()));
+    for (int64_t v : shape) {
+      tp.add_int64_data(v);
+    }
+    reshape_fixes.emplace(
+        node.output(0),
+        ReshapeShapeFix{node.output(0) + "_dp_shape", std::move(tp)});
+  }
+
+  if (folded_values.empty() && reshape_fixes.empty()) {
     restore();
     return;
   }
@@ -898,18 +966,38 @@ void _EvalPartialShape(onnx::ModelProto& model) {
   for (auto& node : original_nodes) {
     auto iter = node.output_size() == 1 ? folded_values.find(node.output(0))
                                         : folded_values.end();
-    if (iter == folded_values.end()) {
-      *model.mutable_graph()->add_node() = std::move(node);
+    if (iter != folded_values.end()) {
+      onnx::NodeProto* constant = model.mutable_graph()->add_node();
+      constant->set_name(node.name());
+      constant->set_op_type("Constant");
+      constant->add_output(iter->first);
+      onnx::AttributeProto* attr = constant->add_attribute();
+      attr->set_name("value");
+      attr->set_type(onnx::AttributeProto::TENSOR);
+      *attr->mutable_t() = std::move(iter->second);
       continue;
     }
-    onnx::NodeProto* constant = model.mutable_graph()->add_node();
-    constant->set_name(node.name());
-    constant->set_op_type("Constant");
-    constant->add_output(iter->first);
-    onnx::AttributeProto* attr = constant->add_attribute();
-    attr->set_name("value");
-    attr->set_type(onnx::AttributeProto::TENSOR);
-    *attr->mutable_t() = std::move(iter->second);
+    auto fix_iter = node.output_size() == 1 ? reshape_fixes.find(node.output(0))
+                                            : reshape_fixes.end();
+    if (fix_iter != reshape_fixes.end()) {
+      // Emit the materialized shape as a Constant just before the Reshape
+      // (preserving topological order), then repoint the Reshape's shape input
+      // at it. The original shape-producing subgraph is now unused and is
+      // cleaned up by the optimizer's dead-node elimination.
+      onnx::NodeProto* shape_const = model.mutable_graph()->add_node();
+      shape_const->set_op_type("Constant");
+      shape_const->add_output(fix_iter->second.shape_name);
+      onnx::AttributeProto* attr = shape_const->add_attribute();
+      attr->set_name("value");
+      attr->set_type(onnx::AttributeProto::TENSOR);
+      *attr->mutable_t() = std::move(fix_iter->second.shape_tensor);
+
+      onnx::NodeProto* reshape = model.mutable_graph()->add_node();
+      *reshape = std::move(node);
+      reshape->set_input(1, fix_iter->second.shape_name);
+      continue;
+    }
+    *model.mutable_graph()->add_node() = std::move(node);
   }
 }
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -308,6 +308,38 @@ def test_partial_shape_evaluation_reshape_single_dynamic_dim():
     assert list(shape_value) == [-1, 60]
 
 
+def test_data_propagation_through_reshape():
+    # ONNX has no data-propagation function for Reshape, so onnxsim registers one
+    # (contrib_schemas): a shape tensor threaded through an element-preserving
+    # Reshape must keep its propagated value so downstream shape arithmetic still
+    # folds. Here Shape(x) -> Reshape(., [-1]) -> Gather([1, 2]) reads only the
+    # static dims, so it must pre-compute to [3, 4] even though the batch is
+    # dynamic -- which requires the value to survive the Reshape.
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, ["batch", 3, 4])
+    g = helper.make_tensor_value_info("g", TensorProto.INT64, [2])
+    flat = helper.make_tensor("flat", TensorProto.INT64, [1], [-1])
+    indices = helper.make_tensor("indices", TensorProto.INT64, [2], [1, 2])
+    nodes = [
+        helper.make_node("Shape", ["x"], ["s"]),
+        helper.make_node("Reshape", ["s", "flat"], ["s2"]),
+        helper.make_node("Gather", ["s2", "indices"], ["g"], axis=0),
+    ]
+    graph = helper.make_graph(nodes, "g", [x], [g], initializer=[flat, indices])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    onnx.checker.check_model(model)
+
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+    op_types = [n.op_type for n in sim_model.graph.node]
+    # The value propagated through the Reshape, so the whole chain pre-computes.
+    assert "Gather" not in op_types
+    assert "Reshape" not in op_types
+    value = _constant_value(sim_model, "g")
+    assert value is not None
+    assert list(value) == [3, 4]
+
+
 def test_unfoldable_const_node_keeps_topological_order():
     # A const node (all-constant inputs) that fails to fold must keep its
     # original position. Here SequenceEmpty is treated as a const node; its

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -270,6 +270,44 @@ def test_partial_shape_evaluation_keeps_dynamic_gather():
     assert _constant_value(sim_model, "g") is None
 
 
+def test_partial_shape_evaluation_reshape_single_dynamic_dim():
+    # Data propagation for Reshape: the target shape is computed at runtime from
+    # the input's shape (Shape -> Gather -> Concat), and it has a single dynamic
+    # entry (the batch) plus otherwise-static dimensions. Partial shape
+    # evaluation propagates that shape to [batch, 60], and the Reshape pass
+    # materializes it as the constant [-1, 60] -- the single -1 lets ONNX infer
+    # the dynamic dim from the total element count, which is provably equivalent
+    # -- so the whole Shape -> Gather -> Concat scaffolding collapses away.
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, ["batch", 3, 4, 5])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, ["batch", 60])
+    idx0 = helper.make_tensor("idx0", TensorProto.INT64, [1], [0])
+    sixty = helper.make_tensor("sixty", TensorProto.INT64, [1], [60])  # 3*4*5
+    nodes = [
+        helper.make_node("Shape", ["x"], ["s"]),
+        helper.make_node("Gather", ["s", "idx0"], ["b"], axis=0),
+        helper.make_node("Concat", ["b", "sixty"], ["newshape"], axis=0),
+        helper.make_node("Reshape", ["x", "newshape"], ["y"]),
+    ]
+    graph = helper.make_graph(nodes, "g", [x], [y], initializer=[idx0, sixty])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    onnx.checker.check_model(model)
+
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+    op_types = [n.op_type for n in sim_model.graph.node]
+    # The runtime shape computation is gone; only the Reshape (fed by a constant
+    # shape) survives.
+    assert "Shape" not in op_types
+    assert "Gather" not in op_types
+    assert "Concat" not in op_types
+    reshape = [n for n in sim_model.graph.node if n.op_type == "Reshape"]
+    assert len(reshape) == 1
+    shape_value = _constant_value(sim_model, reshape[0].input[1])
+    assert shape_value is not None
+    assert list(shape_value) == [-1, 60]
+
+
 def test_unfoldable_const_node_keeps_topological_order():
     # A const node (all-constant inputs) that fails to fold must keep its
     # original position. Here SequenceEmpty is treated as a const node; its


### PR DESCRIPTION
## Summary

Teaches onnxsim's partial shape evaluation to fold the runtime shape computation feeding a `Reshape` when the target shape has a **single dynamic dimension** (a dynamic batch or sequence length) — the common transformer / speech-export pattern that the existing *fully-concrete* folder leaves untouched. On such a graph the whole `Shape → Gather → Concat` scaffolding that computes the `Reshape` target at runtime is replaced by a constant and swept away.

Also trims the README's "Projects Using ONNX Simplifier" list to projects that *currently* use onnxsim (this PR started as that README change).

## Key changes

**Reshape shape materialization — `_EvalPartialShape` (`onnxsim/onnxsim.cpp`)**
- The existing partial-shape folder only rewrites a node whose propagated value is *entirely* concrete, so a shape tensor that keeps one symbolic entry (e.g. `[batch, 1024, 128]`) — and the subgraph computing it — is left in place.
- Now, when a `Reshape`'s shape input propagates to a value with exactly one unknown entry and otherwise-positive constants, the shape is materialized as a constant with the unknown slot set to `-1` (e.g. `[-1, 1024, 128]`). ONNX `Reshape` infers the `-1` dim from the total element count, so the result is identical for every input, while the shape-producing subgraph becomes dead and is removed by the optimizer.

**Data-propagation function for `Reshape` (`onnxsim/contrib_schemas.cpp`)**
- ONNX ships data-propagation functions for the shape family (`Shape`, `Gather`, `Concat`, `Slice`, `Squeeze`, `Unsqueeze`, `Add/Sub/Mul`, …) but **not** for `Reshape`, so a shape tensor threaded *through* a `Reshape` (e.g. `Shape(x) → Reshape(·, [-1]) → Gather(…)`) loses its propagated value and downstream shape arithmetic stops folding.
- Registers a `PartialDataPropagationFunction` on the standard `Reshape` schema (alongside the existing schema augmentations) using ONNX's own `PropagateShapeDataFromInputToOutput` — the same helper `Squeeze`/`Unsqueeze` use. A `Reshape` never changes a tensor's element count or row-major order, so a shape tensor's propagated value is invariant under it; the value flows straight through.

**README**
- Trims "Projects Using ONNX Simplifier" to projects whose current export / conversion code still calls onnxsim, verified by searching each repo: **YOLOX**, **PaddleDetection**, **X2Paddle**, **ncnn**, **Rockchip RKNN Model Zoo**. Drops entries that have migrated to onnxslim (Ultralytics YOLO and YOLOv5 both now depend on onnxslim) or no longer reference onnxsim in current code (MMDetection/MMDeploy, MNN, the TensorRT ecosystem entry, and the retired MXNet tutorial).

## Notable details

- **Correctness.** The `-1` sentinel is provably equivalent to the runtime-computed dim, and every simplified graph is still gated by onnxsim's own equivalence check. The data-propagation function only runs inside the partial-shape pass (data propagation is not enabled for ordinary shape inference), so it never changes normal type/shape inference.
- **Scope.** This fires wherever ONNX data propagation can supply the `Reshape` shape value — the canonical `Shape → Gather → Concat → Reshape` dynamic-batch pattern. Graphs whose shape chains route through ops ONNX data propagation doesn't cover (`Where`, `Equal`, `Div`, `Expand`) are unaffected; closing those is future work (symbolic shape evaluation).

## Testing

- New regression tests in `tests/test_simple.py`:
  - `test_partial_shape_evaluation_reshape_single_dynamic_dim` — `Shape → Gather → Concat → Reshape` with a dynamic batch collapses to a single `Reshape` fed by a `[-1, …]` constant.
  - `test_data_propagation_through_reshape` — a shape threaded through a `Reshape` still lets the downstream `Gather` pre-compute.
- Full `tests/test_simple.py` passes; real-model spot checks (AST, Wav2Vec2) stay valid with unchanged node counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wt99khTftKMSKGHymCRiir