### PR TITLE
Fix race condition in model converter initialization

### DIFF
--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -9,6 +9,25 @@
         </style>
         <script type="text/javascript" src="./onnxsim.js"></script>
         <script type="text/javascript">
+            // The "Choose file" picker must stay disabled until BOTH WASM
+            // runtimes are initialized: the one on this page (used to populate
+            // the pass list) and the one inside the conversion worker (which
+            // actually receives the model). Enabling it earlier lets a user
+            // pick a file before the worker is listening, so the conversion
+            // message is dropped and the runtime raises uninitialized errors.
+            let runtimeReady = false; // this page's WASM (pass list)
+            let workerReady = false;  // the worker's WASM (conversion)
+            const maybeEnableInput = () => {
+                if (!runtimeReady || !workerReady) return;
+                const input = document.getElementById("file-input");
+                if (input) {
+                    input.disabled = false;
+                    input.removeAttribute("title");
+                }
+                const status = document.getElementById("loading-status");
+                if (status) status.style.display = "none";
+            };
+
             create_onnxsim().then((runtime) => {
                 to_ary = (vec) => {
                     return new Array(vec.size()).fill(0).map((_, id) => vec.get(id))
@@ -32,6 +51,8 @@
                 for (const p of to_ary(runtime.onnxoptimizer_fuse_elimination_passes()).sort()) {
                     checkboxes[p].checked = true;
                 }
+                runtimeReady = true;
+                maybeEnableInput();
             });
 
             // The most recent conversion parameters, captured so that the
@@ -97,6 +118,12 @@
                 let result_name = "";
                 worker.onmessage = (e) => {
                     switch (e.data[0]) {
+                        case "ready":
+                            // The worker's WASM runtime has finished loading and
+                            // is now listening for conversion requests.
+                            workerReady = true;
+                            maybeEnableInput();
+                            break;
                         case "stdout":
                             log_output.value += e.data[1] + "\n";
                             log_output.scrollTop = log_output.scrollHeight;
@@ -194,7 +221,8 @@
     </head>
     <body>
         <h1>Model converter</h1>
-        <input type="file" id="file-input" />
+        <input type="file" id="file-input" disabled title="Loading WebAssembly runtime…" />
+        <span id="loading-status">⏳ Loading WebAssembly runtime… the file picker is disabled until it is ready.</span>
         <button id="download-button" disabled>Download</button>
         <div>
             <input type="radio" name="optimizer" value="simplify" id="optimizer_simplify" checked>

--- a/scripts/convertmodel/worker.js
+++ b/scripts/convertmodel/worker.js
@@ -13,6 +13,10 @@ create_onnxsim({
         postMessage(["stderr", str]);
     },
 }).then((runtime) => {
+    // Tell the page the WASM runtime is initialized so it can enable the
+    // "Choose file" picker. Registering the message listener below only
+    // happens now, so any file posted earlier would be dropped.
+    postMessage(["ready"]);
     addEventListener("message", (e) => {
         console.log(e.data);
         const buf = e.data[1];


### PR DESCRIPTION
## Summary
This PR fixes a race condition in the model converter where users could select a file before the WebAssembly runtimes were fully initialized, causing conversion messages to be dropped and uninitialized errors to be raised.

## Key Changes
- Added synchronization logic to track initialization state of both the main page's WASM runtime (used for pass list population) and the worker's WASM runtime (used for actual conversion)
- The file input picker now remains disabled until both runtimes are ready, preventing premature file selection
- Added a "ready" message from the worker to signal when its WASM runtime has finished initializing
- Updated the UI to show a loading status message and disabled state with a tooltip while initialization is in progress
- The file input is only enabled after both `runtimeReady` and `workerReady` flags are set to true

## Implementation Details
- Two boolean flags (`runtimeReady` and `workerReady`) track the initialization state of each runtime
- A `maybeEnableInput()` function checks both flags and enables the file input only when both are true
- The main page sets `runtimeReady = true` after `create_onnxsim()` completes
- The worker sends a "ready" message after its WASM runtime initializes, which the main page receives to set `workerReady = true`
- Added visual feedback with a loading status message that hides once initialization is complete

https://claude.ai/code/session_01LCfM1sKeD3z9WNyuNU8siW