### PR TITLE
Add SymExpr subtraction, exact division, and decidable equality

### DIFF
--- a/onnxsim/sym_expr.cpp
+++ b/onnxsim/sym_expr.cpp
@@ -139,6 +139,43 @@ std::string wrap(const SymExpr& e) {
 
 }  // namespace
 
+std::optional<SymExpr> TryExactDivide(const SymExpr& num, const SymExpr& den) {
+  // Only single-term divisors (a product of dimensions times a constant); a
+  // genuine polynomial sum is never a shape-arithmetic divisor.
+  if (den.terms().size() != 1) return std::nullopt;
+  const auto& [den_mono, den_coeff] = *den.terms().begin();
+  if (den_coeff == 0) return std::nullopt;  // division by zero
+  const auto den_powers = powers_of(den_mono);
+
+  SymExpr quotient;  // starts at 0, so num == 0 divides to 0
+  for (const auto& [mono, coeff] : num.terms()) {
+    if (coeff % den_coeff != 0)
+      return std::nullopt;  // coefficient not divisible
+    auto powers = powers_of(mono);
+    for (const auto& [name, power] : den_powers) {
+      const auto it = powers.find(name);
+      if (it == powers.end() || it->second < power) {
+        return std::nullopt;  // this term is not divisible by den's monomial
+      }
+      it->second -= power;
+    }
+    // Rebuild the quotient term coeff/den_coeff * (remaining symbols), using
+    // the public API only (mirrors divide_by above).
+    SymExpr term(coeff / den_coeff);
+    for (const auto& [name, power] : powers)
+      for (std::size_t k = 0; k < power; ++k) term *= SymExpr::Symbol(name);
+    quotient += term;
+  }
+  return quotient;
+}
+
+std::optional<bool> TryEqual(const SymExpr& a, const SymExpr& b) {
+  const SymExpr diff = a - b;
+  if (diff.is_zero()) return true;        // a and b are structurally identical
+  if (!diff.is_symbolic()) return false;  // concrete, non-zero difference
+  return std::nullopt;                    // symbolic difference: undecidable
+}
+
 std::string SymExpr::str() const { return join_terms(terms_); }
 
 std::string SymExpr::str_factored() const {

--- a/onnxsim/sym_expr.h
+++ b/onnxsim/sym_expr.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <iterator>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -91,6 +92,13 @@ class SymExpr {
     return a;
   }
 
+  // a - b, needed by shape arithmetic (Slice's end - start, Sub) and by
+  // TryEqual below. Defined as a + (-1)*b to reuse the existing operators.
+  friend SymExpr operator-(SymExpr a, const SymExpr& b) {
+    a += SymExpr(-1) * b;
+    return a;
+  }
+
   friend SymExpr operator*(const SymExpr& a, const SymExpr& b) {
     SymExpr r;
     for (const auto& [m1, c1] : a.terms_) {
@@ -127,6 +135,29 @@ class SymExpr {
   // Invariant: no entry has a zero coefficient; every Monomial key is sorted.
   std::map<Monomial, std::int64_t> terms_;
 };
+
+// Exact division num / den, for the symbolic *shape* evaluation that a
+// data-propagation pass needs (distinct from model_info's MAC formulas). The
+// canonical case is Reshape's -1 sentinel, resolved as
+//   total // non_deferred_size   e.g.  (batch*1024*128) // (1024*128) -> batch
+// and strided/pooled dims. Divisors there are always a single term (a product
+// of dimensions times a constant), so only single-term `den` is supported.
+//
+// Returns the quotient q with q*den == num when den divides num exactly (every
+// term's coefficient divisible by den's, and den's monomial a sub-multiset of
+// each term's); std::nullopt when it does not divide evenly or den is a genuine
+// polynomial sum. Never guesses -- an undecidable division stays unresolved so
+// the caller leaves that shape symbolic rather than folding something wrong.
+std::optional<SymExpr> TryExactDivide(const SymExpr& num, const SymExpr& den);
+
+// Decidable equality for Equal/Where in shape evaluation. a == b iff a - b ==
+// 0:
+//   - structurally equal (a - b is 0)             -> true
+//   - concrete, non-zero difference (e.g. 512,1024) -> false
+//   - symbolic difference (e.g. batch vs 512)       -> std::nullopt (unknown)
+// The unknown case is deliberate: a Where whose condition can't be decided
+// leaves its output unresolved rather than picking a branch that may be wrong.
+std::optional<bool> TryEqual(const SymExpr& a, const SymExpr& b);
 
 // compute_density = flops / mem_access is the one metric that is a *ratio* of
 // two polynomials rather than a polynomial, so it gets its own small type. When

--- a/onnxsim/sym_expr_test.cpp
+++ b/onnxsim/sym_expr_test.cpp
@@ -53,6 +53,49 @@ int main() {
   const SymRatio dens_partial(batch * seq, batch + seq);
   assert(dens_partial.str() == "batch*seq/(batch + seq)");
 
+  // --- subtraction (shape arithmetic: Slice end-start, Sub) ---------------
+  assert((SymExpr(5) - SymExpr(3)).to_int() == 2);
+  assert((SymExpr(2) * batch - batch).str() == "batch");
+
+  // --- exact division: Reshape's -1, (batch*1024*128) // (1024*128) -> batch
+  {
+    const SymExpr total = batch * SymExpr(1024) * SymExpr(128);
+    const SymExpr non_deferred = SymExpr(1024) * SymExpr(128);
+    const auto q = onnxsim::TryExactDivide(total, non_deferred);
+    assert(q.has_value() && q->str() == "batch");
+  }
+  // divide a polynomial by a shared symbol: (512*batch*seq + 8*batch)/batch
+  {
+    const SymExpr n = SymExpr(512) * batch * seq + SymExpr(8) * batch;
+    const auto q = onnxsim::TryExactDivide(n, batch);
+    assert(q.has_value() && q->str() == "512*seq + 8");
+  }
+  // not evenly divisible -> nullopt: (batch + seq) / seq (batch term has no
+  // seq)
+  assert(!onnxsim::TryExactDivide(batch + seq, seq).has_value());
+  // coefficient not divisible -> nullopt: (3*batch) / 2
+  assert(!onnxsim::TryExactDivide(SymExpr(3) * batch, SymExpr(2)).has_value());
+  // a genuine polynomial (multi-term) divisor is unsupported -> nullopt
+  assert(!onnxsim::TryExactDivide(batch * seq, batch + seq).has_value());
+  // 0 / anything -> 0
+  assert(onnxsim::TryExactDivide(SymExpr(0), batch)->is_zero());
+
+  // --- decidable equality for Equal/Where ---------------------------------
+  {
+    auto e = onnxsim::TryEqual(SymExpr(512), SymExpr(512));
+    assert(e.has_value() && *e);  // equal concretes -> true
+  }
+  {
+    auto e = onnxsim::TryEqual(SymExpr(512), SymExpr(1024));
+    assert(e.has_value() && !*e);  // unequal concretes -> false
+  }
+  {
+    auto e = onnxsim::TryEqual(batch, batch);
+    assert(e.has_value() && *e);  // structurally identical -> true
+  }
+  // symbolic vs constant is undecidable -> nullopt (Where leaves it unresolved)
+  assert(!onnxsim::TryEqual(batch, SymExpr(512)).has_value());
+
   std::cout << "all SymExpr tests passed\n";
   std::cout << "  macs           = " << macs.str() << "\n";
   std::cout << "  macs (factored)= " << macs.str_factored() << "\n";


### PR DESCRIPTION
## Summary

Extends the `SymExpr` polynomial (added in #527 for model_info's symbolic MAC / memory formulas) with the small set of operations a symbolic **shape** evaluator needs, so a future data-propagation pass can evaluate shape-computing subgraphs the way onnxslim does — keeping dynamic dims as algebra rather than losing them as opaque `dim_param` strings. All three additions are pure standard C++ with no new dependency, so they build under Emscripten/WASM like the rest of `SymExpr`.

## Key changes

- **`operator-`** — `a - b` (defined as `a + (-1)*b`). Needed by shape arithmetic (`Slice`'s `end - start`, `Sub`) and by `TryEqual`.
- **`TryExactDivide(num, den)` → `std::optional<SymExpr>`** — exact quotient when a single-term divisor (a product of dimensions times a constant) divides `num` evenly. This is the operation behind `Reshape`'s `-1` sentinel:
  ```
  total // non_deferred_size    e.g.  (batch*1024*128) // (1024*128)  ->  batch
  ```
  and strided / pooled dims. Returns `std::nullopt` when it doesn't divide evenly or the divisor is a genuine polynomial sum — it never guesses.
- **`TryEqual(a, b)` → `std::optional<bool>`** — decidable equality for `Equal` / `Where`: `true` / `false` when the difference is `0` / a non-zero constant, `std::nullopt` when the difference is symbolic (e.g. `batch` vs `512`). The unknown case lets a `Where` whose condition can't be decided leave its output unresolved instead of picking a branch that may be wrong.

## Notable details

- **Conservative by construction.** Every operation returns `nullopt` rather than an approximation when it can't answer exactly, so a caller leaves that shape symbolic instead of folding something incorrect.
- **Single-term divisor.** Shape-arithmetic divisors are always a product of dimensions (never a polynomial sum), so `TryExactDivide` supports exactly that case and mirrors the existing private `divide_by` helper, building the quotient through the public API.
- Covered by additions to the existing dependency-free `sym_expr_test` (`g++ -std=c++17 sym_expr.cpp sym_expr_test.cpp` — also builds under `em++`): the Reshape `-1` case, polynomial-by-symbol division, non-divisible → `nullopt`, coefficient-not-divisible → `nullopt`, polynomial divisor → `nullopt`, and the equality tri-state. Compiles clean under `-Wall -Wextra`.

## Motivation

This is the shared numeric primitive for a symbolic shape-evaluation pass (the onnxsim analogue of onnxslim's sympy-backed `sympy_data_`). A proof-of-concept over the shape-family ops plus `Where`/`Equal`/`Div`/`Expand` resolves ~all of AST's and most of SpeechT5's `Reshape` shapes to the single-symbol form that the partial-shape rewrite in #526 already materializes to `[-1, …]` — closing most of the onnxsim-vs-onnxslim node-count gap on dynamic-shape transformer / speech graphs. This PR lands only the primitive; the evaluator builds on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wt99khTftKMSKGHymCRiir

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wt99khTftKMSKGHymCRiir)_