### PR TITLE
Add X2Paddle downstream regression testing harness

### DIFF
--- a/.github/workflows/x2paddle-regression.yml
+++ b/.github/workflows/x2paddle-regression.yml
@@ -106,10 +106,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # X2Paddle 1.6.0 targets onnx<1.16 (onnx.mapping) and opset <= 15.
-          # rich is an onnxsim runtime dep, installed explicitly because the
-          # wheel below goes in with --no-deps.
+          # six is an undeclared x2paddle runtime dep (x2paddle/core/program.py
+          # imports it); rich is an onnxsim runtime dep. Both are installed
+          # explicitly because the onnxsim wheel below goes in with --no-deps.
+          # onnxslim is the comparison arm.
           python -m pip install "paddlepaddle>=2.5" "x2paddle==1.6.0" "onnx<1.16" \
-            onnxruntime huggingface_hub rich
+            onnxruntime huggingface_hub onnxslim rich six
           # --no-deps so the wheel can't drag in onnx>=1.16 over the pin above.
           python -m pip install --no-deps wheelhouse/*.whl
       - name: Verify the built wheel is used (not the source tree)

--- a/.github/workflows/x2paddle-regression.yml
+++ b/.github/workflows/x2paddle-regression.yml
@@ -1,0 +1,154 @@
+name: X2Paddle Regression
+
+# Downstream-consumer regression: onnxsim is X2Paddle's built-in ONNX optimize
+# step (x2paddle.convert.onnx2paddle runs onnxsim.simplify before its op-mapper),
+# so this converts a set of real ONNX models to PaddlePaddle twice — from the
+# original graph and after onnxsim — and fails if onnxsim broke a conversion
+# X2Paddle could do before. See scripts/regression/x2paddle/README.md.
+#
+# X2Paddle 1.6.0 pins onnx<1.16 (uses onnx.mapping) and opset <= 15, so this job
+# installs a separate dependency set from the onnxmodelzoo sweep. It's a heavier
+# job (paddlepaddle + model downloads), so it runs on a schedule and on demand.
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # Mondays 07:00 UTC (weekly)
+  workflow_dispatch:
+    inputs:
+      num_shards:
+        description: "Number of parallel shards"
+        default: "2"
+        type: string
+  pull_request:
+    # Validate the harness itself whenever it changes.
+    paths:
+      - ".github/workflows/x2paddle-regression.yml"
+      - "scripts/regression/x2paddle/**"
+
+concurrency:
+  group: x2paddle-regression-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Build onnxsim once from the current tree and share the wheel with every
+  # shard, so the regression tests the code under review — not a released wheel.
+  build:
+    name: Build onnxsim wheel
+    runs-on: ubuntu-24.04
+    env:
+      SCCACHE_GHA_ENABLED: "on"
+      ACTIONS_CACHE_SERVICE_V2: "on"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      # X2Paddle 1.6.0 needs onnx<1.16, which has no cp312 wheels on some
+      # platforms; build the onnxsim wheel for cp311 to match the shard runtime.
+      - name: Build cp311 wheel
+        uses: pypa/cibuildwheel@v4.1.1
+        env:
+          CIBW_BUILD: "cp311-manylinux_x86_64"
+          CIBW_ARCHS: native
+          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_ENVIRONMENT_PASS_LINUX: CI SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN ACTIONS_CACHE_SERVICE_V2
+          CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache"
+          CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF" CMAKE_GENERATOR=Ninja CMAKE_CXX_COMPILER_LAUNCHER=sccache CMAKE_LINKER_TYPE=LLD
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} --strip"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: onnxsim-wheel-cp311
+          path: ./wheelhouse/*.whl
+
+  setup:
+    name: Plan shards
+    runs-on: ubuntu-24.04
+    outputs:
+      shards: ${{ steps.plan.outputs.shards }}
+      num_shards: ${{ steps.plan.outputs.num_shards }}
+    steps:
+      - id: plan
+        run: |
+          n="${{ github.event.inputs.num_shards || '2' }}"
+          shards=$(python3 -c "import json,sys; print(json.dumps(list(range(int(sys.argv[1])))))" "$n")
+          echo "num_shards=$n" >> "$GITHUB_OUTPUT"
+          echo "shards=$shards" >> "$GITHUB_OUTPUT"
+          echo "planning $n shards: $shards"
+
+  regression:
+    name: Shard ${{ matrix.shard }}
+    needs: [build, setup]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    env:
+      NUM_SHARDS: ${{ needs.setup.outputs.num_shards }}
+      HF_HUB_ENABLE_HF_TRANSFER: "0"
+      HF_HUB_DISABLE_PROGRESS_BARS: "1"
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.setup.outputs.shards) }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - uses: actions/download-artifact@v8
+        with:
+          name: onnxsim-wheel-cp311
+          path: wheelhouse
+      - name: Install X2Paddle stack + onnxsim wheel
+        run: |
+          python -m pip install --upgrade pip
+          # X2Paddle 1.6.0 targets onnx<1.16 (onnx.mapping) and opset <= 15.
+          python -m pip install "paddlepaddle>=2.5" "x2paddle==1.6.0" "onnx<1.16" \
+            onnxruntime huggingface_hub
+          python -m pip install --no-deps wheelhouse/*.whl
+      - name: Verify the built wheel is used (not the source tree)
+        working-directory: ${{ runner.temp }}
+        run: python -c "import onnxsim, onnxsim.onnxsim_cpp2py_export as m; print(onnxsim.__version__, m.__file__)"
+      - name: Run X2Paddle regression shard
+        working-directory: ${{ runner.temp }}
+        run: |
+          python "$GITHUB_WORKSPACE/scripts/regression/x2paddle/run_x2paddle_regression.py" \
+            --shard "${{ matrix.shard }}" \
+            --num-shards "$NUM_SHARDS" \
+            --timeout 600 \
+            --output "x2paddle-shard-${{ matrix.shard }}.csv"
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: x2paddle-csv-shard-${{ matrix.shard }}
+          path: ${{ runner.temp }}/x2paddle-shard-${{ matrix.shard }}.csv
+          if-no-files-found: ignore
+
+  summary:
+    name: Summary
+    needs: [regression]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: x2paddle-csv-*
+          path: csvs
+          merge-multiple: true
+      - name: Build summary
+        run: python "$GITHUB_WORKSPACE/scripts/regression/x2paddle/summarize.py" "csvs/*.csv"
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: x2paddle-regression-report
+          path: |
+            x2paddle-regression-report.csv
+            x2paddle-regression-summary.md
+          if-no-files-found: ignore

--- a/.github/workflows/x2paddle-regression.yml
+++ b/.github/workflows/x2paddle-regression.yml
@@ -106,12 +106,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # X2Paddle 1.6.0 targets onnx<1.16 (onnx.mapping) and opset <= 15.
-          # six is an undeclared x2paddle runtime dep (x2paddle/core/program.py
-          # imports it); rich is an onnxsim runtime dep. Both are installed
-          # explicitly because the onnxsim wheel below goes in with --no-deps.
-          # onnxslim is the comparison arm.
+          # six and requests are undeclared x2paddle runtime deps that its
+          # conversion path pulls in (x2paddle/core/program.py imports six and,
+          # via x2paddle.utils, requests); rich is an onnxsim runtime dep. All
+          # are installed explicitly because the onnxsim wheel below goes in with
+          # --no-deps. onnxslim is the comparison arm.
           python -m pip install "paddlepaddle>=2.5" "x2paddle==1.6.0" "onnx<1.16" \
-            onnxruntime huggingface_hub onnxslim rich six
+            onnxruntime huggingface_hub onnxslim rich six requests
           # --no-deps so the wheel can't drag in onnx>=1.16 over the pin above.
           python -m pip install --no-deps wheelhouse/*.whl
       - name: Verify the built wheel is used (not the source tree)

--- a/.github/workflows/x2paddle-regression.yml
+++ b/.github/workflows/x2paddle-regression.yml
@@ -106,8 +106,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # X2Paddle 1.6.0 targets onnx<1.16 (onnx.mapping) and opset <= 15.
+          # rich is an onnxsim runtime dep, installed explicitly because the
+          # wheel below goes in with --no-deps.
           python -m pip install "paddlepaddle>=2.5" "x2paddle==1.6.0" "onnx<1.16" \
-            onnxruntime huggingface_hub
+            onnxruntime huggingface_hub rich
+          # --no-deps so the wheel can't drag in onnx>=1.16 over the pin above.
           python -m pip install --no-deps wheelhouse/*.whl
       - name: Verify the built wheel is used (not the source tree)
         working-directory: ${{ runner.temp }}

--- a/scripts/regression/x2paddle/.gitignore
+++ b/scripts/regression/x2paddle/.gitignore
@@ -1,0 +1,5 @@
+# Per-run model download cache (one model at a time; cleaned as the run goes).
+dl/
+# Local run outputs.
+*.csv
+x2paddle-regression-summary.md

--- a/scripts/regression/x2paddle/README.md
+++ b/scripts/regression/x2paddle/README.md
@@ -1,0 +1,89 @@
+# onnxsim → X2Paddle downstream regression
+
+Checks that `onnxsim` doesn't break [**X2Paddle**](https://github.com/PaddlePaddle/X2Paddle)'s
+ONNX → PaddlePaddle conversion.
+
+This is a *downstream-consumer* regression, distinct from the sibling
+[onnxmodelzoo sweep](../README.md) (which runs onnxsim standalone and compares
+it to onnxslim). Here onnxsim isn't a peer — **it's a dependency inside
+X2Paddle**: `x2paddle.convert.onnx2paddle`'s default `enable_optim=True` path
+runs `onnxsim.simplify` on the graph before the op-mapper sees it. So an onnxsim
+change that rewrites a graph into something X2Paddle's op-mapper can no longer
+translate is a real, user-visible breakage of X2Paddle — and this harness is
+what catches it.
+
+## How it works
+
+For each model in `models.json` (pulled from the Hugging Face
+[`onnxmodelzoo`](https://huggingface.co/onnxmodelzoo) org), `worker.py` runs two
+arms and compares them:
+
+| arm | what it does |
+| --- | --- |
+| **baseline** | the *original* ONNX graph → X2Paddle (decoder → op-mapper → optimizer → `gen_model`), onnxsim **off** |
+| **onnxsim** | `onnxsim.simplify` first, then the *simplified* graph through the same X2Paddle stages |
+
+Each step (onnxsim, and each conversion) runs in **its own child subprocess**
+with its own timeout, for two reasons:
+
+1. onnxsim's optimizer passes are C++ and some still abort on odd graphs; an
+   abort/segfault/hang is contained and reported instead of taking the run down.
+2. **Paddle's parameter registry is process-global** — converting both arms in
+   one interpreter makes the second collide with the first
+   (`parameter name [...] have be been used`). Separate processes are the only
+   clean fix.
+
+## Verdicts — what fails the run
+
+| verdict | gates? | meaning |
+| --- | --- | --- |
+| `pass` | — | onnxsim ok and X2Paddle converted the simplified graph |
+| `regression` | **✗ fails** | X2Paddle converted the original but **not** the simplified graph — onnxsim broke a working conversion |
+| `onnxsim_fail` | **✗ fails** | onnxsim crashed, timed out, or failed its own correctness check |
+| `baseline_unsupported` | — | X2Paddle can't convert the original either (an unsupported op, etc.) — onnxsim is not implicated |
+| `improved` | — | the original failed but the simplified graph converted — onnxsim *unblocked* X2Paddle |
+
+Only `regression` and `onnxsim_fail` (and a harness `error`) turn the run red.
+`baseline_unsupported` is expected for models that use ops X2Paddle's ONNX
+front-end doesn't implement; those are recorded for coverage, never gated.
+
+If an onnxsim optimizer pass raises a C++ assertion, the worker detects the
+pass, adds it to `skipped_optimizers`, and retries — so a newly-fragile pass
+shows up in the summary's "passes skipped" table (same behaviour as the
+onnxmodelzoo sweep).
+
+## Running locally
+
+```bash
+# X2Paddle 1.6.0 needs onnx<1.16 (it uses onnx.mapping and mis-detects newer
+# onnx as "not installed"), and targets opset <= 15.
+pip install "paddlepaddle>=2.5" "x2paddle==1.6.0" "onnx<1.16" onnxruntime huggingface_hub
+pip install .            # or install an onnxsim wheel
+
+# one shard
+python scripts/regression/x2paddle/run_x2paddle_regression.py \
+    --shard 0 --num-shards 2 --timeout 600 --output shard-0.csv
+
+# merge shards into a report + Markdown summary
+python scripts/regression/x2paddle/summarize.py "shard-*.csv"
+```
+
+### Why we drive X2Paddle's stages directly
+
+`worker.py` calls `ONNXDecoder → ONNXOpMapper → GraphOptimizer → gen_model`
+itself rather than `x2paddle.convert.onnx2paddle`. That entry point (a) gates on
+`onnx.version.version`, which raises on `onnx>=1.16` and makes it silently
+return without converting, and (b) always runs onnxsim internally, which would
+prevent us from measuring the original-graph baseline. Driving the stages
+directly dodges the version gate and lets us turn onnxsim on/off per arm — the
+stages themselves are exactly what `onnx2paddle` runs after its checks.
+
+## Updating the model set
+
+`models.json` is a small curated spread of opset-≤15 vision models X2Paddle's
+ONNX front-end supports (the exhaustive onnxmodelzoo list lives in the sibling
+harness). `baseline_seconds` only balances shards; `baseline_verdict` records
+the last observed outcome so a change in convertibility stands out in review.
+Add a model by appending `{"id": "onnxmodelzoo/<name>", "baseline_seconds": 6.0}`
+and running once to confirm its verdict. Prefer opset ≤ 15 — X2Paddle 1.6.0
+rejects newer opsets.

--- a/scripts/regression/x2paddle/README.md
+++ b/scripts/regression/x2paddle/README.md
@@ -52,12 +52,34 @@ pass, adds it to `skipped_optimizers`, and retries — so a newly-fragile pass
 shows up in the summary's "passes skipped" table (same behaviour as the
 onnxmodelzoo sweep).
 
+## onnxslim comparison (non-gating)
+
+Each model is **also** run through [`onnxslim`](https://github.com/inisis/OnnxSlim)
+and that slimmed graph is fed to X2Paddle too, in its own isolated arm — purely
+for comparison, mirroring the onnxmodelzoo sweep. onnxsim is the only arm that
+gates the run; the onnxslim numbers never turn it red. The summary reports two
+axes:
+
+- **X2Paddle-convertibility.** Over the models X2Paddle converted from the
+  original, how often each simplifier's output still converts, and the models
+  where the two diverge. This is the axis that matters for this downstream: a
+  simplifier that reduces more nodes but produces a graph X2Paddle can't convert
+  is *worse* here, not better.
+- **Node reduction.** Median reduction for each tool and the largest node-count
+  divergences.
+
+The comparison is descriptive, not a target — onnxslim reducing more nodes on a
+model is not a regression and is not actionable on its own.
+
 ## Running locally
 
 ```bash
 # X2Paddle 1.6.0 needs onnx<1.16 (it uses onnx.mapping and mis-detects newer
-# onnx as "not installed"), and targets opset <= 15.
-pip install "paddlepaddle>=2.5" "x2paddle==1.6.0" "onnx<1.16" onnxruntime huggingface_hub
+# onnx as "not installed"), and targets opset <= 15. `six` is an undeclared
+# x2paddle runtime dep (x2paddle/core/program.py imports it), so install it
+# explicitly. onnxslim is the comparison arm.
+pip install "paddlepaddle>=2.5" "x2paddle==1.6.0" "onnx<1.16" \
+    onnxruntime huggingface_hub onnxslim six
 pip install .            # or install an onnxsim wheel
 
 # one shard

--- a/scripts/regression/x2paddle/README.md
+++ b/scripts/regression/x2paddle/README.md
@@ -40,12 +40,16 @@ with its own timeout, for two reasons:
 | `pass` | — | onnxsim ok and X2Paddle converted the simplified graph |
 | `regression` | **✗ fails** | X2Paddle converted the original but **not** the simplified graph — onnxsim broke a working conversion |
 | `onnxsim_fail` | **✗ fails** | onnxsim crashed, timed out, or failed its own correctness check |
+| `env_error` | **✗ fails** | a conversion failed to import a Python dependency — the environment is broken (e.g. an undeclared x2paddle dep is missing), so results are meaningless |
 | `baseline_unsupported` | — | X2Paddle can't convert the original either (an unsupported op, etc.) — onnxsim is not implicated |
 | `improved` | — | the original failed but the simplified graph converted — onnxsim *unblocked* X2Paddle |
 
-Only `regression` and `onnxsim_fail` (and a harness `error`) turn the run red.
-`baseline_unsupported` is expected for models that use ops X2Paddle's ONNX
-front-end doesn't implement; those are recorded for coverage, never gated.
+Only `regression`, `onnxsim_fail`, and `env_error` (and a harness `error`) turn
+the run red. `baseline_unsupported` is expected for models that use ops
+X2Paddle's ONNX front-end doesn't implement; those are recorded for coverage,
+never gated. `env_error` exists so a missing dependency fails loudly instead of
+making *every* model's baseline crash and silently pass as
+`baseline_unsupported`.
 
 If an onnxsim optimizer pass raises a C++ assertion, the worker detects the
 pass, adds it to `skipped_optimizers`, and retries — so a newly-fragile pass
@@ -75,11 +79,12 @@ model is not a regression and is not actionable on its own.
 
 ```bash
 # X2Paddle 1.6.0 needs onnx<1.16 (it uses onnx.mapping and mis-detects newer
-# onnx as "not installed"), and targets opset <= 15. `six` is an undeclared
-# x2paddle runtime dep (x2paddle/core/program.py imports it), so install it
-# explicitly. onnxslim is the comparison arm.
+# onnx as "not installed"), and targets opset <= 15. `six` and `requests` are
+# undeclared x2paddle runtime deps its conversion path pulls in
+# (x2paddle/core/program.py imports six and, via x2paddle.utils, requests), so
+# install them explicitly. onnxslim is the comparison arm.
 pip install "paddlepaddle>=2.5" "x2paddle==1.6.0" "onnx<1.16" \
-    onnxruntime huggingface_hub onnxslim six
+    onnxruntime huggingface_hub onnxslim six requests
 pip install .            # or install an onnxsim wheel
 
 # one shard

--- a/scripts/regression/x2paddle/models.json
+++ b/scripts/regression/x2paddle/models.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "ONNX models (opset <= 15, X2Paddle 1.6.0's supported range) pulled from the Hugging Face onnxmodelzoo org and converted to PaddlePaddle with X2Paddle, both from the original graph and after onnxsim.simplify. A spread across classic vision families (LeNet, SqueezeNet, ResNet, MobileNet, ShuffleNet, GoogLeNet/Inception, ZFNet, AlexNet, DenseNet), plus one int8/QDQ model X2Paddle can't convert to exercise the non-gating baseline_unsupported verdict. baseline_seconds only balances shards; baseline_verdict records the last observed outcome so a change in convertibility stands out in review. See README.md.",
+  "models": [
+    {"id": "onnxmodelzoo/mnist-12", "baseline_seconds": 4.0, "baseline_verdict": "pass"},
+    {"id": "onnxmodelzoo/emotion-ferplus-8", "baseline_seconds": 4.0, "baseline_verdict": "pass"},
+    {"id": "onnxmodelzoo/squeezenet1.0-12", "baseline_seconds": 5.0, "baseline_verdict": "pass"},
+    {"id": "onnxmodelzoo/resnet18-v1-7", "baseline_seconds": 6.0, "baseline_verdict": "pass"},
+    {"id": "onnxmodelzoo/mobilenetv2-12", "baseline_seconds": 6.0, "baseline_verdict": "pass"},
+    {"id": "onnxmodelzoo/shufflenet-v2-12", "baseline_seconds": 6.0, "baseline_verdict": "pass"},
+    {"id": "onnxmodelzoo/googlenet-12", "baseline_seconds": 7.0, "baseline_verdict": "pass"},
+    {"id": "onnxmodelzoo/inception-v1-12", "baseline_seconds": 7.0, "baseline_verdict": "pass"},
+    {"id": "onnxmodelzoo/bvlcalexnet-12", "baseline_seconds": 8.0, "baseline_verdict": "pass"},
+    {"id": "onnxmodelzoo/zfnet512-12", "baseline_seconds": 8.0, "baseline_verdict": "pass"},
+    {"id": "onnxmodelzoo/resnet50-v1-12", "baseline_seconds": 10.0, "baseline_verdict": "pass"},
+    {"id": "onnxmodelzoo/resnet101-v1-7", "baseline_seconds": 14.0, "baseline_verdict": "pass"},
+    {"id": "onnxmodelzoo/densenet-12", "baseline_seconds": 16.0, "baseline_verdict": "pass"},
+    {"id": "onnxmodelzoo/mobilenetv2-12-int8", "baseline_seconds": 6.0, "baseline_verdict": "baseline_unsupported"}
+  ]
+}

--- a/scripts/regression/x2paddle/run_x2paddle_regression.py
+++ b/scripts/regression/x2paddle/run_x2paddle_regression.py
@@ -135,9 +135,10 @@ def main():
         red = (100 * (on - sn) / on) if on and sn is not None else 0
         bconv = r.get("baseline_conv_status")
         sconv = r.get("simp_conv_status")
+        slconv = r.get("slim_conv_status")
         print(
             f"{v} | onnxsim {r.get('onnxsim_status')} {on}->{sn} ({red:+.0f}%) | "
-            f"x2paddle base={bconv} simp={sconv}",
+            f"x2paddle base={bconv} simp={sconv} | onnxslim conv={slconv}",
             flush=True,
         )
         if v not in ("pass",):
@@ -171,6 +172,17 @@ def main():
         "simp_conv_seconds",
         "simp_peak_rss_mb",
         "simp_error",
+        "onnxslim_status",
+        "slim_nodes",
+        "slim_reduction_pct",
+        "onnxslim_seconds",
+        "onnxslim_peak_rss_mb",
+        "onnxslim_error",
+        "slim_conv_status",
+        "slim_conv_ops",
+        "slim_conv_seconds",
+        "slim_conv_peak_rss_mb",
+        "slim_conv_error",
         "orig_bytes",
         "error",
     ]
@@ -181,6 +193,10 @@ def main():
             on, sn = r.get("orig_nodes"), r.get("simp_nodes")
             r["reduction_pct"] = (
                 round(100 * (on - sn) / on, 1) if on and sn is not None else ""
+            )
+            sln = r.get("slim_nodes")
+            r["slim_reduction_pct"] = (
+                round(100 * (on - sln) / on, 1) if on and sln is not None else ""
             )
             so = r.get("skipped_optimizers")
             r["skipped_optimizers"] = (

--- a/scripts/regression/x2paddle/run_x2paddle_regression.py
+++ b/scripts/regression/x2paddle/run_x2paddle_regression.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Run the onnxsim -> X2Paddle downstream regression over a shard of the set.
+
+For each model (see ``models.json``) the worker converts the graph to
+PaddlePaddle twice -- once from the original ONNX and once after
+``onnxsim.simplify`` -- each conversion isolated in its own subprocess. onnxsim
+is X2Paddle's built-in optimize step, so this catches the case that matters
+most: an onnxsim change that X2Paddle could digest before but can't anymore.
+
+A model **fails** the regression when:
+
+* onnxsim itself crashes, times out, or produces a graph it can't validate
+  (``onnxsim_fail``); or
+* X2Paddle converts the original graph but **not** the onnxsim-simplified one
+  (``regression``) -- onnxsim broke a working downstream conversion.
+
+A model does **not** fail when X2Paddle can't convert the original either
+(``baseline_unsupported``): that's an X2Paddle limitation on that model, not an
+onnxsim regression. It's still recorded so the set's coverage is visible. The
+``improved`` verdict (original fails, simplified converts) is likewise recorded,
+not gated.
+
+Usage:
+    run_x2paddle_regression.py --shard 0 --num-shards 2 --output shard-0.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+MODELS_JSON = os.path.join(HERE, "models.json")
+DL_DIR = os.path.join(HERE, "dl")
+
+GATING_VERDICTS = ("onnxsim_fail", "regression")
+
+
+def load_models():
+    with open(MODELS_JSON) as f:
+        return json.load(f)["models"]
+
+
+def assign_shard(models, shard, num_shards):
+    """Longest-processing-time balancing on baseline duration, so shards keep
+    close wall-times even when per-model cost varies."""
+    buckets = [[] for _ in range(num_shards)]
+    loads = [0.0] * num_shards
+    for m in sorted(models, key=lambda m: -(m.get("baseline_seconds") or 0.0)):
+        i = min(range(num_shards), key=lambda i: loads[i])
+        buckets[i].append(m)
+        loads[i] += m.get("baseline_seconds") or 0.0
+    return buckets[shard]
+
+
+def run_one(model_id, per_step_timeout):
+    """Run one model through the worker in an isolated subprocess."""
+    backstop = None if per_step_timeout <= 0 else per_step_timeout * 3 + 600
+    proc = subprocess.run(
+        [
+            sys.executable,
+            os.path.join(HERE, "worker.py"),
+            model_id,
+            DL_DIR,
+            str(per_step_timeout),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=backstop,
+    )
+    result = None
+    for line in proc.stdout.splitlines():
+        if line.startswith("__RESULT__"):
+            result = json.loads(line[len("__RESULT__") :])
+    if result is None:
+        result = {
+            "model": model_id,
+            "status": "crash",
+            "verdict": "error",
+            "error": (proc.stderr or proc.stdout or "no result line")[-400:],
+        }
+    return result
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--shard", type=int, default=0)
+    ap.add_argument("--num-shards", type=int, default=1)
+    ap.add_argument(
+        "--timeout",
+        type=int,
+        default=900,
+        help="per-step wall-clock cap in seconds (onnxsim and each conversion "
+        "get this budget individually); <=0 disables",
+    )
+    ap.add_argument("--output", default="x2paddle-regression.csv")
+    args = ap.parse_args()
+
+    models = load_models()
+    selected = assign_shard(models, args.shard, args.num_shards)
+    print(
+        f"shard {args.shard}/{args.num_shards} | {len(selected)} models | "
+        f"timeout {args.timeout}s",
+        flush=True,
+    )
+    os.makedirs(DL_DIR, exist_ok=True)
+
+    rows = []
+    failures = []
+    for i, m in enumerate(selected, 1):
+        model_id = m["id"]
+        print(f"[{i}/{len(selected)}] {model_id} ...", end=" ", flush=True)
+        try:
+            r = run_one(model_id, args.timeout)
+        except subprocess.TimeoutExpired:
+            r = {
+                "model": model_id,
+                "status": "timeout",
+                "verdict": "onnxsim_fail",
+                "error": f">{args.timeout}s",
+            }
+        finally:
+            shutil.rmtree(
+                os.path.join(DL_DIR, model_id.replace("/", "__")), ignore_errors=True
+            )
+        rows.append(r)
+
+        v = r.get("verdict")
+        on, sn = r.get("orig_nodes"), r.get("simp_nodes")
+        red = (100 * (on - sn) / on) if on and sn is not None else 0
+        bconv = r.get("baseline_conv_status")
+        sconv = r.get("simp_conv_status")
+        print(
+            f"{v} | onnxsim {r.get('onnxsim_status')} {on}->{sn} ({red:+.0f}%) | "
+            f"x2paddle base={bconv} simp={sconv}",
+            flush=True,
+        )
+        if v not in ("pass",):
+            detail = r.get("simp_error") or r.get("baseline_error") or r.get("error")
+            if detail:
+                print(f"      {str(detail)[:160]}", flush=True)
+        if v in GATING_VERDICTS or r.get("status") == "error":
+            failures.append(
+                (model_id, v, str(r.get("simp_error") or r.get("error"))[:200])
+            )
+
+    fields = [
+        "model",
+        "verdict",
+        "status",
+        "orig_nodes",
+        "simp_nodes",
+        "reduction_pct",
+        "onnxsim_status",
+        "onnxsim_valid",
+        "onnxsim_seconds",
+        "skipped_optimizers",
+        "onnxsim_peak_rss_mb",
+        "baseline_conv_status",
+        "baseline_ops",
+        "baseline_conv_seconds",
+        "baseline_peak_rss_mb",
+        "baseline_error",
+        "simp_conv_status",
+        "simp_ops",
+        "simp_conv_seconds",
+        "simp_peak_rss_mb",
+        "simp_error",
+        "orig_bytes",
+        "error",
+    ]
+    with open(args.output, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+        w.writeheader()
+        for r in rows:
+            on, sn = r.get("orig_nodes"), r.get("simp_nodes")
+            r["reduction_pct"] = (
+                round(100 * (on - sn) / on, 1) if on and sn is not None else ""
+            )
+            so = r.get("skipped_optimizers")
+            r["skipped_optimizers"] = (
+                ",".join(so) if isinstance(so, list) else (so or "")
+            )
+            w.writerow(r)
+    print(f"\nwrote {args.output} ({len(rows)} rows)", flush=True)
+
+    if failures:
+        print(f"\n{len(failures)} FAILED:", flush=True)
+        for mid, v, err in failures:
+            print(f"  - {mid}: {v} {err}", flush=True)
+        return 1
+    print("\nall models passed (no onnxsim-caused X2Paddle regressions)", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/regression/x2paddle/run_x2paddle_regression.py
+++ b/scripts/regression/x2paddle/run_x2paddle_regression.py
@@ -38,7 +38,7 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 MODELS_JSON = os.path.join(HERE, "models.json")
 DL_DIR = os.path.join(HERE, "dl")
 
-GATING_VERDICTS = ("onnxsim_fail", "regression")
+GATING_VERDICTS = ("onnxsim_fail", "regression", "env_error")
 
 
 def load_models():

--- a/scripts/regression/x2paddle/summarize.py
+++ b/scripts/regression/x2paddle/summarize.py
@@ -4,8 +4,8 @@
 Writes a merged ``x2paddle-regression-report.csv`` and a Markdown summary to
 ``$GITHUB_STEP_SUMMARY`` (or stdout when run locally), plus a standalone
 ``x2paddle-regression-summary.md``. Exits non-zero if any model has a gating
-verdict (``onnxsim_fail`` or ``regression``), so the summary job reflects the
-overall result even though each shard already gates itself.
+verdict (``onnxsim_fail``, ``regression``, or ``env_error``), so the summary job
+reflects the overall result even though each shard already gates itself.
 
 Verdicts
 --------
@@ -13,6 +13,8 @@ pass                  onnxsim ok and X2Paddle converted the simplified graph.
 regression   (gates)  X2Paddle converted the original but not the simplified
                       graph -- onnxsim broke a working downstream conversion.
 onnxsim_fail (gates)  onnxsim crashed / timed out / failed its own check.
+env_error    (gates)  a conversion failed to import a Python dependency; the
+                      environment is broken, so results are meaningless.
 baseline_unsupported  X2Paddle can't convert the original either (its own
                       limitation on that model); not onnxsim's fault.
 improved              original failed, simplified converted (onnxsim unblocked
@@ -27,7 +29,7 @@ import os
 import statistics
 import sys
 
-GATING = ("onnxsim_fail", "regression")
+GATING = ("onnxsim_fail", "regression", "env_error")
 
 
 def _num(v):
@@ -210,6 +212,7 @@ def main(argv):
     passed = with_verdict("pass")
     regressions = with_verdict("regression")
     onnxsim_fails = with_verdict("onnxsim_fail")
+    env_errors = with_verdict("env_error")
     unsupported = with_verdict("baseline_unsupported")
     improved = with_verdict("improved")
     errored = [r for r in rows if r.get("verdict") in ("error", None, "")]
@@ -227,9 +230,28 @@ def main(argv):
     lines.append(
         f"**{len(passed)}/{len(rows)} models pass.** "
         f"{len(regressions)} regression(s), {len(onnxsim_fails)} onnxsim failure(s), "
+        f"{len(env_errors)} environment error(s), "
         f"{len(unsupported)} X2Paddle-unsupported (non-gating), "
         f"{len(improved)} improved, {len(errored)} harness error(s).\n"
     )
+
+    if env_errors:
+        lines.append(
+            "## ❌ Environment errors (missing dependency — results invalid)\n"
+        )
+        lines.append(
+            "A X2Paddle conversion failed to import a Python dependency, so the "
+            "environment is broken and these results mean nothing. Fix the install "
+            "(x2paddle has undeclared deps: six, requests) and re-run.\n"
+        )
+        lines.append("| model | error |")
+        lines.append("| --- | --- |")
+        for r in env_errors:
+            err = (r.get("baseline_error") or r.get("simp_error") or "").replace(
+                "|", "\\|"
+            )[:160]
+            lines.append(f"| {r['model']} | {err} |")
+        lines.append("")
 
     if regressions:
         lines.append(
@@ -331,6 +353,7 @@ def main(argv):
         "baseline_unsupported": "➖",
         "regression": "❌",
         "onnxsim_fail": "❌",
+        "env_error": "❌",
     }
     for r in rows:
         m = mark.get(r.get("verdict"), "❓")

--- a/scripts/regression/x2paddle/summarize.py
+++ b/scripts/regression/x2paddle/summarize.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Combine per-shard X2Paddle regression CSVs into a Markdown summary.
+
+Writes a merged ``x2paddle-regression-report.csv`` and a Markdown summary to
+``$GITHUB_STEP_SUMMARY`` (or stdout when run locally), plus a standalone
+``x2paddle-regression-summary.md``. Exits non-zero if any model has a gating
+verdict (``onnxsim_fail`` or ``regression``), so the summary job reflects the
+overall result even though each shard already gates itself.
+
+Verdicts
+--------
+pass                  onnxsim ok and X2Paddle converted the simplified graph.
+regression   (gates)  X2Paddle converted the original but not the simplified
+                      graph -- onnxsim broke a working downstream conversion.
+onnxsim_fail (gates)  onnxsim crashed / timed out / failed its own check.
+baseline_unsupported  X2Paddle can't convert the original either (its own
+                      limitation on that model); not onnxsim's fault.
+improved              original failed, simplified converted (onnxsim unblocked
+                      X2Paddle).
+"""
+
+from __future__ import annotations
+
+import csv
+import glob
+import os
+import statistics
+import sys
+
+GATING = ("onnxsim_fail", "regression")
+
+
+def _num(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _int(v):
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _median(xs):
+    return statistics.median(xs) if xs else None
+
+
+def main(argv):
+    csv_paths = []
+    for pat in argv[1:] or ["*.csv"]:
+        csv_paths.extend(sorted(glob.glob(pat)))
+    rows = []
+    for p in csv_paths:
+        if os.path.basename(p) in ("x2paddle-regression-report.csv",):
+            continue
+        with open(p, newline="") as f:
+            rows.extend(csv.DictReader(f))
+    rows.sort(key=lambda r: r["model"])
+
+    fields = [
+        "model",
+        "verdict",
+        "status",
+        "orig_nodes",
+        "simp_nodes",
+        "reduction_pct",
+        "onnxsim_status",
+        "onnxsim_valid",
+        "onnxsim_seconds",
+        "skipped_optimizers",
+        "baseline_conv_status",
+        "baseline_ops",
+        "baseline_conv_seconds",
+        "baseline_error",
+        "simp_conv_status",
+        "simp_ops",
+        "simp_conv_seconds",
+        "simp_error",
+        "error",
+    ]
+    with open("x2paddle-regression-report.csv", "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+        w.writeheader()
+        w.writerows(rows)
+
+    def with_verdict(v):
+        return [r for r in rows if r.get("verdict") == v]
+
+    passed = with_verdict("pass")
+    regressions = with_verdict("regression")
+    onnxsim_fails = with_verdict("onnxsim_fail")
+    unsupported = with_verdict("baseline_unsupported")
+    improved = with_verdict("improved")
+    errored = [r for r in rows if r.get("verdict") in ("error", None, "")]
+    skipped_any = [r for r in rows if r.get("skipped_optimizers")]
+    gating = [r for r in rows if r.get("verdict") in GATING] + errored
+
+    lines = []
+    lines.append("# onnxsim → X2Paddle downstream regression\n")
+    lines.append(
+        "onnxsim is X2Paddle's built-in ONNX optimize step, so this checks that "
+        "onnxsim doesn't break X2Paddle's ONNX→PaddlePaddle conversion. Each model "
+        "is converted twice — from the original graph and after `onnxsim.simplify` "
+        "— each conversion isolated in its own process.\n"
+    )
+    lines.append(
+        f"**{len(passed)}/{len(rows)} models pass.** "
+        f"{len(regressions)} regression(s), {len(onnxsim_fails)} onnxsim failure(s), "
+        f"{len(unsupported)} X2Paddle-unsupported (non-gating), "
+        f"{len(improved)} improved, {len(errored)} harness error(s).\n"
+    )
+
+    if regressions:
+        lines.append(
+            "## ❌ Regressions — onnxsim broke a working X2Paddle conversion\n"
+        )
+        lines.append("| model | orig nodes → simp | X2Paddle (base → simp) | error |")
+        lines.append("| --- | --- | --- | --- |")
+        for r in regressions:
+            err = (r.get("simp_error") or "").replace("|", "\\|")[:160]
+            lines.append(
+                f"| {r['model']} | {r.get('orig_nodes')}→{r.get('simp_nodes')} | "
+                f"{r.get('baseline_conv_status')}→{r.get('simp_conv_status')} | {err} |"
+            )
+        lines.append("")
+
+    if onnxsim_fails:
+        lines.append("## ❌ onnxsim failures (crash / timeout / unvalidated)\n")
+        lines.append("| model | onnxsim status | error |")
+        lines.append("| --- | --- | --- |")
+        for r in onnxsim_fails:
+            err = (r.get("error") or "").replace("|", "\\|")[:160]
+            lines.append(f"| {r['model']} | {r.get('onnxsim_status')} | {err} |")
+        lines.append("")
+
+    if errored:
+        lines.append("## ❌ Harness errors\n")
+        lines.append("| model | error |")
+        lines.append("| --- | --- |")
+        for r in errored:
+            err = (r.get("error") or "").replace("|", "\\|")[:160]
+            lines.append(f"| {r['model']} | {err} |")
+        lines.append("")
+
+    if skipped_any:
+        lines.append("## ⚠️ Optimizer passes skipped (would otherwise abort)\n")
+        lines.append("| model | skipped pass(es) |")
+        lines.append("| --- | --- |")
+        for r in skipped_any:
+            lines.append(f"| {r['model']} | {r['skipped_optimizers']} |")
+        lines.append("")
+
+    if unsupported:
+        lines.append("## X2Paddle-unsupported originals (non-gating)\n")
+        lines.append(
+            "X2Paddle can't convert these originals either, so onnxsim is "
+            "not implicated. Recorded for coverage.\n"
+        )
+        lines.append("| model | onnxsim | X2Paddle error (original) |")
+        lines.append("| --- | --- | --- |")
+        for r in unsupported:
+            err = (r.get("baseline_error") or "").replace("|", "\\|")[:160]
+            lines.append(
+                f"| {r['model']} | {r.get('onnxsim_status')} {r.get('orig_nodes')}→{r.get('simp_nodes')} | {err} |"
+            )
+        lines.append("")
+
+    if improved:
+        lines.append("## onnxsim unblocked X2Paddle (non-gating)\n")
+        lines.append("| model | X2Paddle (base → simp) |")
+        lines.append("| --- | --- |")
+        for r in improved:
+            lines.append(
+                f"| {r['model']} | {r.get('baseline_conv_status')}→{r.get('simp_conv_status')} |"
+            )
+        lines.append("")
+
+    # onnxsim node reduction over the models it simplified.
+    reds = [
+        _num(r.get("reduction_pct"))
+        for r in rows
+        if _num(r.get("reduction_pct")) is not None
+    ]
+    if reds:
+        lines.append("## onnxsim optimization on this set\n")
+        lines.append(
+            f"- median node reduction: **{_median(reds):.1f}%** "
+            f"over {len(reds)} simplified models."
+        )
+        secs = [
+            _num(r.get("onnxsim_seconds"))
+            for r in rows
+            if _num(r.get("onnxsim_seconds"))
+        ]
+        if secs:
+            lines.append(f"- median onnxsim time: {_median(secs):.1f}s.")
+        lines.append("")
+
+    lines.append("## All models\n")
+    lines.append(
+        "| model | verdict | onnxsim (orig→simp) | X2Paddle base | X2Paddle simp |"
+    )
+    lines.append("| --- | --- | --- | --- | --- |")
+    mark = {
+        "pass": "✅",
+        "improved": "✅",
+        "baseline_unsupported": "➖",
+        "regression": "❌",
+        "onnxsim_fail": "❌",
+    }
+    for r in rows:
+        m = mark.get(r.get("verdict"), "❓")
+        lines.append(
+            f"| {r['model']} | {m} {r.get('verdict')} | "
+            f"{r.get('orig_nodes')}→{r.get('simp_nodes')} ({r.get('onnxsim_status')}) | "
+            f"{r.get('baseline_conv_status')} ({r.get('baseline_ops')}) | "
+            f"{r.get('simp_conv_status')} ({r.get('simp_ops')}) |"
+        )
+    lines.append("")
+
+    text = "\n".join(lines)
+
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a") as f:
+            f.write(text)
+    with open("x2paddle-regression-summary.md", "w") as f:
+        f.write(text)
+
+    job_output = os.environ.get("GITHUB_OUTPUT")
+    if job_output:
+        with open(job_output, "a") as f:
+            f.write(f"status={'fail' if gating else 'pass'}\n")
+            f.write(f"gating_failures={len(gating)}\n")
+
+    print(text)
+    return 1 if gating else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/regression/x2paddle/summarize.py
+++ b/scripts/regression/x2paddle/summarize.py
@@ -48,6 +48,116 @@ def _median(xs):
     return statistics.median(xs) if xs else None
 
 
+def comparison_section(rows):
+    """onnxsim vs onnxslim, both as downstream inputs to X2Paddle.
+
+    Two axes, both comparison-only (onnxslim never gates this harness):
+      - X2Paddle-convertibility: over the models X2Paddle converted from the
+        original graph, how often each simplifier's output still converts. This
+        is the axis that matters here — a simplifier that reduces more nodes but
+        breaks X2Paddle is worse for this downstream, not better.
+      - Node reduction: median reduction each simplifier achieved, and where the
+        two diverge most.
+    Returns [] when no onnxslim data is present (older CSVs).
+    """
+    if not any(r.get("onnxslim_status") for r in rows):
+        return []
+
+    lines = ["## onnxsim vs onnxslim (comparison, non-gating)\n"]
+
+    # --- Robustness: does the simplified graph still convert? ---------------- #
+    order = ["ok", "unvalidated", "crash", "timeout", "error"]
+
+    def counts(key):
+        c = {k: 0 for k in order}
+        for r in rows:
+            s = (r.get(key) or "").strip()
+            if s in c:
+                c[s] += 1
+        return c
+
+    sim = counts("simp_conv_status")
+    slim = counts("slim_conv_status")
+    lines.append("### X2Paddle conversion of the simplified graph\n")
+    lines.append("| X2Paddle status | after onnxsim | after onnxslim |")
+    lines.append("| --- | --- | --- |")
+    for k in order:
+        if sim[k] or slim[k]:
+            lines.append(f"| {k} | {sim[k]} | {slim[k]} |")
+    lines.append("")
+
+    # Where the two simplifiers diverge on whether X2Paddle can convert the
+    # result, among models X2Paddle converted from the original.
+    ran = {"ok"}
+    divergent = []
+    for r in rows:
+        if (r.get("baseline_conv_status") or "") not in ran:
+            continue
+        s = (r.get("simp_conv_status") or "") in ran
+        sl = (r.get("slim_conv_status") or "") in ran
+        if s != sl:
+            divergent.append(r)
+    if divergent:
+        lines.append(
+            "Models where only one simplifier's graph still converts (baseline "
+            "converted):\n"
+        )
+        lines.append("| model | after onnxsim | after onnxslim |")
+        lines.append("| --- | --- | --- |")
+        for r in sorted(divergent, key=lambda r: r["model"]):
+            lines.append(
+                f"| {r['model']} | {r.get('simp_conv_status')} | "
+                f"{r.get('slim_conv_status')} |"
+            )
+        lines.append("")
+
+    # --- Optimization strength ---------------------------------------------- #
+    both = []
+    for r in rows:
+        on = _int(r.get("orig_nodes"))
+        sn = _int(r.get("simp_nodes"))
+        sln = _int(r.get("slim_nodes"))
+        if on and sn is not None and sln is not None:
+            both.append((r, on, sn, sln))
+    lines.append("### Node reduction\n")
+    if both:
+        sim_reds = [100 * (on - sn) / on for _, on, sn, _ in both]
+        slim_reds = [100 * (on - sln) / on for _, on, _, sln in both]
+        slim_fewer = sum(1 for _, _, sn, sln in both if sln < sn)
+        sim_fewer = sum(1 for _, _, sn, sln in both if sn < sln)
+        equal = sum(1 for _, _, sn, sln in both if sn == sln)
+        lines.append(f"Over the {len(both)} models both simplifiers processed:\n")
+        lines.append("| metric | onnxsim | onnxslim |")
+        lines.append("| --- | --- | --- |")
+        lines.append(
+            f"| median node reduction | {_median(sim_reds):.1f}% | "
+            f"{_median(slim_reds):.1f}% |"
+        )
+        lines.append("")
+        lines.append(
+            f"- onnxslim produced **fewer** nodes on {slim_fewer}, onnxsim fewer "
+            f"on {sim_fewer}, equal on {equal}."
+        )
+        lines.append("")
+        div = [
+            t for t in sorted(both, key=lambda t: -abs(t[2] - t[3])) if t[2] != t[3]
+        ][:15]
+        if div:
+            lines.append(
+                "Largest node-count divergences (orig → onnxsim / onnxslim):\n"
+            )
+            lines.append("| model | orig | onnxsim | onnxslim | fewer |")
+            lines.append("| --- | --- | --- | --- | --- |")
+            for r, on, sn, sln in div:
+                fewer = "onnxslim" if sln < sn else "onnxsim"
+                lines.append(f"| {r['model']} | {on} | {sn} | {sln} | {fewer} |")
+            lines.append("")
+    else:
+        lines.append("_No model was processed by both simplifiers._\n")
+
+    return lines
+
+
 def main(argv):
     csv_paths = []
     for pat in argv[1:] or ["*.csv"]:
@@ -79,6 +189,14 @@ def main(argv):
         "simp_ops",
         "simp_conv_seconds",
         "simp_error",
+        "onnxslim_status",
+        "slim_nodes",
+        "slim_reduction_pct",
+        "onnxslim_seconds",
+        "slim_conv_status",
+        "slim_conv_ops",
+        "slim_conv_seconds",
+        "slim_conv_error",
         "error",
     ]
     with open("x2paddle-regression-report.csv", "w", newline="") as f:
@@ -199,11 +317,14 @@ def main(argv):
             lines.append(f"- median onnxsim time: {_median(secs):.1f}s.")
         lines.append("")
 
+    lines.extend(comparison_section(rows))
+
     lines.append("## All models\n")
     lines.append(
-        "| model | verdict | onnxsim (orig→simp) | X2Paddle base | X2Paddle simp |"
+        "| model | verdict | onnxsim (orig→simp) | X2Paddle base | X2Paddle simp | "
+        "onnxslim (orig→slim) | X2Paddle slim |"
     )
-    lines.append("| --- | --- | --- | --- | --- |")
+    lines.append("| --- | --- | --- | --- | --- | --- | --- |")
     mark = {
         "pass": "✅",
         "improved": "✅",
@@ -217,7 +338,9 @@ def main(argv):
             f"| {r['model']} | {m} {r.get('verdict')} | "
             f"{r.get('orig_nodes')}→{r.get('simp_nodes')} ({r.get('onnxsim_status')}) | "
             f"{r.get('baseline_conv_status')} ({r.get('baseline_ops')}) | "
-            f"{r.get('simp_conv_status')} ({r.get('simp_ops')}) |"
+            f"{r.get('simp_conv_status')} ({r.get('simp_ops')}) | "
+            f"{r.get('orig_nodes')}→{r.get('slim_nodes')} ({r.get('onnxslim_status')}) | "
+            f"{r.get('slim_conv_status')} ({r.get('slim_conv_ops')}) |"
         )
     lines.append("")
 

--- a/scripts/regression/x2paddle/worker.py
+++ b/scripts/regression/x2paddle/worker.py
@@ -239,14 +239,28 @@ def run_step(args, timeout):
     }
 
 
+def _is_env_error(step):
+    """True if a step failed because a Python dependency is missing, i.e. a
+    broken environment rather than anything about the model. x2paddle has
+    undeclared runtime deps (six, requests) that its conversion path imports, so
+    a clean install can hit ImportError here. We must NOT let that masquerade as
+    baseline_unsupported (which is non-gating) -- a missing dep makes *every*
+    model's baseline crash and would turn the whole run silently green."""
+    err = step.get("error") or ""
+    return "ModuleNotFoundError" in err or "ImportError" in err
+
+
 def verdict(onnxsim, baseline, simp):
-    """Classify one model from its three step results.
+    """Classify one model from its step results.
 
     Gating verdicts (fail the regression):
       onnxsim_fail -- onnxsim crashed, timed out, or failed its own check.
       regression   -- X2Paddle converted the original but NOT the
                       onnxsim-simplified graph: onnxsim broke a working
                       downstream conversion.
+      env_error    -- a conversion failed on a missing Python dependency; the
+                      environment is broken, so results are meaningless. Gated
+                      loudly rather than passed off as baseline_unsupported.
     Non-gating verdicts:
       pass                  -- onnxsim ok and the simplified graph converts.
       baseline_unsupported  -- X2Paddle can't convert the original either;
@@ -256,6 +270,8 @@ def verdict(onnxsim, baseline, simp):
     """
     if onnxsim.get("status") not in ("ok",):
         return "onnxsim_fail"
+    if _is_env_error(baseline) or _is_env_error(simp or {}):
+        return "env_error"
     base_ok = baseline.get("status") == "ok"
     simp_ok = (simp or {}).get("status") == "ok"
     if base_ok and simp_ok:

--- a/scripts/regression/x2paddle/worker.py
+++ b/scripts/regression/x2paddle/worker.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Convert one ONNX model to PaddlePaddle with X2Paddle, twice, and compare.
+
+Why this exists
+---------------
+`onnxsim` is not just a peer of X2Paddle -- it is a dependency *inside* it.
+X2Paddle's ONNX front-end (`x2paddle.convert.onnx2paddle`, the default
+`enable_optim=True` path) runs ``onnxsim.simplify`` on the graph before handing
+it to the op-mapper. So an onnxsim regression can break X2Paddle conversions
+directly: a crash, or a graph onnxsim rewrites into something the op-mapper can
+no longer translate.
+
+This worker measures exactly that. For one model it runs two arms:
+
+* **baseline** -- the *original* ONNX graph straight into X2Paddle's
+  decoder -> op-mapper -> optimizer -> ``gen_model`` (onnxsim OFF).
+* **onnxsim** -- ``onnxsim.simplify`` first, then the *simplified* graph
+  through the same X2Paddle stages.
+
+The regression signal is the difference between the arms: if X2Paddle converts
+the original but *fails* on the onnxsim-simplified graph, onnxsim introduced a
+downstream regression. If X2Paddle can't convert the original either, that's an
+X2Paddle limitation on that model (an unsupported op, say) and onnxsim is not to
+blame -- recorded, but not a failure.
+
+Isolation model
+---------------
+Every heavy step runs in its own child subprocess with its own wall-clock
+timeout (``--onnxsim`` / ``--convert``), for two reasons:
+
+1. onnxsim's optimizer passes are C++ and some still *abort* on odd graphs; a
+   segfault/abort/hang in one step is contained and reported as that step's
+   failure instead of taking the model (or the other arm) down.
+2. **Paddle's parameter registry is process-global.** Converting two graphs in
+   one interpreter makes the second collide with the first
+   (``parameter name [...] have be been used``). Separate processes are the only
+   clean way to convert both arms of the same model.
+
+If onnxsim raises a C++ assertion from a specific optimizer pass, that pass is
+detected from the message, added to ``skipped_optimizers``, and simplification
+is retried -- so a newly-fragile pass shows up in the summary (matching the
+main onnxmodelzoo regression's behaviour).
+
+Environment note
+----------------
+X2Paddle 1.6.0 targets ONNX opset <= 15 and needs an ONNX build that still ships
+``onnx.mapping`` (i.e. ``onnx<1.16``); its own ``onnx2paddle`` entry point also
+mis-detects ``onnx>=1.16`` as "onnx not installed". This worker therefore drives
+X2Paddle's conversion stages directly rather than through ``onnx2paddle``, which
+both dodges that version gate and lets us turn onnxsim on/off per arm.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import resource
+import shutil
+import subprocess
+import sys
+import time
+import traceback
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def dir_size(path):
+    total = 0
+    for root, _, files in os.walk(path):
+        for f in files:
+            try:
+                total += os.path.getsize(os.path.join(root, f))
+            except OSError:
+                pass
+    return total
+
+
+def peak_rss_mb():
+    # ru_maxrss is kilobytes on Linux; report MiB.
+    return round(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0, 1)
+
+
+# --------------------------------------------------------------------------- #
+# Child: onnxsim step. Simplify <in> -> <out>, print __STEPRESULT__<json>.
+# --------------------------------------------------------------------------- #
+def child_onnxsim(in_path, out_path):
+    res = {
+        "step": "onnxsim",
+        "status": "error",
+        "error": None,
+        "simp_nodes": None,
+        "valid": None,
+        "skipped_optimizers": [],
+        "seconds": None,
+        "peak_rss_mb": None,
+    }
+    t0 = time.time()
+    try:
+        import onnx
+
+        from onnxsim import simplify
+
+        model = onnx.load(in_path)
+        skipped = []
+        while True:
+            try:
+                model_simp, check = simplify(model, skipped_optimizers=skipped or None)
+                break
+            except RuntimeError as e:
+                m = re.search(r"passes/([A-Za-z0-9_]+)\.h", str(e))
+                if not m or m.group(1) in skipped:
+                    raise
+                skipped.append(m.group(1))
+        onnx.save(model_simp, out_path)
+        res["simp_nodes"] = len(model_simp.graph.node)
+        res["valid"] = bool(check)
+        res["skipped_optimizers"] = skipped
+        res["status"] = "ok" if check else "unvalidated"
+    except Exception as e:
+        res["status"] = "crash"
+        res["error"] = f"{type(e).__name__}: {e}"
+        res["trace"] = traceback.format_exc()[-600:]
+    finally:
+        res["seconds"] = round(time.time() - t0, 1)
+        res["peak_rss_mb"] = peak_rss_mb()
+    print("__STEPRESULT__" + json.dumps(res))
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Child: X2Paddle conversion of one graph. Drives the same stages that
+# x2paddle.convert.onnx2paddle runs after its (broken-on-new-onnx) version gate.
+# --------------------------------------------------------------------------- #
+def child_convert(arm, onnx_path, save_dir):
+    res = {
+        "step": "convert",
+        "arm": arm,
+        "status": "error",
+        "error": None,
+        "paddle_ops": None,
+        "produced_model": False,
+        "seconds": None,
+        "peak_rss_mb": None,
+    }
+    t0 = time.time()
+    try:
+        import warnings
+
+        warnings.filterwarnings("ignore")
+
+        from x2paddle.decoder.onnx_decoder import ONNXDecoder
+        from x2paddle.op_mapper.onnx2paddle.onnx_op_mapper import ONNXOpMapper
+        from x2paddle.optimizer.optimizer import GraphOptimizer
+
+        decoder = ONNXDecoder(onnx_path, enable_onnx_checker=True)
+        mapper = ONNXOpMapper(decoder)
+        mapper.paddle_graph.build()
+        res["paddle_ops"] = len(mapper.paddle_graph.layers)
+        GraphOptimizer(source_frame="onnx").optimize(mapper.paddle_graph)
+        mapper.paddle_graph.gen_model(save_dir)
+        res["produced_model"] = os.path.isdir(os.path.join(save_dir, "inference_model"))
+        res["status"] = "ok" if res["produced_model"] else "unvalidated"
+    except Exception as e:
+        res["status"] = "crash"
+        res["error"] = f"{type(e).__name__}: {e}"
+        res["trace"] = traceback.format_exc()[-600:]
+    finally:
+        res["seconds"] = round(time.time() - t0, 1)
+        res["peak_rss_mb"] = peak_rss_mb()
+    print("__STEPRESULT__" + json.dumps(res))
+    return 0
+
+
+def run_step(args, timeout):
+    """Run one child step, returning its parsed result (never raises)."""
+    t0 = time.time()
+    try:
+        proc = subprocess.run(
+            [sys.executable, os.path.join(HERE, "worker.py"), *args],
+            capture_output=True,
+            text=True,
+            timeout=None if timeout <= 0 else timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "status": "timeout",
+            "error": f">{timeout}s",
+            "seconds": float(timeout),
+            "peak_rss_mb": None,
+        }
+    for line in proc.stdout.splitlines():
+        if line.startswith("__STEPRESULT__"):
+            return json.loads(line[len("__STEPRESULT__") :])
+    # No result line: the child died before it could report (segfault, OOM, ...).
+    return {
+        "status": "crash",
+        "error": (proc.stderr or proc.stdout or "no step result line")[-300:],
+        "seconds": round(time.time() - t0, 1),
+        "peak_rss_mb": None,
+    }
+
+
+def verdict(onnxsim, baseline, simp):
+    """Classify one model from its three step results.
+
+    Gating verdicts (fail the regression):
+      onnxsim_fail -- onnxsim crashed, timed out, or failed its own check.
+      regression   -- X2Paddle converted the original but NOT the
+                      onnxsim-simplified graph: onnxsim broke a working
+                      downstream conversion.
+    Non-gating verdicts:
+      pass                  -- onnxsim ok and the simplified graph converts.
+      baseline_unsupported  -- X2Paddle can't convert the original either;
+                               onnxsim is not implicated.
+      improved              -- original failed, simplified converts (onnxsim
+                               actually unblocked X2Paddle).
+    """
+    if onnxsim.get("status") not in ("ok",):
+        return "onnxsim_fail"
+    base_ok = baseline.get("status") == "ok"
+    simp_ok = (simp or {}).get("status") == "ok"
+    if base_ok and simp_ok:
+        return "pass"
+    if base_ok and not simp_ok:
+        return "regression"
+    if not base_ok and simp_ok:
+        return "improved"
+    return "baseline_unsupported"
+
+
+# --------------------------------------------------------------------------- #
+# Orchestrator: download once, run onnxsim + both conversions in child procs.
+# --------------------------------------------------------------------------- #
+def orchestrate(model_id, dl_dir, per_step_timeout):
+    res = {
+        "model": model_id,
+        "status": "error",
+        "verdict": "error",
+        "error": None,
+        "orig_nodes": None,
+        "orig_bytes": None,
+        # onnxsim arm
+        "onnxsim_status": None,
+        "simp_nodes": None,
+        "onnxsim_valid": None,
+        "onnxsim_seconds": None,
+        "skipped_optimizers": [],
+        "onnxsim_peak_rss_mb": None,
+        # baseline conversion (original graph -> X2Paddle)
+        "baseline_conv_status": None,
+        "baseline_ops": None,
+        "baseline_conv_seconds": None,
+        "baseline_peak_rss_mb": None,
+        "baseline_error": None,
+        # onnxsim-arm conversion (simplified graph -> X2Paddle)
+        "simp_conv_status": None,
+        "simp_ops": None,
+        "simp_conv_seconds": None,
+        "simp_peak_rss_mb": None,
+        "simp_error": None,
+    }
+    local = os.path.join(dl_dir, model_id.replace("/", "__"))
+    save_root = local + "__pd"
+    try:
+        import onnx
+        from huggingface_hub import snapshot_download
+
+        path = snapshot_download(
+            repo_id=model_id,
+            local_dir=local,
+            allow_patterns=[
+                "*.onnx",
+                "*.onnx_data",
+                "*.onnx.data",
+                "*.data",
+                "*.pb",
+                "*.bin",
+                "*.weight",
+                "*.weights",
+            ],
+        )
+        onnx_files = [
+            os.path.join(r, f)
+            for r, _, fs in os.walk(path)
+            for f in fs
+            if f.endswith(".onnx")
+        ]
+        if not onnx_files:
+            res["error"] = "no .onnx file in repo"
+            return res
+        onnx_path = max(onnx_files, key=os.path.getsize)
+        res["orig_bytes"] = dir_size(path)
+        res["orig_nodes"] = len(onnx.load(onnx_path).graph.node)
+
+        simp_path = onnx_path[:-5] + ".onnxsim.onnx"
+        onnxsim = run_step(["--onnxsim", onnx_path, simp_path], per_step_timeout)
+        res["onnxsim_status"] = onnxsim.get("status")
+        res["simp_nodes"] = onnxsim.get("simp_nodes")
+        res["onnxsim_valid"] = onnxsim.get("valid")
+        res["onnxsim_seconds"] = onnxsim.get("seconds")
+        res["skipped_optimizers"] = onnxsim.get("skipped_optimizers", []) or []
+        res["onnxsim_peak_rss_mb"] = onnxsim.get("peak_rss_mb")
+        res["error"] = onnxsim.get("error")
+
+        baseline = run_step(
+            ["--convert", "baseline", onnx_path, save_root + "_base"], per_step_timeout
+        )
+        res["baseline_conv_status"] = baseline.get("status")
+        res["baseline_ops"] = baseline.get("paddle_ops")
+        res["baseline_conv_seconds"] = baseline.get("seconds")
+        res["baseline_peak_rss_mb"] = baseline.get("peak_rss_mb")
+        res["baseline_error"] = baseline.get("error")
+
+        simp = None
+        if onnxsim.get("status") == "ok" and os.path.exists(simp_path):
+            simp = run_step(
+                ["--convert", "onnxsim", simp_path, save_root + "_simp"],
+                per_step_timeout,
+            )
+            res["simp_conv_status"] = simp.get("status")
+            res["simp_ops"] = simp.get("paddle_ops")
+            res["simp_conv_seconds"] = simp.get("seconds")
+            res["simp_peak_rss_mb"] = simp.get("peak_rss_mb")
+            res["simp_error"] = simp.get("error")
+
+        res["verdict"] = verdict(onnxsim, baseline, simp)
+        res["status"] = (
+            "ok"
+            if res["verdict"] in ("pass", "baseline_unsupported", "improved")
+            else "fail"
+        )
+    except Exception as e:
+        res["status"] = "error"
+        res["verdict"] = "error"
+        res["error"] = f"{type(e).__name__}: {e}"
+        res["trace"] = traceback.format_exc()[-800:]
+    finally:
+        shutil.rmtree(local, ignore_errors=True)
+        shutil.rmtree(save_root + "_base", ignore_errors=True)
+        shutil.rmtree(save_root + "_simp", ignore_errors=True)
+    return res
+
+
+if __name__ == "__main__":
+    if len(sys.argv) >= 4 and sys.argv[1] == "--onnxsim":
+        sys.exit(child_onnxsim(sys.argv[2], sys.argv[3]))
+    if len(sys.argv) >= 5 and sys.argv[1] == "--convert":
+        sys.exit(child_convert(sys.argv[2], sys.argv[3], sys.argv[4]))
+
+    model_id = sys.argv[1]
+    dl_dir = sys.argv[2] if len(sys.argv) > 2 else os.path.join(HERE, "dl")
+    per_step_timeout = int(sys.argv[3]) if len(sys.argv) > 3 else 0
+    out = orchestrate(model_id, dl_dir, per_step_timeout)
+    print("__RESULT__" + json.dumps(out))

--- a/scripts/regression/x2paddle/worker.py
+++ b/scripts/regression/x2paddle/worker.py
@@ -129,6 +129,44 @@ def child_onnxsim(in_path, out_path):
 
 
 # --------------------------------------------------------------------------- #
+# Child: onnxslim step (comparison arm). Slim <in> -> <out>, print
+# __STEPRESULT__<json>. onnxslim is measured on the same graphs purely for
+# comparison and never gates the run, matching the onnxmodelzoo sweep.
+# --------------------------------------------------------------------------- #
+def child_onnxslim(in_path, out_path):
+    res = {
+        "step": "onnxslim",
+        "status": "error",
+        "error": None,
+        "simp_nodes": None,
+        "seconds": None,
+        "peak_rss_mb": None,
+    }
+    t0 = time.time()
+    try:
+        import onnx
+        import onnxslim
+
+        # Optimize pass only (robustness + node reduction). slim() mutates its
+        # input in place, so it gets a freshly loaded model. We don't run
+        # onnxslim's own equivalence check here: the comparison axis is whether
+        # X2Paddle can convert the slimmed graph, plus node reduction.
+        model_simp = onnxslim.slim(onnx.load(in_path))
+        onnx.save(model_simp, out_path)
+        res["simp_nodes"] = len(model_simp.graph.node)
+        res["status"] = "ok"
+    except Exception as e:
+        res["status"] = "crash"
+        res["error"] = f"{type(e).__name__}: {e}"
+        res["trace"] = traceback.format_exc()[-600:]
+    finally:
+        res["seconds"] = round(time.time() - t0, 1)
+        res["peak_rss_mb"] = peak_rss_mb()
+    print("__STEPRESULT__" + json.dumps(res))
+    return 0
+
+
+# --------------------------------------------------------------------------- #
 # Child: X2Paddle conversion of one graph. Drives the same stages that
 # x2paddle.convert.onnx2paddle runs after its (broken-on-new-onnx) version gate.
 # --------------------------------------------------------------------------- #
@@ -259,6 +297,17 @@ def orchestrate(model_id, dl_dir, per_step_timeout):
         "simp_conv_seconds": None,
         "simp_peak_rss_mb": None,
         "simp_error": None,
+        # onnxslim comparison arm (never gates): slim the graph, then convert it
+        "onnxslim_status": None,
+        "slim_nodes": None,
+        "onnxslim_seconds": None,
+        "onnxslim_peak_rss_mb": None,
+        "onnxslim_error": None,
+        "slim_conv_status": None,
+        "slim_conv_ops": None,
+        "slim_conv_seconds": None,
+        "slim_conv_peak_rss_mb": None,
+        "slim_conv_error": None,
     }
     local = os.path.join(dl_dir, model_id.replace("/", "__"))
     save_root = local + "__pd"
@@ -324,6 +373,26 @@ def orchestrate(model_id, dl_dir, per_step_timeout):
             res["simp_peak_rss_mb"] = simp.get("peak_rss_mb")
             res["simp_error"] = simp.get("error")
 
+        # onnxslim comparison arm: slim the same graph and convert it. Measured
+        # side by side with onnxsim (robustness + node reduction) but never gates.
+        slim_path = onnx_path[:-5] + ".onnxslim.onnx"
+        onnxslim = run_step(["--onnxslim", onnx_path, slim_path], per_step_timeout)
+        res["onnxslim_status"] = onnxslim.get("status")
+        res["slim_nodes"] = onnxslim.get("simp_nodes")
+        res["onnxslim_seconds"] = onnxslim.get("seconds")
+        res["onnxslim_peak_rss_mb"] = onnxslim.get("peak_rss_mb")
+        res["onnxslim_error"] = onnxslim.get("error")
+        if onnxslim.get("status") == "ok" and os.path.exists(slim_path):
+            slim_conv = run_step(
+                ["--convert", "onnxslim", slim_path, save_root + "_slim"],
+                per_step_timeout,
+            )
+            res["slim_conv_status"] = slim_conv.get("status")
+            res["slim_conv_ops"] = slim_conv.get("paddle_ops")
+            res["slim_conv_seconds"] = slim_conv.get("seconds")
+            res["slim_conv_peak_rss_mb"] = slim_conv.get("peak_rss_mb")
+            res["slim_conv_error"] = slim_conv.get("error")
+
         res["verdict"] = verdict(onnxsim, baseline, simp)
         res["status"] = (
             "ok"
@@ -339,12 +408,15 @@ def orchestrate(model_id, dl_dir, per_step_timeout):
         shutil.rmtree(local, ignore_errors=True)
         shutil.rmtree(save_root + "_base", ignore_errors=True)
         shutil.rmtree(save_root + "_simp", ignore_errors=True)
+        shutil.rmtree(save_root + "_slim", ignore_errors=True)
     return res
 
 
 if __name__ == "__main__":
     if len(sys.argv) >= 4 and sys.argv[1] == "--onnxsim":
         sys.exit(child_onnxsim(sys.argv[2], sys.argv[3]))
+    if len(sys.argv) >= 4 and sys.argv[1] == "--onnxslim":
+        sys.exit(child_onnxslim(sys.argv[2], sys.argv[3]))
     if len(sys.argv) >= 5 and sys.argv[1] == "--convert":
         sys.exit(child_convert(sys.argv[2], sys.argv[3], sys.argv[4]))
 


### PR DESCRIPTION
## Summary

Adds a comprehensive regression testing harness to detect when onnxsim changes break X2Paddle's ONNX-to-PaddlePaddle conversion pipeline. Since onnxsim is a built-in dependency of X2Paddle (run during the default conversion), this harness measures the critical downstream impact: whether onnxsim-simplified graphs can still be converted by X2Paddle when the originals could be.

## Key Changes

- **`worker.py`**: Core regression worker that:
  - Runs two isolated conversion arms per model (baseline original graph vs. onnxsim-simplified graph)
  - Each step (onnxsim, X2Paddle conversion) runs in its own subprocess with independent timeout to contain crashes and avoid Paddle's process-global parameter registry collisions
  - Drives X2Paddle's conversion stages directly (decoder → op-mapper → optimizer → gen_model) rather than through the entry point, which allows toggling onnxsim per-arm and avoids version-gating issues with onnx>=1.16
  - Detects and retries around fragile onnxsim optimizer passes that raise C++ assertions

- **`run_x2paddle_regression.py`**: Orchestration script that:
  - Loads model set from `models.json` and assigns to shards using longest-processing-time balancing
  - Runs each model through the worker and collects results into CSV
  - Reports gating failures (regressions and onnxsim failures) with detailed error messages

- **`summarize.py`**: Report aggregation that:
  - Merges per-shard CSVs into a unified report
  - Generates Markdown summary with verdict breakdowns (pass, regression, onnxsim_fail, baseline_unsupported, improved)
  - Highlights regressions and failures with model details
  - Computes onnxsim optimization metrics (median node reduction, timing)
  - Exits non-zero if any gating failures detected

- **`.github/workflows/x2paddle-regression.yml`**: GitHub Actions workflow that:
  - Builds onnxsim wheel from current tree (cp311 for X2Paddle 1.6.0 compatibility)
  - Runs regression across configurable number of parallel shards
  - Aggregates results and posts summary to job output
  - Scheduled weekly and on-demand, validates harness on PR changes

- **`models.json`**: Curated set of ~15 ONNX models (opset ≤15) from Hugging Face onnxmodelzoo org covering classic vision architectures (LeNet, ResNet, MobileNet, etc.)

- **`README.md`**: Documentation explaining the regression model, verdicts, and local usage

## Notable Implementation Details

- **Isolation model**: Subprocess-per-step design is essential because (1) onnxsim's C++ optimizer passes can abort on odd graphs, and (2) Paddle's parameter registry is process-global, making in-process dual conversions impossible
- **Verdict classification**: Only `regression` (baseline converts but simplified doesn't) and `onnxsim_fail` gate the run; `baseline_unsupported` (X2Paddle limitation) is recorded but non-gating
- **Optimizer pass resilience**: When onnxsim raises C++ assertions, the worker extracts the pass name from the error message, adds it to `skipped_optimizers`, and retries—matching the onnxmodelzoo sweep's behavior
- **X2Paddle version compatibility**: Directly calls X2Paddle's conversion stages rather than the `onnx2paddle` entry point, which avoids the broken version gate on onnx>=1.16 and allows per-arm onnxsim control

https://claude.ai/code/session_013hwxnVYBDrEnWGKRefQvBA