### PR TITLE
Add ultralytics ONNX export regression test (onnxsim vs onnxslim)

### DIFF
--- a/scripts/regression/RESULTS_ultralytics.md
+++ b/scripts/regression/RESULTS_ultralytics.md
@@ -1,0 +1,75 @@
+# ultralytics: onnxsim vs onnxslim (ONNX export regression)
+
+Tests whether **onnxsim** can replace **onnxslim** at the one place ultralytics
+uses it — the ONNX export "simplify" step in
+[`ultralytics/engine/exporter.py`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/exporter.py):
+
+```python
+# ultralytics export_onnx(), simplify=True path
+import onnxslim
+model_onnx = onnxslim.slim(model_onnx)          # incumbent
+# candidate:
+# import onnxsim
+# model_onnx, ok = onnxsim.simplify(model_onnx)
+```
+
+`scripts/regression/ultralytics_export_compare.py` exports each YOLO task to a
+raw (un-simplified) ONNX graph, then runs **both** simplifiers on that identical
+graph and compares node count, ONNX Runtime validity, and numerical parity
+(max abs diff of every output vs the raw export on a fixed random input).
+
+## Environment
+
+| package | version |
+| --- | --- |
+| ultralytics | 8.4.112 |
+| onnxsim | 0.7.0 |
+| onnxslim | 0.1.94 |
+| onnx | 1.22.0 |
+| onnxruntime | 1.28.0 |
+| torch | 2.13.0+cpu (torchvision 0.28.0+cpu) |
+| opset | 20 |
+
+## Results
+
+Models: `yolo11n` across all five tasks, plus a dynamic-axes detect export
+(`dynamic=True`) to stress dynamic-shape passes. `raw` = node count of the
+un-simplified export; `parity` = max abs output diff vs that raw graph.
+
+| model (task) | raw | onnxsim nodes | onnxsim s | onnxsim parity | onnxslim nodes | onnxslim s | onnxslim parity |
+| --- | --: | --: | --: | --: | --: | --: | --: |
+| yolo11n (detect) | 355 | **320** | 0.64 | 0.0 | 320 | 1.07 | 0.0 |
+| yolo11n-seg (segment) | 393 | **355** | 0.58 | 0.0 | 355 | 0.60 | 0.0 |
+| yolo11n-cls (classify) | 153 | **144** | 0.29 | 0.0 | 144 | 0.20 | 0.0 |
+| yolo11n-pose (pose) | 405 | **354** | 0.63 | 0.0 | 354 | 0.66 | 0.0 |
+| yolo11n-obb (obb) | 385 | **356** | 0.33 | 0.0 | 356 | 0.77 | 0.0 |
+| yolo11n (detect, dynamic) | 575 | **419** | 0.70 | 0.0 | 419 | 1.87 | 0.0 |
+
+**Result: onnxsim is a clean drop-in for onnxslim on every tested model.** For
+all six configurations the two simplifiers land the **exact same node count**,
+both graphs load and run in ONNX Runtime, and both reproduce the raw export's
+outputs to the bit (parity `0.0`). onnxsim's own `check_ok` equivalence check
+passed in every case. onnxsim was also faster in aggregate (~3.2s vs ~5.2s
+total), with the largest gap on the dynamic-shape export (0.70s vs 1.87s) —
+historically the case that stressed onnxsim's C++ passes.
+
+## Reproduce
+
+```bash
+pip install ultralytics onnxsim onnxslim onnxruntime "onnx>=1.12,<2"
+python scripts/regression/ultralytics_export_compare.py --dynamic-detect
+```
+
+Weights auto-download from the ultralytics GitHub release assets. Exit code is
+non-zero if onnxsim fails to produce a valid, numerically-matching graph for any
+model.
+
+## Notes
+
+- One environment snag, unrelated to either simplifier: a CPU-only `torch`
+  paired with a non-`+cpu` `torchvision` wheel makes `yolo11n-cls.pt` fail to
+  load with `operator torchvision::nms does not exist`. Installing the matching
+  `torchvision==<ver>+cpu` build fixes it; classify then exports and passes.
+- The dynamic-detect input must use a real spatial size (the harness feeds
+  640×640); a degenerate 1×1 map breaks the detector's own concat before any
+  simplifier runs.

--- a/scripts/regression/ultralytics_export_compare.py
+++ b/scripts/regression/ultralytics_export_compare.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Regression: can onnxsim replace onnxslim in ultralytics' ONNX export?
+
+ultralytics (``ultralytics/engine/exporter.py``) exports a YOLO model to ONNX
+and then, when ``simplify=True``, slims the graph with::
+
+    model_onnx = onnxslim.slim(model_onnx)
+
+This script tests swapping that call for onnxsim::
+
+    model_onnx, ok = onnxsim.simplify(model_onnx)
+
+For each YOLO task it exports the *raw* ONNX graph once (``simplify=False``),
+then runs BOTH simplifiers on that identical graph and compares:
+
+* status  - did the simplifier run without raising?
+* nodes   - node count before / after (optimization strength)
+* valid   - does the simplified graph load + run in onnxruntime?
+* parity  - max abs diff of every output vs the raw graph on a fixed random
+            input (correctness of the simplification)
+
+onnxslim is the incumbent baseline; onnxsim is the candidate. A task "passes"
+for onnxsim when it produces a graph that is valid and numerically matches the
+raw export within tolerance, i.e. onnxsim is at least as safe a drop-in as the
+onnxslim the exporter ships today.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+import traceback
+
+import numpy as np
+import onnx
+
+DEFAULT_MODELS = [
+    "yolo11n.pt",       # detect
+    "yolo11n-seg.pt",   # segment
+    "yolo11n-cls.pt",   # classify
+    "yolo11n-pose.pt",  # pose
+    "yolo11n-obb.pt",   # oriented bounding boxes
+]
+
+# numeric parity tolerance for raw-vs-simplified outputs
+RTOL = 1e-3
+ATOL = 1e-4
+
+
+def _node_count(model: onnx.ModelProto) -> int:
+    return len(model.graph.node)
+
+
+def _run(model: onnx.ModelProto, feeds: dict[str, np.ndarray]):
+    """Run a model in onnxruntime and return the list of output arrays."""
+    import onnxruntime as ort
+
+    so = ort.SessionOptions()
+    so.log_severity_level = 3
+    sess = ort.InferenceSession(
+        model.SerializeToString(), so, providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _feeds(model: onnx.ModelProto, spatial: int = 640) -> dict[str, np.ndarray]:
+    """Build a deterministic random input matching the model's input shapes.
+
+    Dynamic axes have no fixed size, so we pick concrete ones: axis 0 (batch)
+    -> 1, and any other dynamic axis -> ``spatial`` (a stride-32-aligned size
+    the detector's downsampling path is valid for; feeding 1 there produces a
+    degenerate 1x1 map that breaks the network before any simplifier runs).
+    """
+    rng = np.random.default_rng(0)
+    feeds = {}
+    for inp in model.graph.input:
+        shape = []
+        for axis, d in enumerate(inp.type.tensor_type.shape.dim):
+            if d.dim_value > 0:
+                shape.append(d.dim_value)
+            else:
+                shape.append(1 if axis == 0 else spatial)
+        feeds[inp.name] = rng.standard_normal(shape).astype(np.float32)
+    return feeds
+
+
+def _parity(ref_outs, test_outs) -> float:
+    """Max abs diff across all outputs; inf if shapes/counts mismatch."""
+    if len(ref_outs) != len(test_outs):
+        return float("inf")
+    worst = 0.0
+    for a, b in zip(ref_outs, test_outs):
+        a = np.asarray(a, dtype=np.float64)
+        b = np.asarray(b, dtype=np.float64)
+        if a.shape != b.shape:
+            return float("inf")
+        worst = max(worst, float(np.max(np.abs(a - b))) if a.size else 0.0)
+    return worst
+
+
+def _slim_with_onnxsim(model: onnx.ModelProto):
+    import onnxsim
+
+    sim, ok = onnxsim.simplify(model)
+    return sim, ok
+
+
+def _slim_with_onnxslim(model: onnx.ModelProto):
+    import onnxslim
+
+    return onnxslim.slim(model), True
+
+
+def export_raw(weight: str, imgsz: int = 640, dynamic: bool = False):
+    """Export a YOLO model to a raw (un-simplified) ONNX ModelProto."""
+    from ultralytics import YOLO
+
+    model = YOLO(weight)
+    path = model.export(
+        format="onnx", simplify=False, imgsz=imgsz, dynamic=dynamic, verbose=False
+    )
+    return onnx.load(str(path))
+
+
+def evaluate(weight: str, dynamic: bool = False) -> dict:
+    label = f"{weight}{' [dyn]' if dynamic else ''}"
+    row: dict = {"model": label}
+    try:
+        raw = export_raw(weight, dynamic=dynamic)
+    except Exception as e:  # noqa: BLE001
+        row["error"] = f"export failed: {e}"
+        traceback.print_exc()
+        return row
+
+    row["raw_nodes"] = _node_count(raw)
+    feeds = _feeds(raw)
+    try:
+        ref = _run(raw, feeds)
+    except Exception as e:  # noqa: BLE001
+        row["error"] = f"raw model failed to run: {e}"
+        return row
+
+    for tool, fn in (("sim", _slim_with_onnxsim), ("slim", _slim_with_onnxslim)):
+        try:
+            t = time.time()
+            out, ok = fn(onnx.ModelProto.FromString(raw.SerializeToString()))
+            row[f"{tool}_seconds"] = round(time.time() - t, 2)
+            row[f"{tool}_nodes"] = _node_count(out)
+            row[f"{tool}_check_ok"] = bool(ok)
+            try:
+                test = _run(out, feeds)
+                row[f"{tool}_valid"] = True
+                row[f"{tool}_parity"] = _parity(ref, test)
+            except Exception as e:  # noqa: BLE001
+                row[f"{tool}_valid"] = False
+                row[f"{tool}_parity"] = float("inf")
+                row[f"{tool}_run_error"] = str(e)
+            row[f"{tool}_status"] = "ok"
+        except Exception as e:  # noqa: BLE001
+            row[f"{tool}_status"] = "crash"
+            row[f"{tool}_error"] = str(e)
+            traceback.print_exc()
+    return row
+
+
+def _fmt_parity(v) -> str:
+    if v is None:
+        return "-"
+    if v == float("inf"):
+        return "MISMATCH"
+    return f"{v:.2e}"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("models", nargs="*", default=DEFAULT_MODELS)
+    ap.add_argument("--imgsz", type=int, default=640)
+    ap.add_argument(
+        "--dynamic-detect",
+        action="store_true",
+        help="also export yolo11n.pt with dynamic axes (stresses dynamic-shape passes)",
+    )
+    args = ap.parse_args()
+
+    models = args.models or DEFAULT_MODELS
+    rows = [evaluate(m) for m in models]
+    if args.dynamic_detect:
+        rows.append(evaluate("yolo11n.pt", dynamic=True))
+
+    print("\n\n================ onnxsim vs onnxslim in ultralytics ================\n")
+    hdr = (
+        f"{'model':<18} {'raw':>5} | {'onnxsim nodes/valid/parity/ok':<34} | "
+        f"{'onnxslim nodes/valid/parity':<26}"
+    )
+    print(hdr)
+    print("-" * len(hdr))
+    regressions = []
+    for r in rows:
+        if "error" in r:
+            print(f"{r['model']:<18} EXPORT ERROR: {r['error']}")
+            regressions.append(r["model"])
+            continue
+        sim_ok = r.get("sim_valid") and r.get("sim_parity", float("inf")) <= (ATOL + RTOL)
+        slim_ok = r.get("slim_valid") and r.get("slim_parity", float("inf")) <= (ATOL + RTOL)
+        sim_cell = (
+            f"{r.get('sim_nodes','-'):>5} "
+            f"{'Y' if r.get('sim_valid') else 'N'} "
+            f"{_fmt_parity(r.get('sim_parity')):>9} "
+            f"{'ok' if r.get('sim_check_ok') else 'no':>3}"
+        )
+        slim_cell = (
+            f"{r.get('slim_nodes','-'):>5} "
+            f"{'Y' if r.get('slim_valid') else 'N'} "
+            f"{_fmt_parity(r.get('slim_parity')):>9}"
+        )
+        print(f"{r['model']:<18} {r.get('raw_nodes','-'):>5} | {sim_cell:<34} | {slim_cell:<26}")
+        if not sim_ok:
+            regressions.append(r["model"])
+
+    print("\nLegend: nodes=node count after simplify, valid=loads+runs in ORT,")
+    print("        parity=max abs diff vs raw export, ok=onnxsim's own check_ok.")
+    print(f"        parity tolerance = atol {ATOL} + rtol {RTOL}\n")
+
+    if regressions:
+        print(f"RESULT: onnxsim NOT a clean drop-in for: {', '.join(regressions)}")
+        return 1
+    print("RESULT: onnxsim is a valid drop-in replacement for onnxslim on all tested models.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/regression/ultralytics_export_compare.py
+++ b/scripts/regression/ultralytics_export_compare.py
@@ -35,11 +35,11 @@ import numpy as np
 import onnx
 
 DEFAULT_MODELS = [
-    "yolo11n.pt",       # detect
-    "yolo11n-seg.pt",   # segment
-    "yolo11n-cls.pt",   # classify
+    "yolo11n.pt",  # detect
+    "yolo11n-seg.pt",  # segment
+    "yolo11n-cls.pt",  # classify
     "yolo11n-pose.pt",  # pose
-    "yolo11n-obb.pt",   # oriented bounding boxes
+    "yolo11n-obb.pt",  # oriented bounding boxes
 ]
 
 # numeric parity tolerance for raw-vs-simplified outputs
@@ -200,20 +200,23 @@ def main() -> int:
             print(f"{r['model']:<18} EXPORT ERROR: {r['error']}")
             regressions.append(r["model"])
             continue
-        sim_ok = r.get("sim_valid") and r.get("sim_parity", float("inf")) <= (ATOL + RTOL)
-        slim_ok = r.get("slim_valid") and r.get("slim_parity", float("inf")) <= (ATOL + RTOL)
+        sim_ok = r.get("sim_valid") and r.get("sim_parity", float("inf")) <= (
+            ATOL + RTOL
+        )
         sim_cell = (
-            f"{r.get('sim_nodes','-'):>5} "
+            f"{r.get('sim_nodes', '-'):>5} "
             f"{'Y' if r.get('sim_valid') else 'N'} "
             f"{_fmt_parity(r.get('sim_parity')):>9} "
             f"{'ok' if r.get('sim_check_ok') else 'no':>3}"
         )
         slim_cell = (
-            f"{r.get('slim_nodes','-'):>5} "
+            f"{r.get('slim_nodes', '-'):>5} "
             f"{'Y' if r.get('slim_valid') else 'N'} "
             f"{_fmt_parity(r.get('slim_parity')):>9}"
         )
-        print(f"{r['model']:<18} {r.get('raw_nodes','-'):>5} | {sim_cell:<34} | {slim_cell:<26}")
+        print(
+            f"{r['model']:<18} {r.get('raw_nodes', '-'):>5} | {sim_cell:<34} | {slim_cell:<26}"
+        )
         if not sim_ok:
             regressions.append(r["model"])
 
@@ -224,7 +227,9 @@ def main() -> int:
     if regressions:
         print(f"RESULT: onnxsim NOT a clean drop-in for: {', '.join(regressions)}")
         return 1
-    print("RESULT: onnxsim is a valid drop-in replacement for onnxslim on all tested models.")
+    print(
+        "RESULT: onnxsim is a valid drop-in replacement for onnxslim on all tested models."
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary

Adds a regression test to evaluate whether **onnxsim** can serve as a drop-in replacement for **onnxslim** in ultralytics' ONNX export pipeline. This addresses the single integration point where ultralytics currently uses onnxslim for graph simplification.

## Changes

- **`scripts/regression/ultralytics_export_compare.py`**: New comprehensive regression test that:
  - Exports YOLO models (detect, segment, classify, pose, OBB) to raw ONNX graphs
  - Runs both onnxsim and onnxslim simplifiers on identical graphs
  - Compares simplification results across four dimensions:
    - **Status**: Did the simplifier run without crashing?
    - **Nodes**: Node count reduction (optimization strength)
    - **Validity**: Does the simplified graph load and run in ONNX Runtime?
    - **Parity**: Numerical correctness (max absolute difference of outputs vs raw export on fixed random input)
  - Supports dynamic-axes testing to stress dynamic-shape optimization passes
  - Configurable model list and image size

- **`scripts/regression/RESULTS_ultralytics.md`**: Documentation of test results showing:
  - onnxsim achieves identical node counts to onnxslim across all six test configurations
  - Both simplifiers produce numerically identical outputs (parity 0.0)
  - onnxsim is faster in aggregate (~3.2s vs ~5.2s total)
  - Conclusion: onnxsim is a valid drop-in replacement

## Implementation Details

- Uses deterministic random inputs (seeded RNG) for reproducible parity testing
- Handles dynamic axes by substituting concrete dimensions (batch=1, spatial=640)
- Tolerance-based parity validation (atol=1e-4, rtol=1e-3) for floating-point comparison
- Comprehensive error handling with detailed reporting for export failures, runtime errors, and simplification crashes
- Exit code indicates pass/fail for CI integration

https://claude.ai/code/session_01VPjHkVJdCjvq4tdocZv2jL