### PR TITLE
Add symbolic value evaluator for shape scaffolding (M1 of #532)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 # configure onnx-optimizer after onnxruntime, because they both depend on onnx and onnxruntime has its own flags for onnx
 add_subdirectory(third_party/onnx-optimizer EXCLUDE_FROM_ALL)
 
-add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/contrib_schemas.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp onnxsim/sym_expr.cpp onnxsim/model_metrics.cpp)
+add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/contrib_schemas.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp onnxsim/sym_expr.cpp onnxsim/sym_value_eval.cpp onnxsim/model_metrics.cpp)
 if (ONNXSIM_BUILTIN_ORT)
   target_include_directories(onnxsim PRIVATE ${ONNXRUNTIME_INCLUDE_DIR})
 endif()
@@ -182,4 +182,12 @@ if (ONNXSIM_TESTS)
                                     onnxsim/model_metrics.cpp onnxsim/sym_expr.cpp)
   target_include_directories(model_metrics_test PRIVATE onnxsim)
   add_test(NAME model_metrics_test COMMAND model_metrics_test)
+
+  # The M1 symbolic value evaluator (issue #532) is likewise dependency-free
+  # (only SymExpr), so it builds and runs standalone -- including under
+  # Emscripten -- without configuring ONNX / onnxruntime.
+  add_executable(sym_value_eval_test onnxsim/sym_value_eval_test.cpp
+                                     onnxsim/sym_value_eval.cpp onnxsim/sym_expr.cpp)
+  target_include_directories(sym_value_eval_test PRIVATE onnxsim)
+  add_test(NAME sym_value_eval_test COMMAND sym_value_eval_test)
 endif()

--- a/onnxsim/sym_value_eval.cpp
+++ b/onnxsim/sym_value_eval.cpp
@@ -89,9 +89,9 @@ class Evaluator {
   // The int list carried by attribute `attr_name`, else by input `input_index`
   // (opset >= 13 moved several of these axis/starts/ends operands to inputs).
   // Requires every element to be concrete.
-  std::optional<std::vector<int64_t>> IntListOperand(const SymNode& node,
-                                                     const std::string& attr_name,
-                                                     std::size_t input_index) const {
+  std::optional<std::vector<int64_t>> IntListOperand(
+      const SymNode& node, const std::string& attr_name,
+      std::size_t input_index) const {
     if (const SymAttr* a = node.attr(attr_name)) return a->ints;
     if (input_index < node.input.size()) {
       if (const SymTensor* t = Value(node.input[input_index])) {
@@ -132,14 +132,16 @@ class Evaluator {
     if (op == "Range") return EvalRange(node);
     if (op == "ReduceProd") return EvalReduceProd(node);
     if (op == "Tile") return EvalTile(node);
-    if (op == "Transpose") return EvalUnary(node, [](const SymExpr& e) {
-      return e;  // rank <= 1 transpose is the identity
-    });
+    if (op == "Transpose")
+      return EvalUnary(node, [](const SymExpr& e) {
+        return e;  // rank <= 1 transpose is the identity
+      });
     if (op == "Expand") return EvalExpand(node);
     if (op == "Neg")
       return EvalUnary(node, [](const SymExpr& e) { return SymExpr(0) - e; });
     if (op == "Floor")
-      return EvalUnary(node, [](const SymExpr& e) { return e; });  // integer data
+      return EvalUnary(node,
+                       [](const SymExpr& e) { return e; });  // integer data
     if (op == "Add" || op == "Sub" || op == "Mul" || op == "Div")
       return EvalArithmetic(node);
     if (op == "Equal") return EvalEqual(node);
@@ -171,7 +173,8 @@ class Evaluator {
     if (it == graph_.shape.end()) return std::nullopt;
     const std::vector<SymExpr>& dims = it->second;
     const int64_t rank = static_cast<int64_t>(dims.size());
-    // Optional start/end slice of the shape (opset 15+). Defaults span the rank.
+    // Optional start/end slice of the shape (opset 15+). Defaults span the
+    // rank.
     int64_t start = IntAttr(node, "start", 0).value();
     int64_t end = IntAttr(node, "end", rank).value();
     if (start < 0) start += rank;
@@ -247,8 +250,9 @@ class Evaluator {
     if (node.input.empty()) return std::nullopt;
     const SymTensor* data = Value(node.input[0]);
     if (!data) return std::nullopt;
-    if (data->scalar) return *data;                       // already rank 0
-    if (data->size() == 1) return SymTensor::Scalar(data->data[0]);  // [1] -> ()
+    if (data->scalar) return *data;  // already rank 0
+    if (data->size() == 1)
+      return SymTensor::Scalar(data->data[0]);  // [1] -> ()
     return std::nullopt;
   }
 
@@ -291,15 +295,15 @@ class Evaluator {
     if (node.input.empty()) return std::nullopt;
     const SymTensor* data = Value(node.input[0]);
     if (!data) return std::nullopt;
-    // Casting between integer / bool representations preserves the exact integer
-    // value the shape scaffolding carries, so the symbolic value is unchanged.
-    // A float target is not modelled (later float arithmetic would be lost), so
-    // leave it unresolved.
+    // Casting between integer / bool representations preserves the exact
+    // integer value the shape scaffolding carries, so the symbolic value is
+    // unchanged. A float target is not modelled (later float arithmetic would
+    // be lost), so leave it unresolved.
     const int64_t to = IntAttr(node, "to", 0).value();
     // onnx::TensorProto data types: FLOAT=1, INT8=3, INT16=5, INT32=6, INT64=7,
     // BOOL=9, UINT8=2, UINT16=4, UINT32=12, UINT64=13, INT4=22, UINT4=21.
-    static const std::vector<int64_t> kIntegerTypes = {2, 3,  4,  5,  6,
-                                                       7, 9, 12, 13, 21, 22};
+    static const std::vector<int64_t> kIntegerTypes = {2, 3,  4,  5,  6, 7,
+                                                       9, 12, 13, 21, 22};
     if (std::find(kIntegerTypes.begin(), kIntegerTypes.end(), to) ==
         kIntegerTypes.end())
       return std::nullopt;
@@ -313,8 +317,8 @@ class Evaluator {
     if (!data || !shape) return std::nullopt;
     const int64_t count = data->size();
     // Only rank <= 1 targets are representable here: a 1-D value flattened /
-    // kept 1-D (the `Shape -> Reshape([-1]) -> Gather` pattern), or collapsed to
-    // a scalar. Higher-rank targets are left alone.
+    // kept 1-D (the `Shape -> Reshape([-1]) -> Gather` pattern), or collapsed
+    // to a scalar. Higher-rank targets are left alone.
     if (shape->empty()) {  // reshape to scalar
       if (count != 1) return std::nullopt;
       return SymTensor::Scalar(data->data[0]);
@@ -330,9 +334,10 @@ class Evaluator {
   std::optional<SymTensor> EvalConstantOfShape(const SymNode& node) {
     if (node.input.empty()) return std::nullopt;
     const SymTensor* shape = Value(node.input[0]);
-    // The shape input lists the output dims. A single-entry shape gives a rank-1
-    // output; multi-entry shapes exceed the rank<=1 model.
-    if (!shape || !shape->is_vector() || shape->size() != 1) return std::nullopt;
+    // The shape input lists the output dims. A single-entry shape gives a
+    // rank-1 output; multi-entry shapes exceed the rank<=1 model.
+    if (!shape || !shape->is_vector() || shape->size() != 1)
+      return std::nullopt;
     auto len = ConcreteInt(shape->data[0]);
     if (!len || *len < 0) return std::nullopt;
     SymExpr fill(0);  // ONNX default is a single 0
@@ -342,8 +347,8 @@ class Evaluator {
       else
         return std::nullopt;
     }
-    return SymTensor::Vector(std::vector<SymExpr>(static_cast<std::size_t>(*len),
-                                                  fill));
+    return SymTensor::Vector(
+        std::vector<SymExpr>(static_cast<std::size_t>(*len), fill));
   }
 
   std::optional<SymTensor> EvalRange(const SymNode& node) {
@@ -396,7 +401,8 @@ class Evaluator {
     const SymTensor* shape = Value(node.input[1]);
     if (!data || !shape || !shape->is_vector()) return std::nullopt;
     // Only rank <= 1 targets are representable. An empty target shape keeps the
-    // (necessarily length-1) input; a single-entry target gives a rank-1 result.
+    // (necessarily length-1) input; a single-entry target gives a rank-1
+    // result.
     if (shape->size() == 0) {
       if (data->size() != 1) return std::nullopt;
       return data->scalar ? *data : SymTensor::Scalar(data->data[0]);
@@ -435,13 +441,12 @@ class Evaluator {
     const std::string& op = node.op_type;
     return BinaryElementwise(
         *a, *b,
-        [&op](const SymExpr& x,
-              const SymExpr& y) -> std::optional<SymExpr> {
+        [&op](const SymExpr& x, const SymExpr& y) -> std::optional<SymExpr> {
           if (op == "Add") return x + y;
           if (op == "Sub") return x - y;
           if (op == "Mul") return x * y;
-          // Div: exact integer division only; a symbolic remainder is undecidable
-          // and leaves the value unresolved (never rounds/guesses).
+          // Div: exact integer division only; a symbolic remainder is
+          // undecidable and leaves the value unresolved (never rounds/guesses).
           return TryExactDivide(x, y);
         });
   }
@@ -452,7 +457,8 @@ class Evaluator {
     const SymTensor* b = Value(node.input[1]);
     if (!a || !b) return std::nullopt;
     return BinaryElementwise(
-        *a, *b, [](const SymExpr& x, const SymExpr& y) -> std::optional<SymExpr> {
+        *a, *b,
+        [](const SymExpr& x, const SymExpr& y) -> std::optional<SymExpr> {
           auto eq = TryEqual(x, y);
           if (!eq) return std::nullopt;  // undecidable comparison
           return SymExpr(*eq ? 1 : 0);

--- a/onnxsim/sym_value_eval.cpp
+++ b/onnxsim/sym_value_eval.cpp
@@ -1,0 +1,520 @@
+#include "sym_value_eval.h"
+
+#include <algorithm>
+#include <functional>
+
+namespace onnxsim {
+namespace {
+
+// A SymExpr collapses to a concrete int only when it carries no symbol.
+std::optional<int64_t> ConcreteInt(const SymExpr& e) {
+  if (e.is_symbolic()) return std::nullopt;
+  return e.to_int();
+}
+
+// The i-th element of an operand, applying numpy broadcasting: a scalar or a
+// length-1 vector repeats, so index 0 is reused for every output position.
+const SymExpr& Broadcast(const SymTensor& t, int64_t i) {
+  return t.data.size() == 1 ? t.data[0] : t.data[static_cast<std::size_t>(i)];
+}
+
+// The broadcast output length for a set of operands, and whether the result is
+// a scalar. Returns nullopt when two genuine vectors disagree in length (an
+// input the shape scaffolding never produces, so it is left unevaluated rather
+// than guessed at). A result is scalar only when *every* operand is a scalar.
+struct BroadcastShape {
+  int64_t length;
+  bool scalar;
+};
+std::optional<BroadcastShape> BroadcastOf(
+    std::initializer_list<const SymTensor*> operands) {
+  int64_t length = 1;
+  bool all_scalar = true;
+  for (const SymTensor* t : operands) {
+    if (!t->scalar) all_scalar = false;
+    const int64_t n = t->size();
+    if (n == 1) continue;  // scalar / length-1 vector broadcasts
+    if (length != 1 && length != n) return std::nullopt;
+    length = n;
+  }
+  return BroadcastShape{length, all_scalar};
+}
+
+// Apply an elementwise binary op with numpy broadcasting. `f` returns nullopt
+// for an undecidable element (e.g. a symbolic Div that does not divide evenly),
+// which aborts the whole output so the tensor is left unresolved.
+std::optional<SymTensor> BinaryElementwise(
+    const SymTensor& a, const SymTensor& b,
+    const std::function<std::optional<SymExpr>(const SymExpr&, const SymExpr&)>&
+        f) {
+  const auto bshape = BroadcastOf({&a, &b});
+  if (!bshape) return std::nullopt;
+  std::vector<SymExpr> out;
+  out.reserve(static_cast<std::size_t>(bshape->length));
+  for (int64_t i = 0; i < bshape->length; ++i) {
+    auto v = f(Broadcast(a, i), Broadcast(b, i));
+    if (!v) return std::nullopt;
+    out.push_back(std::move(*v));
+  }
+  if (bshape->scalar) return SymTensor::Scalar(std::move(out[0]));
+  return SymTensor::Vector(std::move(out));
+}
+
+class Evaluator {
+ public:
+  explicit Evaluator(const SymGraph& graph) : graph_(graph) {
+    for (const auto& [name, value] : graph.initializer) values_[name] = value;
+  }
+
+  std::map<std::string, SymTensor> Run() {
+    for (const SymNode& node : graph_.node) {
+      auto value = Eval(node);
+      if (value && node.output.size() == 1 && !node.output[0].empty()) {
+        values_[node.output[0]] = std::move(*value);
+      }
+    }
+    return values_;
+  }
+
+ private:
+  // A resolved value for an operand: an initializer, a Constant, or an already
+  // evaluated node output. Absent name / empty ("" optional-input sentinel) /
+  // unresolved tensor all read as "not available".
+  const SymTensor* Value(const std::string& name) const {
+    if (name.empty()) return nullptr;
+    auto it = values_.find(name);
+    return it == values_.end() ? nullptr : &it->second;
+  }
+
+  // The int list carried by attribute `attr_name`, else by input `input_index`
+  // (opset >= 13 moved several of these axis/starts/ends operands to inputs).
+  // Requires every element to be concrete.
+  std::optional<std::vector<int64_t>> IntListOperand(const SymNode& node,
+                                                     const std::string& attr_name,
+                                                     std::size_t input_index) const {
+    if (const SymAttr* a = node.attr(attr_name)) return a->ints;
+    if (input_index < node.input.size()) {
+      if (const SymTensor* t = Value(node.input[input_index])) {
+        std::vector<int64_t> out;
+        out.reserve(t->data.size());
+        for (const SymExpr& e : t->data) {
+          auto c = ConcreteInt(e);
+          if (!c) return std::nullopt;
+          out.push_back(*c);
+        }
+        return out;
+      }
+    }
+    return std::nullopt;
+  }
+
+  std::optional<int64_t> IntAttr(const SymNode& node, const std::string& name,
+                                 int64_t fallback) const {
+    if (const SymAttr* a = node.attr(name)) {
+      if (a->i) return *a->i;
+    }
+    return fallback;
+  }
+
+  std::optional<SymTensor> Eval(const SymNode& node) {
+    const std::string& op = node.op_type;
+    if (op == "Constant") return EvalConstant(node);
+    if (op == "Shape") return EvalShape(node);
+    if (op == "Size") return EvalSize(node);
+    if (op == "Gather") return EvalGather(node);
+    if (op == "Concat") return EvalConcat(node);
+    if (op == "Unsqueeze") return EvalUnsqueeze(node);
+    if (op == "Squeeze") return EvalSqueeze(node);
+    if (op == "Slice") return EvalSlice(node);
+    if (op == "Cast") return EvalCast(node);
+    if (op == "Reshape") return EvalReshape(node);
+    if (op == "ConstantOfShape") return EvalConstantOfShape(node);
+    if (op == "Range") return EvalRange(node);
+    if (op == "ReduceProd") return EvalReduceProd(node);
+    if (op == "Tile") return EvalTile(node);
+    if (op == "Transpose") return EvalUnary(node, [](const SymExpr& e) {
+      return e;  // rank <= 1 transpose is the identity
+    });
+    if (op == "Expand") return EvalExpand(node);
+    if (op == "Neg")
+      return EvalUnary(node, [](const SymExpr& e) { return SymExpr(0) - e; });
+    if (op == "Floor")
+      return EvalUnary(node, [](const SymExpr& e) { return e; });  // integer data
+    if (op == "Add" || op == "Sub" || op == "Mul" || op == "Div")
+      return EvalArithmetic(node);
+    if (op == "Equal") return EvalEqual(node);
+    if (op == "Where") return EvalWhere(node);
+    if (op == "Min" || op == "Max") return EvalMinMax(node);
+    return std::nullopt;
+  }
+
+  // --- seeds --------------------------------------------------------------
+
+  std::optional<SymTensor> EvalConstant(const SymNode& node) {
+    if (const SymAttr* a = node.attr("value")) {
+      if (a->t) return *a->t;
+    }
+    if (const SymAttr* a = node.attr("value_ints")) {
+      std::vector<SymExpr> v;
+      for (int64_t x : a->ints) v.emplace_back(x);
+      return SymTensor::Vector(std::move(v));
+    }
+    if (const SymAttr* a = node.attr("value_int")) {
+      if (a->i) return SymTensor::Scalar(SymExpr(*a->i));
+    }
+    return std::nullopt;
+  }
+
+  std::optional<SymTensor> EvalShape(const SymNode& node) {
+    if (node.input.empty()) return std::nullopt;
+    auto it = graph_.shape.find(node.input[0]);
+    if (it == graph_.shape.end()) return std::nullopt;
+    const std::vector<SymExpr>& dims = it->second;
+    const int64_t rank = static_cast<int64_t>(dims.size());
+    // Optional start/end slice of the shape (opset 15+). Defaults span the rank.
+    int64_t start = IntAttr(node, "start", 0).value();
+    int64_t end = IntAttr(node, "end", rank).value();
+    if (start < 0) start += rank;
+    if (end < 0) end += rank;
+    start = std::clamp<int64_t>(start, 0, rank);
+    end = std::clamp<int64_t>(end, 0, rank);
+    std::vector<SymExpr> out;
+    for (int64_t i = start; i < end; ++i)
+      out.push_back(dims[static_cast<std::size_t>(i)]);
+    return SymTensor::Vector(std::move(out));
+  }
+
+  std::optional<SymTensor> EvalSize(const SymNode& node) {
+    if (node.input.empty()) return std::nullopt;
+    auto it = graph_.shape.find(node.input[0]);
+    if (it == graph_.shape.end()) return std::nullopt;
+    SymExpr prod(1);
+    for (const SymExpr& d : it->second) prod = prod * d;
+    return SymTensor::Scalar(std::move(prod));
+  }
+
+  // --- shape family -------------------------------------------------------
+
+  std::optional<SymTensor> EvalGather(const SymNode& node) {
+    if (node.input.size() < 2) return std::nullopt;
+    const SymTensor* data = Value(node.input[0]);
+    const SymTensor* indices = Value(node.input[1]);
+    if (!data || !indices || !data->is_vector()) return std::nullopt;
+    const int64_t axis = IntAttr(node, "axis", 0).value();
+    if (!(axis == 0 || axis == -1)) return std::nullopt;  // rank-1 data only
+    const int64_t len = data->size();
+    std::vector<SymExpr> out;
+    out.reserve(indices->data.size());
+    for (const SymExpr& idx_e : indices->data) {
+      auto idx = ConcreteInt(idx_e);
+      if (!idx) return std::nullopt;
+      int64_t i = *idx < 0 ? *idx + len : *idx;
+      if (i < 0 || i >= len) return std::nullopt;
+      out.push_back(data->data[static_cast<std::size_t>(i)]);
+    }
+    // A scalar index selects a scalar; a 1-D index tensor yields a 1-D result.
+    if (indices->scalar) return SymTensor::Scalar(std::move(out[0]));
+    return SymTensor::Vector(std::move(out));
+  }
+
+  std::optional<SymTensor> EvalConcat(const SymNode& node) {
+    const int64_t axis = IntAttr(node, "axis", 0).value();
+    if (!(axis == 0 || axis == -1)) return std::nullopt;  // rank-1 inputs
+    std::vector<SymExpr> out;
+    for (const std::string& name : node.input) {
+      const SymTensor* t = Value(name);
+      if (!t || !t->is_vector()) return std::nullopt;
+      out.insert(out.end(), t->data.begin(), t->data.end());
+    }
+    return SymTensor::Vector(std::move(out));
+  }
+
+  std::optional<SymTensor> EvalUnsqueeze(const SymNode& node) {
+    if (node.input.empty()) return std::nullopt;
+    const SymTensor* data = Value(node.input[0]);
+    if (!data) return std::nullopt;
+    auto axes = IntListOperand(node, "axes", 1);
+    // Only the scalar -> length-1 vector case is representable in the rank<=1
+    // model this pass tracks; anything raising rank above 1 is left alone.
+    if (data->scalar && axes && axes->size() == 1 &&
+        ((*axes)[0] == 0 || (*axes)[0] == -1)) {
+      return SymTensor::Vector({data->data[0]});
+    }
+    return std::nullopt;
+  }
+
+  std::optional<SymTensor> EvalSqueeze(const SymNode& node) {
+    if (node.input.empty()) return std::nullopt;
+    const SymTensor* data = Value(node.input[0]);
+    if (!data) return std::nullopt;
+    if (data->scalar) return *data;                       // already rank 0
+    if (data->size() == 1) return SymTensor::Scalar(data->data[0]);  // [1] -> ()
+    return std::nullopt;
+  }
+
+  std::optional<SymTensor> EvalSlice(const SymNode& node) {
+    if (node.input.empty()) return std::nullopt;
+    const SymTensor* data = Value(node.input[0]);
+    if (!data || !data->is_vector()) return std::nullopt;
+    auto starts = IntListOperand(node, "starts", 1);
+    auto ends = IntListOperand(node, "ends", 2);
+    auto axes = IntListOperand(node, "axes", 3);
+    auto steps = IntListOperand(node, "steps", 4);
+    if (!starts || !ends || starts->size() != 1 || ends->size() != 1)
+      return std::nullopt;
+    if (axes && !(axes->size() == 1 && ((*axes)[0] == 0 || (*axes)[0] == -1)))
+      return std::nullopt;  // rank-1 data, axis 0 only
+    const int64_t step = (steps && steps->size() == 1) ? (*steps)[0] : 1;
+    if (step == 0) return std::nullopt;
+    const int64_t len = data->size();
+    int64_t start = (*starts)[0];
+    int64_t end = (*ends)[0];
+    // ONNX Slice normalization / clamping, honouring the direction of `step`.
+    if (start < 0) start += len;
+    if (end < 0) end += len;
+    std::vector<SymExpr> out;
+    if (step > 0) {
+      start = std::clamp<int64_t>(start, 0, len);
+      end = std::clamp<int64_t>(end, 0, len);
+      for (int64_t i = start; i < end; i += step)
+        out.push_back(data->data[static_cast<std::size_t>(i)]);
+    } else {
+      start = std::clamp<int64_t>(start, 0, len - 1);
+      end = std::clamp<int64_t>(end, -1, len - 1);
+      for (int64_t i = start; i > end; i += step)
+        out.push_back(data->data[static_cast<std::size_t>(i)]);
+    }
+    return SymTensor::Vector(std::move(out));
+  }
+
+  std::optional<SymTensor> EvalCast(const SymNode& node) {
+    if (node.input.empty()) return std::nullopt;
+    const SymTensor* data = Value(node.input[0]);
+    if (!data) return std::nullopt;
+    // Casting between integer / bool representations preserves the exact integer
+    // value the shape scaffolding carries, so the symbolic value is unchanged.
+    // A float target is not modelled (later float arithmetic would be lost), so
+    // leave it unresolved.
+    const int64_t to = IntAttr(node, "to", 0).value();
+    // onnx::TensorProto data types: FLOAT=1, INT8=3, INT16=5, INT32=6, INT64=7,
+    // BOOL=9, UINT8=2, UINT16=4, UINT32=12, UINT64=13, INT4=22, UINT4=21.
+    static const std::vector<int64_t> kIntegerTypes = {2, 3,  4,  5,  6,
+                                                       7, 9, 12, 13, 21, 22};
+    if (std::find(kIntegerTypes.begin(), kIntegerTypes.end(), to) ==
+        kIntegerTypes.end())
+      return std::nullopt;
+    return *data;
+  }
+
+  std::optional<SymTensor> EvalReshape(const SymNode& node) {
+    if (node.input.size() < 2) return std::nullopt;
+    const SymTensor* data = Value(node.input[0]);
+    auto shape = IntListOperand(node, "shape", 1);
+    if (!data || !shape) return std::nullopt;
+    const int64_t count = data->size();
+    // Only rank <= 1 targets are representable here: a 1-D value flattened /
+    // kept 1-D (the `Shape -> Reshape([-1]) -> Gather` pattern), or collapsed to
+    // a scalar. Higher-rank targets are left alone.
+    if (shape->empty()) {  // reshape to scalar
+      if (count != 1) return std::nullopt;
+      return SymTensor::Scalar(data->data[0]);
+    }
+    if (shape->size() != 1) return std::nullopt;
+    const int64_t dim = (*shape)[0];
+    if (dim == -1 || dim == 0 || dim == count) {
+      return SymTensor::Vector(data->data);  // element order is preserved
+    }
+    return std::nullopt;
+  }
+
+  std::optional<SymTensor> EvalConstantOfShape(const SymNode& node) {
+    if (node.input.empty()) return std::nullopt;
+    const SymTensor* shape = Value(node.input[0]);
+    // The shape input lists the output dims. A single-entry shape gives a rank-1
+    // output; multi-entry shapes exceed the rank<=1 model.
+    if (!shape || !shape->is_vector() || shape->size() != 1) return std::nullopt;
+    auto len = ConcreteInt(shape->data[0]);
+    if (!len || *len < 0) return std::nullopt;
+    SymExpr fill(0);  // ONNX default is a single 0
+    if (const SymAttr* a = node.attr("value")) {
+      if (a->t && a->t->data.size() == 1)
+        fill = a->t->data[0];
+      else
+        return std::nullopt;
+    }
+    return SymTensor::Vector(std::vector<SymExpr>(static_cast<std::size_t>(*len),
+                                                  fill));
+  }
+
+  std::optional<SymTensor> EvalRange(const SymNode& node) {
+    if (node.input.size() < 3) return std::nullopt;
+    const SymTensor* start = Value(node.input[0]);
+    const SymTensor* limit = Value(node.input[1]);
+    const SymTensor* delta = Value(node.input[2]);
+    if (!start || !limit || !delta) return std::nullopt;
+    auto s = ConcreteInt(start->data[0]);
+    auto l = ConcreteInt(limit->data[0]);
+    auto d = ConcreteInt(delta->data[0]);
+    if (!s || !l || !d || *d == 0) return std::nullopt;
+    std::vector<SymExpr> out;
+    if (*d > 0)
+      for (int64_t v = *s; v < *l; v += *d) out.emplace_back(v);
+    else
+      for (int64_t v = *s; v > *l; v += *d) out.emplace_back(v);
+    return SymTensor::Vector(std::move(out));
+  }
+
+  std::optional<SymTensor> EvalReduceProd(const SymNode& node) {
+    if (node.input.empty()) return std::nullopt;
+    const SymTensor* data = Value(node.input[0]);
+    if (!data || !data->is_vector()) return std::nullopt;
+    SymExpr prod(1);
+    for (const SymExpr& e : data->data) prod = prod * e;
+    const int64_t keepdims = IntAttr(node, "keepdims", 1).value();
+    if (keepdims) return SymTensor::Vector({std::move(prod)});
+    return SymTensor::Scalar(std::move(prod));
+  }
+
+  std::optional<SymTensor> EvalTile(const SymNode& node) {
+    if (node.input.size() < 2) return std::nullopt;
+    const SymTensor* data = Value(node.input[0]);
+    const SymTensor* repeats = Value(node.input[1]);
+    if (!data || !data->is_vector() || !repeats || repeats->size() != 1)
+      return std::nullopt;
+    auto r = ConcreteInt(repeats->data[0]);
+    if (!r || *r < 0) return std::nullopt;
+    std::vector<SymExpr> out;
+    out.reserve(data->data.size() * static_cast<std::size_t>(*r));
+    for (int64_t k = 0; k < *r; ++k)
+      out.insert(out.end(), data->data.begin(), data->data.end());
+    return SymTensor::Vector(std::move(out));
+  }
+
+  std::optional<SymTensor> EvalExpand(const SymNode& node) {
+    if (node.input.size() < 2) return std::nullopt;
+    const SymTensor* data = Value(node.input[0]);
+    const SymTensor* shape = Value(node.input[1]);
+    if (!data || !shape || !shape->is_vector()) return std::nullopt;
+    // Only rank <= 1 targets are representable. An empty target shape keeps the
+    // (necessarily length-1) input; a single-entry target gives a rank-1 result.
+    if (shape->size() == 0) {
+      if (data->size() != 1) return std::nullopt;
+      return data->scalar ? *data : SymTensor::Scalar(data->data[0]);
+    }
+    if (shape->size() != 1) return std::nullopt;
+    auto n = ConcreteInt(shape->data[0]);
+    if (!n || *n < 0) return std::nullopt;
+    const int64_t in = data->size();
+    // numpy broadcast of the 1-D input against the length-`n` target: the two
+    // must be equal or one of them 1; the output takes the larger length.
+    if (in != 1 && *n != 1 && in != *n) return std::nullopt;
+    const int64_t length = std::max<int64_t>(in, *n);
+    std::vector<SymExpr> out;
+    out.reserve(static_cast<std::size_t>(length));
+    for (int64_t i = 0; i < length; ++i) out.push_back(Broadcast(*data, i));
+    return SymTensor::Vector(std::move(out));
+  }
+
+  // --- arithmetic + the four data-prop gap ops ----------------------------
+
+  std::optional<SymTensor> EvalUnary(
+      const SymNode& node, const std::function<SymExpr(const SymExpr&)>& f) {
+    if (node.input.empty()) return std::nullopt;
+    const SymTensor* data = Value(node.input[0]);
+    if (!data) return std::nullopt;
+    SymTensor out = *data;
+    for (SymExpr& e : out.data) e = f(e);
+    return out;
+  }
+
+  std::optional<SymTensor> EvalArithmetic(const SymNode& node) {
+    if (node.input.size() < 2) return std::nullopt;
+    const SymTensor* a = Value(node.input[0]);
+    const SymTensor* b = Value(node.input[1]);
+    if (!a || !b) return std::nullopt;
+    const std::string& op = node.op_type;
+    return BinaryElementwise(
+        *a, *b,
+        [&op](const SymExpr& x,
+              const SymExpr& y) -> std::optional<SymExpr> {
+          if (op == "Add") return x + y;
+          if (op == "Sub") return x - y;
+          if (op == "Mul") return x * y;
+          // Div: exact integer division only; a symbolic remainder is undecidable
+          // and leaves the value unresolved (never rounds/guesses).
+          return TryExactDivide(x, y);
+        });
+  }
+
+  std::optional<SymTensor> EvalEqual(const SymNode& node) {
+    if (node.input.size() < 2) return std::nullopt;
+    const SymTensor* a = Value(node.input[0]);
+    const SymTensor* b = Value(node.input[1]);
+    if (!a || !b) return std::nullopt;
+    return BinaryElementwise(
+        *a, *b, [](const SymExpr& x, const SymExpr& y) -> std::optional<SymExpr> {
+          auto eq = TryEqual(x, y);
+          if (!eq) return std::nullopt;  // undecidable comparison
+          return SymExpr(*eq ? 1 : 0);
+        });
+  }
+
+  std::optional<SymTensor> EvalWhere(const SymNode& node) {
+    if (node.input.size() < 3) return std::nullopt;
+    const SymTensor* cond = Value(node.input[0]);
+    const SymTensor* x = Value(node.input[1]);
+    const SymTensor* y = Value(node.input[2]);
+    if (!cond || !x || !y) return std::nullopt;
+    const auto bshape = BroadcastOf({cond, x, y});
+    if (!bshape) return std::nullopt;
+    std::vector<SymExpr> out;
+    out.reserve(static_cast<std::size_t>(bshape->length));
+    for (int64_t i = 0; i < bshape->length; ++i) {
+      // The branch is chosen only when the condition is a concrete bool; a
+      // symbolic condition is undecidable, so the whole Where stays unresolved
+      // rather than picking a branch that might be wrong.
+      auto c = ConcreteInt(Broadcast(*cond, i));
+      if (!c) return std::nullopt;
+      out.push_back(*c != 0 ? Broadcast(*x, i) : Broadcast(*y, i));
+    }
+    if (bshape->scalar) return SymTensor::Scalar(std::move(out[0]));
+    return SymTensor::Vector(std::move(out));
+  }
+
+  std::optional<SymTensor> EvalMinMax(const SymNode& node) {
+    if (node.input.empty()) return std::nullopt;
+    const bool is_min = node.op_type == "Min";
+    const SymTensor* acc_src = Value(node.input[0]);
+    if (!acc_src) return std::nullopt;
+    SymTensor acc = *acc_src;
+    for (std::size_t k = 1; k < node.input.size(); ++k) {
+      const SymTensor* b = Value(node.input[k]);
+      if (!b) return std::nullopt;
+      auto merged = BinaryElementwise(
+          acc, *b,
+          [is_min](const SymExpr& x,
+                   const SymExpr& y) -> std::optional<SymExpr> {
+            // Pick a side only when the difference is a concrete number; a
+            // symbolic difference has unknown sign and is left undecidable.
+            const SymExpr diff = x - y;
+            if (diff.is_symbolic()) return std::nullopt;
+            const bool x_le_y = diff.to_int() <= 0;
+            return (is_min == x_le_y) ? x : y;
+          });
+      if (!merged) return std::nullopt;
+      acc = std::move(*merged);
+    }
+    return acc;
+  }
+
+  const SymGraph& graph_;
+  std::map<std::string, SymTensor> values_;
+};
+
+}  // namespace
+
+std::map<std::string, SymTensor> EvaluateSymbolicValues(const SymGraph& graph) {
+  return Evaluator(graph).Run();
+}
+
+}  // namespace onnxsim

--- a/onnxsim/sym_value_eval.h
+++ b/onnxsim/sym_value_eval.h
@@ -19,16 +19,16 @@ namespace onnxsim {
 // entries are either a concrete int or an *opaque* dim_param string; it cannot
 // do arithmetic on a symbol, so a Reshape target like `[batch, 1024, 128]`, or
 // any `Div`/`Equal`/`Where` over a symbolic dim, stalls the whole chain. This
-// evaluator instead keeps each dynamic dim as a `SymExpr` (an integer-coefficient
-// polynomial in dim symbols) and computes the shape algebra with the M0
-// primitives (`operator+/-/*`, `TryExactDivide`, `TryEqual`).
+// evaluator instead keeps each dynamic dim as a `SymExpr` (an
+// integer-coefficient polynomial in dim symbols) and computes the shape algebra
+// with the M0 primitives (`operator+/-/*`, `TryExactDivide`, `TryEqual`).
 //
 // Like `SymExpr`, this is pure standard C++ with no ONNX / SymEngine / sympy
 // dependency, so it builds unchanged under Emscripten/WASM and is unit-testable
 // on its own (see sym_value_eval_test.cpp). It deliberately touches no onnx::
-// type: the caller (the `_EvalPartialShape` adapter, wired in a later milestone)
-// pre-extracts nodes, initializers and tensor shapes into the plain structs
-// below.
+// type: the caller (the `_EvalPartialShape` adapter, wired in a later
+// milestone) pre-extracts nodes, initializers and tensor shapes into the plain
+// structs below.
 //
 // Design rule for every handler: an op contributes an output value only when it
 // is *fully decidable*. Any undecidable step (a symbolic Div that does not
@@ -39,10 +39,10 @@ namespace onnxsim {
 
 // A symbolic integer shape-data value: a rank-0 (scalar) or rank-1 (vector)
 // tensor whose entries are `SymExpr`. Rank 0 vs rank 1 matters -- a Gather with
-// a scalar index yields a scalar, Unsqueeze/Squeeze convert between the two, and
-// Concat requires rank 1 -- so it is tracked explicitly. Higher-rank shape data
-// does not occur in the scaffolding chains this pass targets; such tensors are
-// simply left unevaluated.
+// a scalar index yields a scalar, Unsqueeze/Squeeze convert between the two,
+// and Concat requires rank 1 -- so it is tracked explicitly. Higher-rank shape
+// data does not occur in the scaffolding chains this pass targets; such tensors
+// are simply left unevaluated.
 struct SymTensor {
   std::vector<SymExpr> data;  // row-major; length == 1 when `scalar`
   bool scalar = false;        // rank 0 (a single number) vs rank 1 (a vector)
@@ -67,13 +67,15 @@ struct SymTensor {
   bool is_vector() const { return !scalar; }
 };
 
-// A node attribute, pre-extracted from the ONNX NodeProto into the few forms the
-// handlers read (INT, INTS, TENSOR). Only one field is populated per attribute.
+// A node attribute, pre-extracted from the ONNX NodeProto into the few forms
+// the handlers read (INT, INTS, TENSOR). Only one field is populated per
+// attribute.
 struct SymAttr {
   std::string name;
   std::optional<int64_t> i;   // AttributeProto::INT
   std::vector<int64_t> ints;  // AttributeProto::INTS
-  std::optional<SymTensor> t; // AttributeProto::TENSOR (Constant / ConstantOfShape)
+  std::optional<SymTensor>
+      t;  // AttributeProto::TENSOR (Constant / ConstantOfShape)
 };
 
 // One node of the graph, in topological order (ONNX graphs already are). An
@@ -94,8 +96,9 @@ struct SymNode {
 
 // Everything the evaluator needs, all dependency-free.
 struct SymGraph {
-  std::vector<SymNode> node;                     // topologically sorted
-  std::map<std::string, SymTensor> initializer;  // integer initializers as values
+  std::vector<SymNode> node;  // topologically sorted
+  std::map<std::string, SymTensor>
+      initializer;  // integer initializers as values
 
   // The shape of a tensor, one `SymExpr` per dimension, seeding `Shape(name)`:
   //   dim_value d   -> SymExpr(d)
@@ -106,11 +109,12 @@ struct SymGraph {
 };
 
 // Walk the graph once in topological order, maintaining a `name -> SymTensor`
-// value table seeded from initializers, `Constant` nodes and `Shape()` of tensors
-// with a known (possibly symbolic) shape. Returns every tensor whose value the
-// pass could resolve. The result may contain values that are still symbolic
-// (e.g. `[batch, 60]`); that is exactly what the `_EvalPartialShape` Reshape
-// rewrite consumes -- a single symbolic entry becomes the Reshape `-1` slot.
+// value table seeded from initializers, `Constant` nodes and `Shape()` of
+// tensors with a known (possibly symbolic) shape. Returns every tensor whose
+// value the pass could resolve. The result may contain values that are still
+// symbolic (e.g. `[batch, 60]`); that is exactly what the `_EvalPartialShape`
+// Reshape rewrite consumes -- a single symbolic entry becomes the Reshape `-1`
+// slot.
 std::map<std::string, SymTensor> EvaluateSymbolicValues(const SymGraph& graph);
 
 }  // namespace onnxsim

--- a/onnxsim/sym_value_eval.h
+++ b/onnxsim/sym_value_eval.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "sym_expr.h"
+
+namespace onnxsim {
+
+// M1 of issue #532: a dependency-free *symbolic value evaluator* for the shape
+// scaffolding (`Shape -> Gather -> Unsqueeze -> Concat -> Reshape`, plus
+// `Where`/`Equal`/`Div`/`Expand`) that ONNX data propagation cannot fold on a
+// graph with a dynamic dimension.
+//
+// ONNX data propagation carries a tensor's value as a TensorShapeProto whose
+// entries are either a concrete int or an *opaque* dim_param string; it cannot
+// do arithmetic on a symbol, so a Reshape target like `[batch, 1024, 128]`, or
+// any `Div`/`Equal`/`Where` over a symbolic dim, stalls the whole chain. This
+// evaluator instead keeps each dynamic dim as a `SymExpr` (an integer-coefficient
+// polynomial in dim symbols) and computes the shape algebra with the M0
+// primitives (`operator+/-/*`, `TryExactDivide`, `TryEqual`).
+//
+// Like `SymExpr`, this is pure standard C++ with no ONNX / SymEngine / sympy
+// dependency, so it builds unchanged under Emscripten/WASM and is unit-testable
+// on its own (see sym_value_eval_test.cpp). It deliberately touches no onnx::
+// type: the caller (the `_EvalPartialShape` adapter, wired in a later milestone)
+// pre-extracts nodes, initializers and tensor shapes into the plain structs
+// below.
+//
+// Design rule for every handler: an op contributes an output value only when it
+// is *fully decidable*. Any undecidable step (a symbolic Div that does not
+// divide evenly, a Where whose condition cannot be resolved, an out-of-range
+// index) leaves the output absent, so a downstream consumer sees "unknown" and
+// keeps the runtime computation rather than folding something wrong. Final
+// graphs remain gated by onnxsim's own equivalence check.
+
+// A symbolic integer shape-data value: a rank-0 (scalar) or rank-1 (vector)
+// tensor whose entries are `SymExpr`. Rank 0 vs rank 1 matters -- a Gather with
+// a scalar index yields a scalar, Unsqueeze/Squeeze convert between the two, and
+// Concat requires rank 1 -- so it is tracked explicitly. Higher-rank shape data
+// does not occur in the scaffolding chains this pass targets; such tensors are
+// simply left unevaluated.
+struct SymTensor {
+  std::vector<SymExpr> data;  // row-major; length == 1 when `scalar`
+  bool scalar = false;        // rank 0 (a single number) vs rank 1 (a vector)
+
+  static SymTensor Scalar(SymExpr v) {
+    SymTensor t;
+    t.data.push_back(std::move(v));
+    t.scalar = true;
+    return t;
+  }
+  static SymTensor Vector(std::vector<SymExpr> v) {
+    SymTensor t;
+    t.data = std::move(v);
+    t.scalar = false;
+    return t;
+  }
+
+  int64_t size() const { return static_cast<int64_t>(data.size()); }
+
+  // The concrete length of the *dim axis* for a rank-1 value; a scalar has no
+  // axis. Used only where a rank-1 value is expected.
+  bool is_vector() const { return !scalar; }
+};
+
+// A node attribute, pre-extracted from the ONNX NodeProto into the few forms the
+// handlers read (INT, INTS, TENSOR). Only one field is populated per attribute.
+struct SymAttr {
+  std::string name;
+  std::optional<int64_t> i;   // AttributeProto::INT
+  std::vector<int64_t> ints;  // AttributeProto::INTS
+  std::optional<SymTensor> t; // AttributeProto::TENSOR (Constant / ConstantOfShape)
+};
+
+// One node of the graph, in topological order (ONNX graphs already are). An
+// empty input name is the ONNX "optional input omitted" sentinel and is treated
+// as absent.
+struct SymNode {
+  std::string op_type;
+  std::vector<std::string> input;
+  std::vector<std::string> output;
+  std::vector<SymAttr> attribute;
+
+  const SymAttr* attr(const std::string& name) const {
+    for (const auto& a : attribute)
+      if (a.name == name) return &a;
+    return nullptr;
+  }
+};
+
+// Everything the evaluator needs, all dependency-free.
+struct SymGraph {
+  std::vector<SymNode> node;                     // topologically sorted
+  std::map<std::string, SymTensor> initializer;  // integer initializers as values
+
+  // The shape of a tensor, one `SymExpr` per dimension, seeding `Shape(name)`:
+  //   dim_value d   -> SymExpr(d)
+  //   dim_param "s" -> SymExpr::Symbol("s")     (the dynamic dim symbol)
+  // A tensor absent from this map has no known shape, so `Shape(name)` on it is
+  // not evaluable and is skipped.
+  std::map<std::string, std::vector<SymExpr>> shape;
+};
+
+// Walk the graph once in topological order, maintaining a `name -> SymTensor`
+// value table seeded from initializers, `Constant` nodes and `Shape()` of tensors
+// with a known (possibly symbolic) shape. Returns every tensor whose value the
+// pass could resolve. The result may contain values that are still symbolic
+// (e.g. `[batch, 60]`); that is exactly what the `_EvalPartialShape` Reshape
+// rewrite consumes -- a single symbolic entry becomes the Reshape `-1` slot.
+std::map<std::string, SymTensor> EvaluateSymbolicValues(const SymGraph& graph);
+
+}  // namespace onnxsim

--- a/onnxsim/sym_value_eval_test.cpp
+++ b/onnxsim/sym_value_eval_test.cpp
@@ -1,0 +1,311 @@
+// Standalone test:
+//   g++ -std=c++17 sym_expr.cpp sym_value_eval.cpp sym_value_eval_test.cpp -o t
+//   ./t
+// (Builds identically under Emscripten: em++ -std=c++17 ...)
+//
+// Exercises the M1 symbolic value evaluator (issue #532) op-by-op and on the
+// end-to-end shape-scaffolding chains from the PoC / tests/test_simple.py,
+// entirely without ONNX -- the graph is assembled from the plain SymGraph
+// structs the real adapter will fill.
+#include "sym_value_eval.h"
+
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using onnxsim::SymAttr;
+using onnxsim::SymExpr;
+using onnxsim::SymGraph;
+using onnxsim::SymNode;
+using onnxsim::SymTensor;
+
+namespace {
+
+// --- tiny builders so the graphs below read like the ONNX helper API --------
+
+SymTensor Vec(std::vector<int64_t> xs) {
+  std::vector<SymExpr> d;
+  for (int64_t x : xs) d.emplace_back(x);
+  return SymTensor::Vector(std::move(d));
+}
+SymTensor Scal(int64_t x) { return SymTensor::Scalar(SymExpr(x)); }
+
+SymAttr AInt(std::string name, int64_t v) {
+  SymAttr a;
+  a.name = std::move(name);
+  a.i = v;
+  return a;
+}
+SymAttr AInts(std::string name, std::vector<int64_t> v) {
+  SymAttr a;
+  a.name = std::move(name);
+  a.ints = std::move(v);
+  return a;
+}
+SymAttr ATensor(std::string name, SymTensor t) {
+  SymAttr a;
+  a.name = std::move(name);
+  a.t = std::move(t);
+  return a;
+}
+
+SymNode N(std::string op, std::vector<std::string> in,
+          std::vector<std::string> out, std::vector<SymAttr> attrs = {}) {
+  SymNode n;
+  n.op_type = std::move(op);
+  n.input = std::move(in);
+  n.output = std::move(out);
+  n.attribute = std::move(attrs);
+  return n;
+}
+
+// A resolved value equals this list of sympy-style strings, with this rank.
+bool Is(const std::map<std::string, SymTensor>& values, const std::string& name,
+        std::vector<std::string> expect, bool scalar) {
+  auto it = values.find(name);
+  if (it == values.end()) return false;
+  const SymTensor& t = it->second;
+  if (t.scalar != scalar) return false;
+  if (t.data.size() != expect.size()) return false;
+  for (std::size_t i = 0; i < expect.size(); ++i)
+    if (t.data[i].str() != expect[i]) return false;
+  return true;
+}
+
+const SymExpr batch = SymExpr::Symbol("batch");
+
+}  // namespace
+
+int main() {
+  // === Fully-static Shape -> Gather collapses even with a dynamic batch =====
+  // (tests/test_simple.py::test_partial_shape_evaluation_gather)
+  {
+    SymGraph g;
+    g.shape["x"] = {batch, SymExpr(3), SymExpr(4), SymExpr(5)};
+    g.initializer["indices"] = Vec({1, 2, 3});
+    g.node = {N("Shape", {"x"}, {"s"}),
+              N("Gather", {"s", "indices"}, {"gout"}, {AInt("axis", 0)})};
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(Is(v, "s", {"batch", "3", "4", "5"}, /*scalar=*/false));
+    assert(Is(v, "gout", {"3", "4", "5"}, false));
+  }
+
+  // === Gather that reads the dynamic dim stays symbolic =====================
+  // The value is still produced -- the consumer decides foldability -- but it
+  // carries the symbol, so the fully-known folder will not fold it.
+  {
+    SymGraph g;
+    g.shape["x"] = {batch, SymExpr(3), SymExpr(4), SymExpr(5)};
+    g.initializer["idx0"] = Vec({0});
+    g.node = {N("Shape", {"x"}, {"s"}),
+              N("Gather", {"s", "idx0"}, {"b"}, {AInt("axis", 0)})};
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(Is(v, "b", {"batch"}, false));
+    assert(v.at("b").data[0].is_symbolic());
+  }
+
+  // === Shape -> Gather(batch) -> Concat -> [batch, 60] ======================
+  // The single-symbolic-entry shape the #526 Reshape rewrite turns into [-1,60].
+  // Also exercises the scalar-index -> Unsqueeze -> Concat variant.
+  {
+    SymGraph g;
+    g.shape["x"] = {batch, SymExpr(3), SymExpr(4), SymExpr(5)};
+    g.initializer["idx0"] = Scal(0);  // scalar index -> scalar Gather result
+    g.initializer["sixty"] = Vec({60});
+    g.node = {N("Shape", {"x"}, {"s"}),
+              N("Gather", {"s", "idx0"}, {"bscalar"}, {AInt("axis", 0)}),
+              N("Unsqueeze", {"bscalar"}, {"bvec"}, {AInts("axes", {0})}),
+              N("Concat", {"bvec", "sixty"}, {"newshape"}, {AInt("axis", 0)})};
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(Is(v, "bscalar", {"batch"}, /*scalar=*/true));
+    assert(Is(v, "bvec", {"batch"}, false));
+    assert(Is(v, "newshape", {"batch", "60"}, false));
+  }
+
+  // === Value survives a flattening Reshape ==================================
+  // (tests/test_simple.py::test_data_propagation_through_reshape)
+  //   Shape(x) -> Reshape(., [-1]) -> Gather([1, 2]) == [3, 4]
+  {
+    SymGraph g;
+    g.shape["x"] = {batch, SymExpr(3), SymExpr(4)};
+    g.initializer["flat"] = Vec({-1});
+    g.initializer["indices"] = Vec({1, 2});
+    g.node = {N("Shape", {"x"}, {"s"}), N("Reshape", {"s", "flat"}, {"s2"}),
+              N("Gather", {"s2", "indices"}, {"gout"}, {AInt("axis", 0)})};
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(Is(v, "s2", {"batch", "3", "4"}, false));
+    assert(Is(v, "gout", {"3", "4"}, false));
+  }
+
+  // === Div: Reshape's -1 resolved as total // non_deferred =================
+  //   ReduceProd(Shape([batch, 1024, 128])) / 131072  ==  batch
+  {
+    SymGraph g;
+    g.shape["x"] = {batch, SymExpr(1024), SymExpr(128)};
+    g.initializer["den"] = Vec({1024 * 128});
+    g.node = {N("Shape", {"x"}, {"s"}),
+              N("ReduceProd", {"s"}, {"total"}, {AInt("keepdims", 1)}),
+              N("Div", {"total", "den"}, {"q"})};
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(Is(v, "total", {"131072*batch"}, false));
+    assert(Is(v, "q", {"batch"}, false));
+  }
+
+  // A Div that does not divide evenly is undecidable -> no value emitted.
+  {
+    SymGraph g;
+    g.shape["x"] = {batch};
+    g.initializer["two"] = Vec({2});
+    g.node = {N("Shape", {"x"}, {"s"}), N("Div", {"s", "two"}, {"q"})};
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(v.find("q") == v.end());
+  }
+
+  // === Equal + Where over decidable comparisons ============================
+  {
+    SymGraph g;
+    g.shape["x"] = {batch, SymExpr(3)};
+    g.initializer["idx1"] = Vec({1});
+    g.initializer["three"] = Vec({3});
+    g.initializer["a"] = Vec({7});
+    g.initializer["b"] = Vec({9});
+    g.node = {N("Shape", {"x"}, {"s"}),
+              N("Gather", {"s", "idx1"}, {"dim1"}, {AInt("axis", 0)}),
+              N("Equal", {"dim1", "three"}, {"cond"}),
+              N("Where", {"cond", "a", "b"}, {"sel"})};
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(Is(v, "cond", {"1"}, false));  // 3 == 3
+    assert(Is(v, "sel", {"7"}, false));
+  }
+
+  // A Where whose condition is undecidable (symbolic Equal) emits nothing.
+  {
+    SymGraph g;
+    g.shape["x"] = {batch};
+    g.initializer["five"] = Vec({5});
+    g.initializer["a"] = Vec({7});
+    g.initializer["b"] = Vec({9});
+    g.node = {N("Shape", {"x"}, {"bdim"}),  // [batch]
+              N("Equal", {"bdim", "five"}, {"cond"}),
+              N("Where", {"cond", "a", "b"}, {"sel"})};
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(v.find("cond") == v.end());
+    assert(v.find("sel") == v.end());
+  }
+
+  // === Expand broadcasts shape data ========================================
+  {
+    SymGraph g;
+    g.initializer["v"] = Scal(5);
+    g.initializer["shape"] = Vec({3});
+    g.node = {N("Expand", {"v", "shape"}, {"e"})};
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(Is(v, "e", {"5", "5", "5"}, false));
+  }
+
+  // === ConstantOfShape fills a length from another value ===================
+  {
+    SymGraph g;
+    g.initializer["shape"] = Vec({4});
+    g.node = {N("ConstantOfShape", {"shape"}, {"z"}),  // default fill 0
+              N("ConstantOfShape", {"shape"}, {"ones"}, {ATensor("value", Scal(1))})};
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(Is(v, "z", {"0", "0", "0", "0"}, false));
+    assert(Is(v, "ones", {"1", "1", "1", "1"}, false));
+  }
+
+  // === Range / Tile / Slice / ReduceProd / Size / Cast / Squeeze ===========
+  {
+    SymGraph g;
+    g.shape["x"] = {batch, SymExpr(6)};
+    g.initializer["start"] = Scal(0);
+    g.initializer["limit"] = Scal(4);
+    g.initializer["delta"] = Scal(1);
+    g.initializer["reps"] = Vec({2});
+    g.initializer["data"] = Vec({10, 11, 12, 13});
+    g.node = {
+        N("Range", {"start", "limit", "delta"}, {"r"}),      // [0,1,2,3]
+        N("Tile", {"r", "reps"}, {"tiled"}),                 // [0,1,2,3,0,1,2,3]
+        N("Slice", {"data"}, {"sl"},                         // data[1:3] -> [11,12]
+          {AInts("starts", {1}), AInts("ends", {3}), AInts("axes", {0})}),
+        N("Size", {"x"}, {"sz"}),                            // batch*6
+        N("Cast", {"data"}, {"casted"}, {AInt("to", 6)}),    // INT32 -> unchanged
+    };
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(Is(v, "r", {"0", "1", "2", "3"}, false));
+    assert(Is(v, "tiled", {"0", "1", "2", "3", "0", "1", "2", "3"}, false));
+    assert(Is(v, "sl", {"11", "12"}, false));
+    assert(Is(v, "sz", {"6*batch"}, /*scalar=*/true));
+    assert(Is(v, "casted", {"10", "11", "12", "13"}, false));
+  }
+
+  // Slice with a negative step reverses; Squeeze [1] -> scalar.
+  {
+    SymGraph g;
+    g.initializer["data"] = Vec({0, 1, 2, 3});
+    g.initializer["one"] = Vec({1});
+    g.node = {
+        N("Slice", {"data"}, {"rev"},
+          {AInts("starts", {3}), AInts("ends", {-5}), AInts("axes", {0}),
+           AInts("steps", {-1})}),
+        N("Squeeze", {"one"}, {"scl"}),
+    };
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(Is(v, "rev", {"3", "2", "1", "0"}, false));
+    assert(Is(v, "scl", {"1"}, /*scalar=*/true));
+  }
+
+  // Cast to a float type is not modelled -> unresolved.
+  {
+    SymGraph g;
+    g.initializer["data"] = Vec({3, 4});
+    g.node = {N("Cast", {"data"}, {"f"}, {AInt("to", 1)})};  // FLOAT
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(v.find("f") == v.end());
+  }
+
+  // === Min / Max: decidable only on a concrete difference ==================
+  {
+    SymGraph g;
+    g.shape["x"] = {batch};
+    g.initializer["three"] = Vec({3});
+    g.initializer["five"] = Vec({5});
+    g.node = {
+        N("Min", {"three", "five"}, {"mn"}),  // 3
+        N("Max", {"three", "five"}, {"mx"}),  // 5
+        N("Shape", {"x"}, {"bdim"}),
+        N("Max", {"bdim", "five"}, {"undec"}),  // max(batch, 5) undecidable
+    };
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(Is(v, "mn", {"3"}, false));
+    assert(Is(v, "mx", {"5"}, false));
+    assert(v.find("undec") == v.end());
+  }
+
+  // === Add / Sub / Mul with broadcasting ===================================
+  {
+    SymGraph g;
+    g.shape["x"] = {batch, SymExpr(3)};
+    g.initializer["one"] = Scal(1);
+    g.node = {
+        N("Shape", {"x"}, {"s"}),          // [batch, 3]
+        N("Add", {"s", "one"}, {"plus"}),  // [batch + 1, 4]
+        N("Mul", {"s", "s"}, {"sq"}),      // [batch**2, 9]
+    };
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(Is(v, "plus", {"batch + 1", "4"}, false));
+    assert(Is(v, "sq", {"batch**2", "9"}, false));
+  }
+
+  // === Constant node seeds (value_ints) ====================================
+  {
+    SymGraph g;
+    g.node = {N("Constant", {}, {"c"}, {AInts("value_ints", {2, 3})})};
+    const auto v = onnxsim::EvaluateSymbolicValues(g);
+    assert(Is(v, "c", {"2", "3"}, false));
+  }
+
+  std::cout << "sym_value_eval_test: all assertions passed\n";
+  return 0;
+}

--- a/onnxsim/sym_value_eval_test.cpp
+++ b/onnxsim/sym_value_eval_test.cpp
@@ -106,8 +106,8 @@ int main() {
   }
 
   // === Shape -> Gather(batch) -> Concat -> [batch, 60] ======================
-  // The single-symbolic-entry shape the #526 Reshape rewrite turns into [-1,60].
-  // Also exercises the scalar-index -> Unsqueeze -> Concat variant.
+  // The single-symbolic-entry shape the #526 Reshape rewrite turns into
+  // [-1,60]. Also exercises the scalar-index -> Unsqueeze -> Concat variant.
   {
     SymGraph g;
     g.shape["x"] = {batch, SymExpr(3), SymExpr(4), SymExpr(5)};
@@ -208,8 +208,9 @@ int main() {
   {
     SymGraph g;
     g.initializer["shape"] = Vec({4});
-    g.node = {N("ConstantOfShape", {"shape"}, {"z"}),  // default fill 0
-              N("ConstantOfShape", {"shape"}, {"ones"}, {ATensor("value", Scal(1))})};
+    g.node = {
+        N("ConstantOfShape", {"shape"}, {"z"}),  // default fill 0
+        N("ConstantOfShape", {"shape"}, {"ones"}, {ATensor("value", Scal(1))})};
     const auto v = onnxsim::EvaluateSymbolicValues(g);
     assert(Is(v, "z", {"0", "0", "0", "0"}, false));
     assert(Is(v, "ones", {"1", "1", "1", "1"}, false));
@@ -225,12 +226,12 @@ int main() {
     g.initializer["reps"] = Vec({2});
     g.initializer["data"] = Vec({10, 11, 12, 13});
     g.node = {
-        N("Range", {"start", "limit", "delta"}, {"r"}),      // [0,1,2,3]
-        N("Tile", {"r", "reps"}, {"tiled"}),                 // [0,1,2,3,0,1,2,3]
-        N("Slice", {"data"}, {"sl"},                         // data[1:3] -> [11,12]
+        N("Range", {"start", "limit", "delta"}, {"r"}),  // [0,1,2,3]
+        N("Tile", {"r", "reps"}, {"tiled"}),             // [0,1,2,3,0,1,2,3]
+        N("Slice", {"data"}, {"sl"},                     // data[1:3] -> [11,12]
           {AInts("starts", {1}), AInts("ends", {3}), AInts("axes", {0})}),
-        N("Size", {"x"}, {"sz"}),                            // batch*6
-        N("Cast", {"data"}, {"casted"}, {AInt("to", 6)}),    // INT32 -> unchanged
+        N("Size", {"x"}, {"sz"}),                          // batch*6
+        N("Cast", {"data"}, {"casted"}, {AInt("to", 6)}),  // INT32 -> unchanged
     };
     const auto v = onnxsim::EvaluateSymbolicValues(g);
     assert(Is(v, "r", {"0", "1", "2", "3"}, false));


### PR DESCRIPTION
## Summary
Implements a dependency-free symbolic value evaluator for ONNX shape scaffolding operations that can propagate dynamic dimensions through arithmetic and control flow operations. This addresses the limitation where ONNX data propagation cannot fold graphs containing dynamic dimensions.

## Key Changes
- **New symbolic evaluator** (`sym_value_eval.h/cpp`): Evaluates shape-related operations while preserving symbolic expressions for dynamic dimensions
  - Supports 25+ ONNX operations including Shape, Gather, Concat, Reshape, Div, Equal, Where, Min/Max, and arithmetic ops
  - Maintains symbolic values as `SymExpr` (integer-coefficient polynomials) through the computation graph
  - Implements numpy broadcasting semantics for elementwise operations
  
- **Conservative evaluation strategy**: Only produces output values when operations are fully decidable
  - Undecidable operations (e.g., symbolic division that doesn't divide evenly, symbolic comparisons) leave outputs absent
  - Prevents incorrect constant folding while allowing partial shape propagation
  
- **Comprehensive test suite** (`sym_value_eval_test.cpp`): 311-line standalone test covering:
  - Shape propagation through Gather with dynamic batch dimensions
  - Reshape with -1 dimension resolution via division
  - Conditional evaluation with Equal/Where
  - Broadcasting and arithmetic operations
  - Edge cases and undecidable scenarios
  
- **Build integration**: Updated CMakeLists.txt to include new source files in the onnxsim library

## Implementation Details
- Pure C++17 with no external dependencies (ONNX, SymEngine, sympy) - builds identically under Emscripten/WASM
- Evaluator walks the graph once in topological order, maintaining a value table seeded from initializers and Shape operations
- Rank ≤1 tensor model matches the shape scaffolding patterns (scalars and 1-D vectors)
- Each operation handler validates preconditions and returns `std::optional<SymTensor>` to signal undecidable cases

https://claude.ai/code/session_01FWo7i8BH8WHN8CB2HF193W