### PR TITLE
Enable branch coverage reporting in Python coverage analysis

### DIFF
--- a/scripts/coverage/README.md
+++ b/scripts/coverage/README.md
@@ -75,8 +75,9 @@ The script is a thin wrapper; the manual flow is:
 COVERAGE=1 python3 -m pip install -e . --no-build-isolation
 
 # 2. clear stale C++ profiles, then run the suite under coverage.py
+#    (--cov-branch so the Python side reports branch coverage, not just lines)
 find .setuptools-cmake-build -name '*.gcda' -delete
-python3 -m pytest --cov=onnxsim --cov-report=term-missing tests
+python3 -m pytest --cov=onnxsim --cov-branch --cov-report=term-missing tests
 
 # 3. collect the C++ side
 gcovr --root . --filter onnxsim/ --exclude '.*third_party.*' \

--- a/scripts/coverage/run_coverage.sh
+++ b/scripts/coverage/run_coverage.sh
@@ -79,9 +79,14 @@ find "${BUILD_DIR}" -name '*.gcda' -delete 2>/dev/null || true
 
 # 3. Run pytest under coverage.py. `--cov=onnxsim` measures the Python package;
 #    the C++ profiles accumulate as a side effect of the extension running.
+#    `--cov-branch` records branch (decision) coverage too. Without it coverage.py
+#    collects lines only and writes branches-valid="0" into python.xml, which the
+#    combined summary renders as a misleading 0% branch rate for the Python side
+#    (gcov measures C++ branches by default, so only the Python half was blank).
 echo "==> Running pytest with Python coverage"
 python3 -m pytest \
   --cov=onnxsim \
+  --cov-branch \
   --cov-report="xml:${OUTPUT_DIR}/python.xml" \
   --cov-report="html:${OUTPUT_DIR}/python-html" \
   --cov-report=term-missing \


### PR DESCRIPTION
## Summary
This change enables branch (decision) coverage tracking in the Python coverage analysis by adding the `--cov-branch` flag to pytest invocations. This ensures that both line and branch coverage metrics are properly collected and reported for the Python side of the codebase.

## Key Changes
- Added `--cov-branch` flag to the pytest command in `scripts/coverage/run_coverage.sh` to enable branch coverage collection
- Updated `scripts/coverage/README.md` to document the branch coverage flag and reflect the change in the manual workflow example
- Added detailed comments explaining why branch coverage is necessary: without it, coverage.py only collects line coverage and writes `branches-valid="0"` to the XML report, which causes the combined summary to incorrectly show 0% branch rate for Python (while gcov properly measures C++ branches by default)

## Implementation Details
The `--cov-branch` flag ensures that coverage.py records decision/branch coverage in addition to line coverage. This is particularly important for the combined coverage report that merges both Python (coverage.py) and C++ (gcov) metrics, preventing misleading 0% branch coverage statistics for the Python portion of the codebase.

https://claude.ai/code/session_01KtGqUzMWE7n73Ry3mbsndz