### PR TITLE
Add path filters to static workflow for WASM demo builds

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -7,8 +7,27 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["master", "pages"]
+    # Only rebuild/deploy the WASM convertmodel demo when files that actually
+    # affect it change (the C++ sources, the build scripts, the demo assets,
+    # or this workflow itself).
+    paths:
+      - ".github/workflows/static.yml"
+      - "build_wasm.sh"
+      - "CMakeLists.txt"
+      - "cmake/**"
+      - "onnxsim/**"
+      - "scripts/convertmodel/**"
+      - ".gitmodules"
 
   pull_request:
+    paths:
+      - ".github/workflows/static.yml"
+      - "build_wasm.sh"
+      - "CMakeLists.txt"
+      - "cmake/**"
+      - "onnxsim/**"
+      - "scripts/convertmodel/**"
+      - ".gitmodules"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## Summary
This change adds path-based filtering to the GitHub Actions static workflow to optimize CI/CD performance by only running the WASM convertmodel demo build when relevant files are modified.

## Key Changes
- Added `paths` filter to the `push` trigger (targeting `master` and `pages` branches) to only run on changes to:
  - Workflow configuration (`.github/workflows/static.yml`)
  - Build scripts (`build_wasm.sh`, `CMakeLists.txt`, `cmake/**`)
  - Source code (`onnxsim/**`, `scripts/convertmodel/**`)
  - Git submodule configuration (`.gitmodules`)

- Added identical `paths` filter to the `pull_request` trigger to apply the same optimization for PR workflows

## Benefits
- Reduces unnecessary workflow runs when unrelated files are modified
- Saves CI/CD resources and reduces feedback latency for developers
- Maintains full builds only when changes actually affect the WASM demo

https://claude.ai/code/session_013oTj1Dr7A2X1JX1osmfBSx