### PR TITLE
Add Hugging Face model loading to converter page

### DIFF
--- a/.github/workflows/convertmodel-inference.yml
+++ b/.github/workflows/convertmodel-inference.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Run Hugging Face loader unit test
         working-directory: scripts/convertmodel
         run: npm run test:hf
+      - name: Run Xet chunk-cache unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:xet
       - name: Run inference smoke test (wasm EP)
         working-directory: scripts/convertmodel
         run: npm run test:inference

--- a/.github/workflows/convertmodel-inference.yml
+++ b/.github/workflows/convertmodel-inference.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run MAC-metrics reader unit test
         working-directory: scripts/convertmodel
         run: npm run test:macs
+      - name: Run Hugging Face loader unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:hf
       - name: Run inference smoke test (wasm EP)
         working-directory: scripts/convertmodel
         run: npm run test:inference

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -17,6 +17,7 @@ on:
       - "cmake/**"
       - "onnxsim/**"
       - "scripts/convertmodel/**"
+      - "scripts/regression/models.json"
       - ".gitmodules"
 
   pull_request:
@@ -27,6 +28,7 @@ on:
       - "cmake/**"
       - "onnxsim/**"
       - "scripts/convertmodel/**"
+      - "scripts/regression/models.json"
       - ".gitmodules"
 
   # Allows you to run this workflow manually from the Actions tab
@@ -96,6 +98,11 @@ jobs:
           cp build-wasm-node-OFF/onnxsim.* scripts/convertmodel
       - run: |
           ccache -s
+
+      # Ship the curated regression model set next to the page so the
+      # "Load from Hugging Face" dropdown can fetch it same-origin (it falls
+      # back to the raw GitHub copy when this file is absent, e.g. local dev).
+      - run: cp scripts/regression/models.json scripts/convertmodel/models.json
 
       # Build the patched Netron (embedding protocol + embedded mode) and serve
       # it from the converter's own origin at ./netron/, so the page can post

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,8 @@ node_modules/
 # is committed — they are produced at deploy time.
 /scripts/convertmodel/netron/
 /netron-src/
+
+# The curated model list is copied next to the page by the deploy workflow so
+# the "Load from Hugging Face" dropdown can read it same-origin. The source of
+# truth is scripts/regression/models.json; the copy is a build artifact.
+/scripts/convertmodel/models.json

--- a/scripts/convertmodel/hf_load.mjs
+++ b/scripts/convertmodel/hf_load.mjs
@@ -79,23 +79,46 @@ async function doLoad() {
   if (statusEl) statusEl.textContent = "loading…";
   try {
     log(`loading model from Hugging Face: ${ref}`);
-    // Live download progress in the status line. Update only when the whole-
-    // percent (or, without a Content-Length, the rounded MB) changes, so the
-    // DOM isn't rewritten on every chunk.
+    // Live download progress + speed in the status line. Speed is smoothed with
+    // an exponential moving average so it doesn't jitter per chunk. The DOM is
+    // only rewritten when the whole-percent (or, without a Content-Length, the
+    // rounded MB) changes, but timing is sampled on every chunk for accuracy.
     let lastShown = -1;
+    let startedAt = 0;
+    let lastAt = 0;
+    let lastLoaded = 0;
+    let emaRate = 0; // bytes/sec
+    const resetProgress = () => {
+      lastShown = -1;
+      startedAt = lastAt = performance.now();
+      lastLoaded = 0;
+      emaRate = 0;
+    };
+    resetProgress();
     const onProgress = ({ loaded, total }) => {
       if (!statusEl) return;
+      // Update the smoothed rate every call, before the display throttle.
+      const now = performance.now();
+      const dt = (now - lastAt) / 1000;
+      if (dt > 0 && loaded > lastLoaded) {
+        const inst = (loaded - lastLoaded) / dt;
+        emaRate = emaRate === 0 ? inst : emaRate * 0.7 + inst * 0.3;
+        lastAt = now;
+        lastLoaded = loaded;
+      }
+      const speed = emaRate > 0 ? ` — ${humanBytes(emaRate)}/s` : "";
+
       if (total > 0) {
         const pct = Math.floor((loaded / total) * 100);
         if (pct === lastShown) return;
         lastShown = pct;
         statusEl.textContent =
-          `downloading… ${pct}% (${humanBytes(loaded)} / ${humanBytes(total)})`;
+          `downloading… ${pct}% (${humanBytes(loaded)} / ${humanBytes(total)})${speed}`;
       } else {
         const mb = Math.floor(loaded / (1024 * 1024));
         if (mb === lastShown) return;
         lastShown = mb;
-        statusEl.textContent = `downloading… ${humanBytes(loaded)}`;
+        statusEl.textContent = `downloading… ${humanBytes(loaded)}${speed}`;
       }
     };
     let bytes;
@@ -120,11 +143,16 @@ async function doLoad() {
         if (hits > 0) log(`reused ${hits} cached chunk(s) (${humanBytes(hitBytes)})`);
       } catch (e) {
         log(`Xet path unavailable (${e && e.message ? e.message : e}); falling back to direct download`);
-        lastShown = -1;
+        resetProgress();
         ({ bytes, name } = await fetchModelBytes(ref, log, onProgress));
       }
     } else {
       ({ bytes, name } = await fetchModelBytes(ref, log, onProgress));
+    }
+    // Report the average download speed over the whole transfer.
+    const elapsed = (performance.now() - startedAt) / 1000;
+    if (elapsed > 0 && bytes && bytes.length) {
+      log(`download average ${humanBytes(bytes.length / elapsed)}/s over ${elapsed.toFixed(1)}s`);
     }
     if (statusEl) statusEl.textContent = "converting…";
     // Publish as the "original" model so the Run inference panel can run it —

--- a/scripts/convertmodel/hf_load.mjs
+++ b/scripts/convertmodel/hf_load.mjs
@@ -158,6 +158,12 @@ async function doLoad() {
     // Publish as the "original" model so the Run inference panel can run it —
     // there is no file-input entry for a Hugging Face download.
     window.__onnxsimOriginal = { bytes, name };
+    // Render the "before" Netron pane too: it normally watches the file input,
+    // which a Hugging Face download bypasses, so drive it explicitly here.
+    // (toArrayBuffer copies the bytes, leaving our Uint8Array intact.)
+    if (typeof window.netronShowBefore === "function") {
+      window.netronShowBefore(bytes, name);
+    }
     // Hand a *copy* to the worker: the buffer is transferred (detached) on
     // postMessage, so copying keeps `bytes` intact for the inference panel.
     const copy = bytes.slice();

--- a/scripts/convertmodel/hf_load.mjs
+++ b/scripts/convertmodel/hf_load.mjs
@@ -6,7 +6,7 @@
 // that entry point as `window.__onnxsimStartConversion` and enables the controls
 // below (via `maybeEnableInput`) only once both WASM runtimes are ready.
 
-import { loadModelList, fetchModelBytes } from "./hf_models.mjs";
+import { loadModelList, fetchModelBytes, humanBytes } from "./hf_models.mjs";
 
 const select = document.getElementById("hf-model-select");
 const refInput = document.getElementById("hf-model-input");
@@ -64,7 +64,27 @@ async function doLoad() {
   if (statusEl) statusEl.textContent = "loading…";
   try {
     log(`loading model from Hugging Face: ${ref}`);
-    const { bytes, name } = await fetchModelBytes(ref, log);
+    // Live download progress in the status line. Update only when the whole-
+    // percent (or, without a Content-Length, the rounded MB) changes, so the
+    // DOM isn't rewritten on every chunk.
+    let lastShown = -1;
+    const onProgress = ({ loaded, total }) => {
+      if (!statusEl) return;
+      if (total > 0) {
+        const pct = Math.floor((loaded / total) * 100);
+        if (pct === lastShown) return;
+        lastShown = pct;
+        statusEl.textContent =
+          `downloading… ${pct}% (${humanBytes(loaded)} / ${humanBytes(total)})`;
+      } else {
+        const mb = Math.floor(loaded / (1024 * 1024));
+        if (mb === lastShown) return;
+        lastShown = mb;
+        statusEl.textContent = `downloading… ${humanBytes(loaded)}`;
+      }
+    };
+    const { bytes, name } = await fetchModelBytes(ref, log, onProgress);
+    if (statusEl) statusEl.textContent = "converting…";
     // Publish as the "original" model so the Run inference panel can run it —
     // there is no file-input entry for a Hugging Face download.
     window.__onnxsimOriginal = { bytes, name };
@@ -72,7 +92,8 @@ async function doLoad() {
     // postMessage, so copying keeps `bytes` intact for the inference panel.
     const copy = bytes.slice();
     window.__onnxsimStartConversion(name, copy.buffer);
-    if (statusEl) statusEl.textContent = "";
+    // Leave "converting…" showing; it is cleared when the worker signals the
+    // conversion is done (the onnxsim:converted listener below).
   } catch (e) {
     log("Hugging Face load failed: " + (e && e.message ? e.message : String(e)));
     if (statusEl) statusEl.textContent = "failed — see console output";
@@ -93,3 +114,10 @@ if (refInput) {
     }
   });
 }
+
+// index.html fires this once a conversion finishes; clear the "converting…"
+// status so the panel returns to idle (harmless for file-upload conversions,
+// where the status line is already empty).
+window.addEventListener("onnxsim:converted", () => {
+  if (statusEl) statusEl.textContent = "";
+});

--- a/scripts/convertmodel/hf_load.mjs
+++ b/scripts/convertmodel/hf_load.mjs
@@ -6,7 +6,13 @@
 // that entry point as `window.__onnxsimStartConversion` and enables the controls
 // below (via `maybeEnableInput`) only once both WASM runtimes are ready.
 
-import { loadModelList, fetchModelBytes, humanBytes } from "./hf_models.mjs";
+import {
+  loadModelList,
+  fetchModelBytes,
+  fetchModelBytesXet,
+  humanBytes,
+} from "./hf_models.mjs";
+import { openXetCache, makeCachingFetch } from "./xet_cache.mjs";
 
 const select = document.getElementById("hf-model-select");
 const refInput = document.getElementById("hf-model-input");
@@ -14,6 +20,15 @@ const loadBtn = document.getElementById("hf-load-button");
 const statusEl = document.getElementById("hf-status");
 const fileInput = document.getElementById("file-input");
 const logOutput = document.getElementById("log-output");
+const xetToggle = document.getElementById("hf-use-xet");
+const clearCacheBtn = document.getElementById("hf-clear-cache");
+
+// The persistent chunk cache is created lazily on first Xet use.
+let xetCache = null;
+function getXetCache() {
+  if (!xetCache) xetCache = openXetCache();
+  return xetCache;
+}
 
 const log = (msg) => {
   if (!logOutput) return;
@@ -83,7 +98,34 @@ async function doLoad() {
         statusEl.textContent = `downloading… ${humanBytes(loaded)}`;
       }
     };
-    const { bytes, name } = await fetchModelBytes(ref, log, onProgress);
+    let bytes;
+    let name;
+    if (xetToggle && xetToggle.checked) {
+      // Experimental Xet path, with the persistent chunk cache. Any failure
+      // (non-Xet repo, CORS on the CAS endpoints, …) falls back to the direct
+      // download so the toggle can never break loading.
+      let hits = 0;
+      let hitBytes = 0;
+      const cachingFetch = makeCachingFetch(
+        globalThis.fetch.bind(globalThis),
+        getXetCache(),
+        { onHit: (_k, n) => { hits += 1; hitBytes += n; } },
+      );
+      try {
+        ({ bytes, name } = await fetchModelBytesXet(ref, {
+          onLog: log,
+          onProgress,
+          fetchImpl: cachingFetch,
+        }));
+        if (hits > 0) log(`reused ${hits} cached chunk(s) (${humanBytes(hitBytes)})`);
+      } catch (e) {
+        log(`Xet path unavailable (${e && e.message ? e.message : e}); falling back to direct download`);
+        lastShown = -1;
+        ({ bytes, name } = await fetchModelBytes(ref, log, onProgress));
+      }
+    } else {
+      ({ bytes, name } = await fetchModelBytes(ref, log, onProgress));
+    }
     if (statusEl) statusEl.textContent = "converting…";
     // Publish as the "original" model so the Run inference panel can run it —
     // there is no file-input entry for a Hugging Face download.
@@ -111,6 +153,17 @@ if (refInput) {
     if (e.key === "Enter") {
       e.preventDefault();
       doLoad();
+    }
+  });
+}
+
+if (clearCacheBtn) {
+  clearCacheBtn.addEventListener("click", async () => {
+    try {
+      await getXetCache().clear();
+      log("Xet chunk cache cleared");
+    } catch (e) {
+      log("could not clear Xet cache: " + (e && e.message ? e.message : e));
     }
   });
 }

--- a/scripts/convertmodel/hf_load.mjs
+++ b/scripts/convertmodel/hf_load.mjs
@@ -1,0 +1,95 @@
+// Wires the "Load from Hugging Face" panel on the converter page.
+//
+// It populates the dropdown from the curated regression set, resolves whatever
+// the user picked or typed to model bytes (hf_models.mjs), and then hands those
+// bytes to the same conversion path an uploaded file uses. index.html publishes
+// that entry point as `window.__onnxsimStartConversion` and enables the controls
+// below (via `maybeEnableInput`) only once both WASM runtimes are ready.
+
+import { loadModelList, fetchModelBytes } from "./hf_models.mjs";
+
+const select = document.getElementById("hf-model-select");
+const refInput = document.getElementById("hf-model-input");
+const loadBtn = document.getElementById("hf-load-button");
+const statusEl = document.getElementById("hf-status");
+const fileInput = document.getElementById("file-input");
+const logOutput = document.getElementById("log-output");
+
+const log = (msg) => {
+  if (!logOutput) return;
+  logOutput.value += msg + "\n";
+  logOutput.scrollTop = logOutput.scrollHeight;
+};
+
+// Fill the dropdown with the curated onnxmodelzoo set. The list is advisory —
+// the free-text box accepts any repo id or .onnx URL regardless.
+loadModelList().then((ids) => {
+  if (!select) return;
+  if (!ids.length) {
+    const opt = document.createElement("option");
+    opt.value = "";
+    opt.textContent = "(model list unavailable — type a repo id or URL)";
+    select.appendChild(opt);
+    return;
+  }
+  for (const id of ids) {
+    const opt = document.createElement("option");
+    opt.value = id;
+    opt.textContent = id.replace(/^onnxmodelzoo\//, "");
+    select.appendChild(opt);
+  }
+});
+
+// Picking from the dropdown mirrors into the text box so the two never disagree
+// about what "Load" will fetch, and the user can tweak the id before loading.
+if (select && refInput) {
+  select.addEventListener("change", () => {
+    if (select.value) refInput.value = select.value;
+  });
+}
+
+async function doLoad() {
+  const ref = ((refInput && refInput.value) || (select && select.value) || "").trim();
+  if (!ref) {
+    log("enter a Hugging Face repo id or .onnx URL, or pick one from the list");
+    return;
+  }
+  if (typeof window.__onnxsimStartConversion !== "function") {
+    log("WebAssembly runtime not ready yet — try again in a moment");
+    return;
+  }
+
+  loadBtn.disabled = true;
+  if (fileInput) fileInput.disabled = true;
+  if (statusEl) statusEl.textContent = "loading…";
+  try {
+    log(`loading model from Hugging Face: ${ref}`);
+    const { bytes, name } = await fetchModelBytes(ref, log);
+    // Publish as the "original" model so the Run inference panel can run it —
+    // there is no file-input entry for a Hugging Face download.
+    window.__onnxsimOriginal = { bytes, name };
+    // Hand a *copy* to the worker: the buffer is transferred (detached) on
+    // postMessage, so copying keeps `bytes` intact for the inference panel.
+    const copy = bytes.slice();
+    window.__onnxsimStartConversion(name, copy.buffer);
+    if (statusEl) statusEl.textContent = "";
+  } catch (e) {
+    log("Hugging Face load failed: " + (e && e.message ? e.message : String(e)));
+    if (statusEl) statusEl.textContent = "failed — see console output";
+    // The conversion never started, so re-enable the file picker here (normally
+    // the worker's convert-done message does that).
+    if (fileInput) fileInput.disabled = false;
+  } finally {
+    loadBtn.disabled = false;
+  }
+}
+
+if (loadBtn) loadBtn.addEventListener("click", doLoad);
+if (refInput) {
+  refInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      doLoad();
+    }
+  });
+}

--- a/scripts/convertmodel/hf_models.mjs
+++ b/scripts/convertmodel/hf_models.mjs
@@ -189,3 +189,73 @@ export async function fetchModelBytes(ref, onLog = () => {}, onProgress = () => 
   onLog(`downloaded ${name} (${bytes.length.toLocaleString()} bytes)`);
   return { bytes, name, repo: parsed.repo };
 }
+
+// Pinned @huggingface/hub build for the experimental Xet download path. Loaded
+// lazily (only when the Xet toggle is used) from a CDN, mirroring how the
+// inference panel lazy-loads onnxruntime-web.
+const HF_HUB_ESM = "https://esm.sh/@huggingface/hub@2.14.4";
+
+// Read a Blob (e.g. the XetBlob returned by downloadFile) to a Uint8Array,
+// reporting streaming progress against its known size.
+async function readBlobWithProgress(blob, onProgress) {
+  const total = blob.size || 0;
+  if (typeof blob.stream !== "function") {
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+    onProgress({ loaded: bytes.length, total: total || bytes.length });
+    return bytes;
+  }
+  const reader = blob.stream().getReader();
+  const chunks = [];
+  let loaded = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    loaded += value.length;
+    onProgress({ loaded, total });
+  }
+  const bytes = new Uint8Array(loaded);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return bytes;
+}
+
+// EXPERIMENTAL: download a model over the Hugging Face Xet protocol via
+// @huggingface/hub's downloadFile, which reconstructs the file from
+// content-addressed blocks. Pass `fetchImpl` (e.g. the caching fetch from
+// xet_cache.mjs) to persist those blocks across loads. Only Hub repos are
+// supported (not arbitrary URLs). Returns { bytes, name, repo }; the caller is
+// expected to fall back to fetchModelBytes() on any failure (CORS, unsupported).
+export async function fetchModelBytesXet(
+  ref,
+  { onLog = () => {}, onProgress = () => {}, fetchImpl } = {},
+) {
+  const parsed = parseRef(ref);
+  if (!parsed.repo) {
+    throw new Error("Xet download needs a Hugging Face repo, not a direct URL");
+  }
+  const revision = parsed.revision || "main";
+  let file = parsed.file;
+  if (!file) {
+    onLog(`querying Hugging Face for the .onnx file in ${parsed.repo}…`);
+    file = await findOnnxFile(parsed.repo, onLog);
+  }
+
+  onLog(`downloading ${file} from ${parsed.repo} via Xet…`);
+  const { downloadFile } = await import(/* @vite-ignore */ HF_HUB_ESM);
+  const blob = await downloadFile({
+    repo: parsed.repo,
+    path: file,
+    revision,
+    fetch: fetchImpl,
+  });
+  if (!blob) throw new Error(`file not found: ${parsed.repo}/${file}`);
+
+  const name = file.split("/").pop();
+  const bytes = await readBlobWithProgress(blob, onProgress);
+  onLog(`downloaded ${name} (${bytes.length.toLocaleString()} bytes via Xet)`);
+  return { bytes, name, repo: parsed.repo };
+}

--- a/scripts/convertmodel/hf_models.mjs
+++ b/scripts/convertmodel/hf_models.mjs
@@ -1,0 +1,146 @@
+// Load ONNX models straight from the Hugging Face Hub into the converter page.
+//
+// The page can already convert a locally-picked file; this module lets it pull
+// a model over HTTPS instead, either from the curated regression set (the
+// `onnxmodelzoo` org listed in scripts/regression/models.json) or from any repo
+// id / .onnx URL the user pastes in. The Hub serves both its JSON API and the
+// file `resolve` endpoint with permissive CORS, so a browser `fetch` is all
+// that's needed — nothing is proxied through a server.
+//
+// This module is pure data/networking: it returns model bytes, and index.html
+// feeds them into the same conversion path an uploaded file takes.
+
+const HF = "https://huggingface.co";
+// Default org for bare names, matching scripts/regression/model_zoo.py.
+const ORG = "onnxmodelzoo";
+
+// Where to find the curated model list. The static deploy ships models.json
+// next to this page (see .github/workflows/static.yml); the raw GitHub copy is
+// a fallback for local dev, where the sibling regression dir isn't served.
+const MODEL_LIST_SOURCES = [
+  "./models.json",
+  "https://raw.githubusercontent.com/onnxsim/onnxsim/master/scripts/regression/models.json",
+];
+
+// Fetch the curated regression model ids for the dropdown. Returns [] (rather
+// than throwing) when no source is reachable, so the free-text box still works.
+export async function loadModelList() {
+  for (const src of MODEL_LIST_SOURCES) {
+    try {
+      const r = await fetch(src);
+      if (!r.ok) continue;
+      const data = await r.json();
+      const ids = (data.models || []).map((m) => m.id).filter(Boolean);
+      if (ids.length) return ids;
+    } catch {
+      // try the next source
+    }
+  }
+  return [];
+}
+
+// Turn a user reference into { repo, file?, revision?, url?, name? }.
+//
+//   "resnet18d_Opset18"                         -> onnxmodelzoo/resnet18d_Opset18
+//   "onnxmodelzoo/resnet18d_Opset18"            -> that repo (file discovered)
+//   ".../<repo>/resolve/<rev>/<path>.onnx"      -> that exact file
+//   ".../<repo>/blob/<rev>/<path>.onnx"         -> that exact file
+//   "https://host/…/model.onnx"                 -> that URL verbatim
+export function parseRef(ref) {
+  ref = (ref || "").trim();
+  if (!ref) throw new Error("empty model reference");
+
+  if (/^https?:\/\//i.test(ref)) {
+    const u = new URL(ref);
+    const isHF = u.hostname === "huggingface.co" || u.hostname.endsWith(".huggingface.co");
+    if (isHF) {
+      const parts = u.pathname.replace(/^\/+/, "").split("/");
+      const [owner, repo, kind, rev, ...rest] = parts;
+      if (!owner || !repo) throw new Error(`cannot parse Hugging Face URL: ${ref}`);
+      const repoId = `${owner}/${repo}`;
+      if ((kind === "resolve" || kind === "blob") && rest.length) {
+        return { repo: repoId, file: rest.join("/"), revision: rev || "main" };
+      }
+      return { repo: repoId };
+    }
+    // A non-Hub URL: use it as-is and hope it points at an .onnx.
+    return { url: ref, name: u.pathname.split("/").pop() || "model.onnx" };
+  }
+
+  // Not a URL: a repo id, defaulting a bare name to the onnxmodelzoo org.
+  const repo = ref.includes("/") ? ref : `${ORG}/${ref}`;
+  return { repo };
+}
+
+// Build the Hub `resolve` URL for a file in a repo, percent-encoding each path
+// segment (so files in subdirs and with spaces still resolve).
+export function fileUrl(repo, file, revision = "main") {
+  const encoded = file.split("/").map(encodeURIComponent).join("/");
+  return `${HF}/${repo}/resolve/${revision}/${encoded}`;
+}
+
+// List a repo's files (with sizes) via the Hub API.
+async function repoSiblings(repo) {
+  const r = await fetch(`${HF}/api/models/${repo}?blobs=true`);
+  if (!r.ok) {
+    throw new Error(`Hugging Face API returned HTTP ${r.status} for ${repo}`);
+  }
+  const info = await r.json();
+  return info.siblings || [];
+}
+
+// Pick the main .onnx file in a repo (largest, matching the regression workers)
+// and warn when the graph relies on external-data blobs the in-browser,
+// single-file converter can't load.
+async function findOnnxFile(repo, onLog) {
+  const siblings = await repoSiblings(repo);
+  const onnx = siblings.filter((s) => s.rfilename && s.rfilename.endsWith(".onnx"));
+  if (!onnx.length) throw new Error(`no .onnx file found in ${repo}`);
+  onnx.sort((a, b) => (b.size || 0) - (a.size || 0));
+  const chosen = onnx[0].rfilename;
+  if (onnx.length > 1) {
+    onLog(`repo has ${onnx.length} .onnx files; using the largest: ${chosen}`);
+  }
+  const external = siblings.some(
+    (s) => s.rfilename && /\.(onnx_data|onnx\.data|data|weight|weights)$/.test(s.rfilename),
+  );
+  if (external) {
+    onLog(
+      "note: this repo ships external-data/weight blobs; the in-browser " +
+        "converter loads a single .onnx file only, so conversion may fail if " +
+        "the graph stores its weights externally.",
+    );
+  }
+  return chosen;
+}
+
+// Resolve a reference and download the model. Returns { bytes, name, repo }.
+// `onLog` receives progress lines for the page's console output.
+export async function fetchModelBytes(ref, onLog = () => {}) {
+  const parsed = parseRef(ref);
+
+  let url;
+  let name;
+  if (parsed.url) {
+    url = parsed.url;
+    name = parsed.name;
+  } else {
+    const revision = parsed.revision || "main";
+    let file = parsed.file;
+    if (!file) {
+      onLog(`querying Hugging Face for the .onnx file in ${parsed.repo}…`);
+      file = await findOnnxFile(parsed.repo, onLog);
+    }
+    url = fileUrl(parsed.repo, file, revision);
+    name = file.split("/").pop();
+  }
+
+  onLog(`downloading ${url}`);
+  const resp = await fetch(url);
+  if (!resp.ok) {
+    throw new Error(`download failed: HTTP ${resp.status} ${resp.statusText}`);
+  }
+  const bytes = new Uint8Array(await resp.arrayBuffer());
+  onLog(`downloaded ${name} (${bytes.length.toLocaleString()} bytes)`);
+  return { bytes, name, repo: parsed.repo };
+}

--- a/scripts/convertmodel/hf_models.mjs
+++ b/scripts/convertmodel/hf_models.mjs
@@ -114,9 +114,54 @@ async function findOnnxFile(repo, onLog) {
   return chosen;
 }
 
+// Human-readable byte size, e.g. 4.7 MB. Used in progress messages.
+export function humanBytes(n) {
+  if (!Number.isFinite(n) || n < 0) return "?";
+  const units = ["B", "KB", "MB", "GB"];
+  let i = 0;
+  let v = n;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i += 1;
+  }
+  return `${i === 0 ? v : v.toFixed(1)} ${units[i]}`;
+}
+
+// Read a fetch Response body to a Uint8Array, reporting progress as it streams.
+// `onProgress({ loaded, total })` is called per chunk (`total` is 0 when the
+// server sends no Content-Length). Falls back to a single arrayBuffer() read
+// when the environment has no streaming body.
+async function readWithProgress(resp, onProgress) {
+  const total = Number(resp.headers && resp.headers.get("content-length")) || 0;
+  if (!resp.body || typeof resp.body.getReader !== "function") {
+    const bytes = new Uint8Array(await resp.arrayBuffer());
+    onProgress({ loaded: bytes.length, total: total || bytes.length });
+    return bytes;
+  }
+  const reader = resp.body.getReader();
+  const chunks = [];
+  let loaded = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    loaded += value.length;
+    onProgress({ loaded, total });
+  }
+  const bytes = new Uint8Array(loaded);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return bytes;
+}
+
 // Resolve a reference and download the model. Returns { bytes, name, repo }.
-// `onLog` receives progress lines for the page's console output.
-export async function fetchModelBytes(ref, onLog = () => {}) {
+// `onLog` receives progress lines for the page's console output; `onProgress`
+// receives { loaded, total } byte counts as the download streams, for a live
+// progress indicator.
+export async function fetchModelBytes(ref, onLog = () => {}, onProgress = () => {}) {
   const parsed = parseRef(ref);
 
   let url;
@@ -140,7 +185,7 @@ export async function fetchModelBytes(ref, onLog = () => {}) {
   if (!resp.ok) {
     throw new Error(`download failed: HTTP ${resp.status} ${resp.statusText}`);
   }
-  const bytes = new Uint8Array(await resp.arrayBuffer());
+  const bytes = await readWithProgress(resp, onProgress);
   onLog(`downloaded ${name} (${bytes.length.toLocaleString()} bytes)`);
   return { bytes, name, repo: parsed.repo };
 }

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -280,6 +280,21 @@
                 to the <code>onnxmodelzoo</code> org; any <code>owner/repo</code>
                 or direct <code>.onnx</code> URL works too.
             </div>
+            <div style="margin-top: 0.25em;">
+                <input type="checkbox" id="hf-use-xet">
+                <label for="hf-use-xet">
+                    Use <a href="https://huggingface.co/docs/xet/en/index" target="_blank" rel="noopener">Xet</a>
+                    protocol (experimental)
+                </label>
+                <button id="hf-clear-cache" type="button">clear chunk cache</button>
+                <div style="color: #666; font-size: 0.85em; margin-top: 0.2em;">
+                    Downloads via <code>@huggingface/hub</code>, reconstructing the
+                    file from content-addressed chunks and caching them in
+                    IndexedDB so repeated / overlapping loads reuse them. Falls
+                    back to the direct download automatically if the Xet path
+                    isn't available (e.g. a non-Xet repo or a CORS block).
+                </div>
+            </div>
         </div>
         <div>
             <input type="radio" name="optimizer" value="simplify" id="optimizer_simplify" checked>

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -33,6 +33,15 @@
                     input.disabled = false;
                     input.removeAttribute("title");
                 }
+                // The "Load from Hugging Face" controls share the same runtimes
+                // as the file picker, so enable them together.
+                for (const id of ["hf-model-select", "hf-model-input", "hf-load-button"]) {
+                    const el = document.getElementById(id);
+                    if (el) {
+                        el.disabled = false;
+                        el.removeAttribute("title");
+                    }
+                }
                 const status = document.getElementById("loading-status");
                 if (status) status.style.display = "none";
             };
@@ -194,16 +203,18 @@
                     }
                 };
 
-                input.addEventListener("change", async (e) => {
-                    const file = e.target.files[0];
-                    if (!file) return;
+                // Run one conversion. `modelName` names the source (for the
+                // download filename and issue report); `buf` is an ArrayBuffer
+                // that is *transferred* to the worker. Shared by the file picker
+                // and the Hugging Face loader (which calls it via the window
+                // handle published below).
+                const startConversion = (modelName, buf) => {
                     const optimizer = document.querySelector('input[name="optimizer"]:checked').value;
-                    result_name = (file.name.endsWith(".onnx") ? file.name.substring(0, file.name.length - 5) : file.name) + "." + optimizer + ".onnx"
+                    result_name = (modelName.endsWith(".onnx") ? modelName.substring(0, modelName.length - 5) : modelName) + "." + optimizer + ".onnx"
 
                     input.disabled = true;
                     dl_btn.disabled = true;
-                    const buf = await file.arrayBuffer();
-                    console.log("sending: ", file.name);
+                    console.log("sending: ", modelName);
                     let passes = null;
                     if (optimizer == "simplify") {
                         passes = Array.from(document.querySelectorAll('input[class="pass"]:not(:checked)')).map((v) => v.name);
@@ -218,7 +229,7 @@
                     last_run_info = {
                         optimizer, passes, constant_fold, shape_inference,
                         tensor_size_threshold, target_opset_version,
-                        file_name: file.name,
+                        file_name: modelName,
                     };
                     // Profiling only applies to "simplify"; the onnx-optimizer
                     // paths do not run the fixed-point profiler.
@@ -228,6 +239,21 @@
                     const annotate_model_info = document.getElementById("id_annotate_model_info").checked;
                     last_run_info.annotate_model_info = annotate_model_info;
                     worker.postMessage([optimizer, buf, passes, constant_fold, shape_inference, tensor_size_threshold, target_opset_version, profile, annotate_model_info], [buf]);
+                };
+                // Expose the conversion entry point for the Hugging Face loader
+                // module (hf_load.mjs), which downloads model bytes and drives
+                // the same path as an uploaded file.
+                window.__onnxsimStartConversion = startConversion;
+
+                input.addEventListener("change", async (e) => {
+                    const file = e.target.files[0];
+                    if (!file) return;
+                    // An uploaded file is readable as "original" from the file
+                    // input itself, so clear any model left over from a previous
+                    // Hugging Face load to avoid running stale bytes.
+                    window.__onnxsimOriginal = null;
+                    const buf = await file.arrayBuffer();
+                    startConversion(file.name, buf);
                 });
             };
         </script>
@@ -237,6 +263,24 @@
         <input type="file" id="file-input" disabled title="Loading WebAssembly runtime…" />
         <span id="loading-status">⏳ Loading WebAssembly runtime… the file picker is disabled until it is ready.</span>
         <button id="download-button" disabled>Download</button>
+        <div id="hf-loader" style="margin-top: 0.6em;">
+            <label for="hf-model-select">…or load from <a href="https://huggingface.co/onnxmodelzoo" target="_blank" rel="noopener">Hugging Face</a>:</label>
+            <select id="hf-model-select" disabled title="Loading WebAssembly runtime…">
+                <option value="">— pick a model from onnxmodelzoo —</option>
+            </select>
+            <input type="text" id="hf-model-input" size="42"
+                   placeholder="repo id (e.g. onnxmodelzoo/resnet18d_Opset18) or an .onnx URL"
+                   disabled title="Loading WebAssembly runtime…" />
+            <button id="hf-load-button" type="button" disabled title="Loading WebAssembly runtime…">Load</button>
+            <span id="hf-status"></span>
+            <div style="color: #666; font-size: 0.85em; margin-top: 0.25em;">
+                Fetches the model straight from the Hugging Face Hub in your
+                browser (nothing is uploaded), then runs it through the same
+                Simplify / Optimize path as an uploaded file. Bare names default
+                to the <code>onnxmodelzoo</code> org; any <code>owner/repo</code>
+                or direct <code>.onnx</code> URL works too.
+            </div>
+        </div>
         <div>
             <input type="radio" name="optimizer" value="simplify" id="optimizer_simplify" checked>
             <label for="optimizer_simplify">
@@ -300,6 +344,7 @@
             </div>
         </div>
         <script type="module" src="./netron_view.mjs"></script>
+        <script type="module" src="./hf_load.mjs"></script>
         <h2>Console outputs:</h2>
         <textarea id="log-output" readonly rows="20" style="width: 100%; box-sizing: border-box;"></textarea>
         <div>

--- a/scripts/convertmodel/inference_browser.mjs
+++ b/scripts/convertmodel/inference_browser.mjs
@@ -129,24 +129,34 @@ async function runOnModel(modelBytes, { iterations, batch, preferWebGPU, profile
 
 // Resolve the model bytes for the chosen source. "converted" uses the bytes the
 // converter page published on window.__onnxsimConverted; "original" reads the
-// file input. Returns { bytes, label } or throws with a user-facing message.
+// file input, falling back to a model loaded from Hugging Face (published on
+// window.__onnxsimOriginal, which has no file-input entry). Returns
+// { bytes, label } or throws with a user-facing message.
 async function resolveModelBytes(source, fileInput) {
   if (source === "converted") {
     const converted = window.__onnxsimConverted;
     if (!converted || !converted.bytes) {
       throw new Error(
-        "no converted model yet — pick a file above to run a conversion " +
-          "first, or switch the model dropdown to 'original'.",
+        "no converted model yet — pick a file (or load one from Hugging " +
+          "Face) above to run a conversion first, or switch the model " +
+          "dropdown to 'original'.",
       );
     }
     return { bytes: converted.bytes, label: `converted (${converted.name})` };
   }
   const file = fileInput.files && fileInput.files[0];
-  if (!file) throw new Error("Pick an .onnx file first.");
-  return {
-    bytes: new Uint8Array(await file.arrayBuffer()),
-    label: `original (${file.name})`,
-  };
+  if (file) {
+    return {
+      bytes: new Uint8Array(await file.arrayBuffer()),
+      label: `original (${file.name})`,
+    };
+  }
+  // No local file picked — use a Hugging Face download if one is loaded.
+  const original = window.__onnxsimOriginal;
+  if (original && original.bytes) {
+    return { bytes: original.bytes, label: `original (${original.name})` };
+  }
+  throw new Error("Pick an .onnx file or load one from Hugging Face first.");
 }
 
 // Render the onnxsim MAC/FLOP metrics (onnxsim PR #527) that travel inside the

--- a/scripts/convertmodel/netron_view.mjs
+++ b/scripts/convertmodel/netron_view.mjs
@@ -5,8 +5,10 @@
 // posted into Netron as raw bytes over the embedding protocol (see netron.mjs),
 // so nothing leaves the page and there is no model-size limit.
 //
-// The "before" pane is driven here by watching the file input directly. The
-// "after" pane is driven by the converter worker code, which calls the
+// The "before" pane is driven by watching the file input directly, and — for
+// models pulled from Hugging Face, which never touch the file input — by the
+// `window.netronShowBefore(bytes, name)` hook this module installs. The "after"
+// pane is driven by the converter worker code, which calls the
 // `window.netronShowAfter(dataUrl, name)` hook this module installs once a
 // conversion finishes.
 
@@ -169,6 +171,17 @@ function initNetronPanel() {
         .catch((err) => console.error("netron (before):", err));
     });
   }
+
+  // Called by the Hugging Face loader (hf_load.mjs) with the downloaded model
+  // bytes, since those never pass through the file input above. `data` may be a
+  // Uint8Array or ArrayBuffer; toArrayBuffer copies it to a standalone buffer.
+  window.netronShowBefore = (data, name) => {
+    try {
+      renderPane("before", toArrayBuffer(data), name);
+    } catch (err) {
+      console.error("netron (before):", err);
+    }
+  };
 
   // Called by the converter worker glue in index.html when a result is ready.
   window.netronShowAfter = (dataUrl, name) => {

--- a/scripts/convertmodel/package.json
+++ b/scripts/convertmodel/package.json
@@ -9,7 +9,8 @@
     "test:netron": "node test/netron.test.mjs",
     "test:trace": "node test/trace.test.mjs",
     "test:macs": "node test/macs.test.mjs",
-    "test:hf": "node test/hf_models.test.mjs"
+    "test:hf": "node test/hf_models.test.mjs",
+    "test:xet": "node test/xet_cache.test.mjs"
   },
   "dependencies": {
     "onnxruntime-web": "^1.27.0"

--- a/scripts/convertmodel/package.json
+++ b/scripts/convertmodel/package.json
@@ -8,7 +8,8 @@
     "test:inference": "node test/inference.test.mjs",
     "test:netron": "node test/netron.test.mjs",
     "test:trace": "node test/trace.test.mjs",
-    "test:macs": "node test/macs.test.mjs"
+    "test:macs": "node test/macs.test.mjs",
+    "test:hf": "node test/hf_models.test.mjs"
   },
   "dependencies": {
     "onnxruntime-web": "^1.27.0"

--- a/scripts/convertmodel/test/hf_models.test.mjs
+++ b/scripts/convertmodel/test/hf_models.test.mjs
@@ -10,6 +10,7 @@ import {
   fileUrl,
   loadModelList,
   fetchModelBytes,
+  humanBytes,
 } from "../hf_models.mjs";
 
 let passed = 0;
@@ -25,23 +26,50 @@ async function acheck(name, fn) {
   console.log("  ok -", name);
 }
 
-// Install a fetch stub that maps URL -> { ok, status, json?, arrayBuffer? }.
+// Install a fetch stub that maps URL -> a route descriptor:
+//   { ok?, status?, statusText?, json?, arrayBuffer?, chunks?, contentLength? }
+// A `chunks` array (of Uint8Array) yields a streaming ReadableStream-style body
+// so the progress path can be exercised; otherwise only arrayBuffer() is served.
 function withFetch(routes, fn) {
   const saved = globalThis.fetch;
   globalThis.fetch = async (url) => {
     const r = routes[url];
-    if (!r) return { ok: false, status: 404, statusText: "Not Found" };
-    return {
+    if (!r) {
+      return { ok: false, status: 404, statusText: "Not Found", headers: headersOf() };
+    }
+    const resp = {
       ok: r.ok !== false,
       status: r.status ?? 200,
       statusText: r.statusText ?? "OK",
+      headers: headersOf(r.contentLength),
       json: async () => r.json,
       arrayBuffer: async () => r.arrayBuffer ?? new ArrayBuffer(0),
     };
+    if (r.chunks) resp.body = streamOf(r.chunks);
+    return resp;
   };
   return Promise.resolve(fn()).finally(() => {
     globalThis.fetch = saved;
   });
+}
+
+function headersOf(contentLength) {
+  const map = {};
+  if (contentLength != null) map["content-length"] = String(contentLength);
+  return { get: (k) => map[k.toLowerCase()] ?? null };
+}
+
+// Minimal getReader()-style body over a fixed list of chunks.
+function streamOf(chunks) {
+  let i = 0;
+  return {
+    getReader: () => ({
+      read: async () =>
+        i < chunks.length
+          ? { done: false, value: chunks[i++] }
+          : { done: true, value: undefined },
+    }),
+  };
 }
 
 check("bare name defaults to the onnxmodelzoo org", () => {
@@ -167,6 +195,51 @@ await acheck("fetchModelBytes surfaces a failed download", async () => {
     { [url]: { ok: false, status: 403, statusText: "Forbidden" } },
     async () => {
       await assert.rejects(fetchModelBytes(url), /HTTP 403/);
+    },
+  );
+});
+
+check("humanBytes formats sizes", () => {
+  assert.equal(humanBytes(0), "0 B");
+  assert.equal(humanBytes(512), "512 B");
+  assert.equal(humanBytes(1536), "1.5 KB");
+  assert.equal(humanBytes(5 * 1024 * 1024), "5.0 MB");
+  assert.equal(humanBytes(-1), "?");
+});
+
+await acheck("fetchModelBytes streams chunks and reports progress", async () => {
+  const url = "https://huggingface.co/o/r/resolve/main/m.onnx";
+  await withFetch(
+    {
+      [url]: {
+        contentLength: 6,
+        chunks: [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])],
+      },
+    },
+    async () => {
+      const progress = [];
+      const { bytes } = await fetchModelBytes(url, () => {}, (p) => progress.push(p));
+      // Bytes are reassembled in order across chunks.
+      assert.deepEqual(Array.from(bytes), [1, 2, 3, 4, 5, 6]);
+      // Progress is reported per chunk, with the total from Content-Length.
+      assert.deepEqual(progress, [
+        { loaded: 3, total: 6 },
+        { loaded: 6, total: 6 },
+      ]);
+    },
+  );
+});
+
+await acheck("fetchModelBytes falls back to arrayBuffer without a body", async () => {
+  const url = "https://huggingface.co/o/r/resolve/main/m.onnx";
+  await withFetch(
+    { [url]: { arrayBuffer: new Uint8Array([7, 8]).buffer } },
+    async () => {
+      const progress = [];
+      const { bytes } = await fetchModelBytes(url, () => {}, (p) => progress.push(p));
+      assert.deepEqual(Array.from(bytes), [7, 8]);
+      // One final progress tick; total defaults to the byte count.
+      assert.deepEqual(progress, [{ loaded: 2, total: 2 }]);
     },
   );
 });

--- a/scripts/convertmodel/test/hf_models.test.mjs
+++ b/scripts/convertmodel/test/hf_models.test.mjs
@@ -1,0 +1,174 @@
+// Unit test for the pure helpers behind the converter page's "Load from
+// Hugging Face" panel. `fetch` is stubbed, so no network or browser is needed.
+//
+// Usage:
+//   node test/hf_models.test.mjs
+
+import assert from "node:assert/strict";
+import {
+  parseRef,
+  fileUrl,
+  loadModelList,
+  fetchModelBytes,
+} from "../hf_models.mjs";
+
+let passed = 0;
+function check(name, fn) {
+  fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+
+async function acheck(name, fn) {
+  await fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+
+// Install a fetch stub that maps URL -> { ok, status, json?, arrayBuffer? }.
+function withFetch(routes, fn) {
+  const saved = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    const r = routes[url];
+    if (!r) return { ok: false, status: 404, statusText: "Not Found" };
+    return {
+      ok: r.ok !== false,
+      status: r.status ?? 200,
+      statusText: r.statusText ?? "OK",
+      json: async () => r.json,
+      arrayBuffer: async () => r.arrayBuffer ?? new ArrayBuffer(0),
+    };
+  };
+  return Promise.resolve(fn()).finally(() => {
+    globalThis.fetch = saved;
+  });
+}
+
+check("bare name defaults to the onnxmodelzoo org", () => {
+  assert.deepEqual(parseRef("resnet18d_Opset18"), {
+    repo: "onnxmodelzoo/resnet18d_Opset18",
+  });
+});
+
+check("an explicit owner/repo is kept as-is", () => {
+  assert.deepEqual(parseRef("microsoft/resnet-50"), {
+    repo: "microsoft/resnet-50",
+  });
+});
+
+check("a Hub repo URL parses to just the repo", () => {
+  assert.deepEqual(
+    parseRef("https://huggingface.co/onnxmodelzoo/resnet18d_Opset18"),
+    { repo: "onnxmodelzoo/resnet18d_Opset18" },
+  );
+});
+
+check("a Hub resolve URL parses to repo + file + revision", () => {
+  assert.deepEqual(
+    parseRef("https://huggingface.co/onnxmodelzoo/foo/resolve/main/sub/model.onnx"),
+    { repo: "onnxmodelzoo/foo", file: "sub/model.onnx", revision: "main" },
+  );
+});
+
+check("a Hub blob URL is treated like resolve", () => {
+  assert.deepEqual(
+    parseRef("https://huggingface.co/o/r/blob/v2/m.onnx"),
+    { repo: "o/r", file: "m.onnx", revision: "v2" },
+  );
+});
+
+check("a non-Hub URL is used verbatim", () => {
+  assert.deepEqual(parseRef("https://example.com/models/net.onnx"), {
+    url: "https://example.com/models/net.onnx",
+    name: "net.onnx",
+  });
+});
+
+check("an empty reference is rejected", () => {
+  assert.throws(() => parseRef("   "), /empty model reference/);
+});
+
+check("fileUrl percent-encodes each path segment", () => {
+  assert.equal(
+    fileUrl("o/r", "a dir/model v2.onnx"),
+    "https://huggingface.co/o/r/resolve/main/a%20dir/model%20v2.onnx",
+  );
+});
+
+await acheck("loadModelList reads ./models.json first", async () => {
+  await withFetch(
+    {
+      "./models.json": {
+        json: { models: [{ id: "onnxmodelzoo/a" }, { id: "onnxmodelzoo/b" }] },
+      },
+    },
+    async () => {
+      const ids = await loadModelList();
+      assert.deepEqual(ids, ["onnxmodelzoo/a", "onnxmodelzoo/b"]);
+    },
+  );
+});
+
+await acheck("loadModelList returns [] when no source is reachable", async () => {
+  await withFetch({}, async () => {
+    assert.deepEqual(await loadModelList(), []);
+  });
+});
+
+await acheck("fetchModelBytes discovers the largest .onnx in a repo", async () => {
+  const api = "https://huggingface.co/api/models/onnxmodelzoo/foo?blobs=true";
+  const big = "https://huggingface.co/onnxmodelzoo/foo/resolve/main/big.onnx";
+  await withFetch(
+    {
+      [api]: {
+        json: {
+          siblings: [
+            { rfilename: "small.onnx", size: 10 },
+            { rfilename: "big.onnx", size: 999 },
+            { rfilename: "readme.md", size: 1 },
+          ],
+        },
+      },
+      [big]: { arrayBuffer: new Uint8Array([1, 2, 3, 4]).buffer },
+    },
+    async () => {
+      const { bytes, name } = await fetchModelBytes("foo");
+      assert.equal(name, "big.onnx");
+      assert.deepEqual(Array.from(bytes), [1, 2, 3, 4]);
+    },
+  );
+});
+
+await acheck("fetchModelBytes downloads an exact resolve URL directly", async () => {
+  const url = "https://huggingface.co/o/r/resolve/main/m.onnx";
+  await withFetch(
+    { [url]: { arrayBuffer: new Uint8Array([9, 9]).buffer } },
+    async () => {
+      const { bytes, name } = await fetchModelBytes(url);
+      assert.equal(name, "m.onnx");
+      assert.deepEqual(Array.from(bytes), [9, 9]);
+    },
+  );
+});
+
+await acheck("fetchModelBytes surfaces a repo with no .onnx", async () => {
+  const api = "https://huggingface.co/api/models/onnxmodelzoo/empty?blobs=true";
+  await withFetch(
+    { [api]: { json: { siblings: [{ rfilename: "readme.md", size: 1 }] } } },
+    async () => {
+      await assert.rejects(fetchModelBytes("empty"), /no \.onnx file found/);
+    },
+  );
+});
+
+await acheck("fetchModelBytes surfaces a failed download", async () => {
+  const url = "https://huggingface.co/o/r/resolve/main/m.onnx";
+  await withFetch(
+    { [url]: { ok: false, status: 403, statusText: "Forbidden" } },
+    async () => {
+      await assert.rejects(fetchModelBytes(url), /HTTP 403/);
+    },
+  );
+});
+
+console.log(`\n${passed} checks passed`);

--- a/scripts/convertmodel/test/xet_cache.test.mjs
+++ b/scripts/convertmodel/test/xet_cache.test.mjs
@@ -1,0 +1,134 @@
+// Unit test for the pure cache-key + caching-fetch logic behind the
+// experimental Xet download path. The IndexedDB wrapper (openXetCache) needs a
+// real browser and is not covered here; makeCachingFetch is tested against a
+// plain Map-backed cache and a stubbed fetch.
+//
+// Usage:
+//   node test/xet_cache.test.mjs
+
+import assert from "node:assert/strict";
+import { casCacheKey, isCacheable, makeCachingFetch } from "../xet_cache.mjs";
+
+let passed = 0;
+function check(name, fn) {
+  fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+async function acheck(name, fn) {
+  await fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+
+check("casCacheKey drops the (volatile presign) query string", () => {
+  const a = casCacheKey("https://cas.example/blk/abc123?sig=AAA&exp=1", "bytes=0-99");
+  const b = casCacheKey("https://cas.example/blk/abc123?sig=BBB&exp=2", "bytes=0-99");
+  assert.equal(a, b); // same block + range -> same key despite rotating signature
+  assert.equal(a, "https://cas.example/blk/abc123#bytes=0-99");
+});
+
+check("casCacheKey separates different ranges", () => {
+  const a = casCacheKey("https://cas.example/blk/x", "bytes=0-99");
+  const b = casCacheKey("https://cas.example/blk/x", "bytes=100-199");
+  assert.notEqual(a, b);
+});
+
+check("isCacheable accepts a ranged GET to a non-Hub host", () => {
+  assert.equal(isCacheable("https://cas.example/blk/x", "GET", "bytes=0-9"), true);
+});
+
+check("isCacheable rejects Hub hosts, non-GET, and range-less requests", () => {
+  assert.equal(isCacheable("https://huggingface.co/api/x", "GET", "bytes=0-9"), false);
+  assert.equal(isCacheable("https://x.huggingface.co/y", "GET", "bytes=0-9"), false);
+  assert.equal(isCacheable("https://cas.example/blk/x", "POST", "bytes=0-9"), false);
+  assert.equal(isCacheable("https://cas.example/blk/x", "GET", null), false);
+});
+
+// A Map-backed cache with the { get, put } shape makeCachingFetch expects.
+function mapCache() {
+  const map = new Map();
+  return {
+    get: async (k) => map.get(k) || null,
+    put: async (k, v) => void map.set(k, v),
+    _map: map,
+  };
+}
+
+await acheck("caches a CAS range GET on miss, replays it on hit", async () => {
+  const cache = mapCache();
+  let networkCalls = 0;
+  const realFetch = async () => {
+    networkCalls += 1;
+    return new Response(new Uint8Array([1, 2, 3, 4]).buffer, {
+      status: 206,
+      headers: { "content-range": "bytes 0-3/4", "content-type": "application/octet-stream" },
+    });
+  };
+  const f = makeCachingFetch(realFetch, cache);
+
+  const url = "https://cas.example/blk/abc?sig=1";
+  const r1 = await f(url, { headers: { Range: "bytes=0-3" } });
+  assert.equal(r1.status, 206);
+  assert.deepEqual(Array.from(new Uint8Array(await r1.arrayBuffer())), [1, 2, 3, 4]);
+  assert.equal(networkCalls, 1);
+
+  // Second call with a *different* presigned query hits the cache (no network).
+  const r2 = await f("https://cas.example/blk/abc?sig=2", { headers: { Range: "bytes=0-3" } });
+  assert.equal(r2.status, 206);
+  assert.equal(r2.headers.get("content-range"), "bytes 0-3/4");
+  assert.deepEqual(Array.from(new Uint8Array(await r2.arrayBuffer())), [1, 2, 3, 4]);
+  assert.equal(networkCalls, 1); // still 1 -> served from cache
+});
+
+await acheck("passes through non-cacheable requests untouched", async () => {
+  const cache = mapCache();
+  let networkCalls = 0;
+  const realFetch = async () => {
+    networkCalls += 1;
+    return new Response("ok", { status: 200 });
+  };
+  const f = makeCachingFetch(realFetch, cache);
+
+  // Hub host (token refresh / file info): not cached.
+  await f("https://huggingface.co/api/models/x", { headers: { Range: "bytes=0-9" } });
+  // No Range header: not cached.
+  await f("https://cas.example/blk/x");
+  assert.equal(networkCalls, 2);
+  assert.equal(cache._map.size, 0);
+});
+
+await acheck("fires onHit / onMiss hooks", async () => {
+  const cache = mapCache();
+  const realFetch = async () =>
+    new Response(new Uint8Array([9]).buffer, { status: 206 });
+  const events = [];
+  const f = makeCachingFetch(realFetch, cache, {
+    onHit: (_k, n) => events.push(["hit", n]),
+    onMiss: () => events.push(["miss"]),
+  });
+  const url = "https://cas.example/blk/z";
+  await f(url, { headers: { Range: "bytes=0-0" } });
+  await f(url, { headers: { Range: "bytes=0-0" } });
+  assert.deepEqual(events, [["miss"], ["hit", 1]]);
+});
+
+await acheck("a cache read error falls back to the network", async () => {
+  const cache = {
+    get: async () => {
+      throw new Error("idb blew up");
+    },
+    put: async () => {},
+  };
+  let networkCalls = 0;
+  const realFetch = async () => {
+    networkCalls += 1;
+    return new Response(new Uint8Array([1]).buffer, { status: 206 });
+  };
+  const f = makeCachingFetch(realFetch, cache);
+  const r = await f("https://cas.example/blk/x", { headers: { Range: "bytes=0-0" } });
+  assert.equal(r.status, 206);
+  assert.equal(networkCalls, 1);
+});
+
+console.log(`\n${passed} checks passed`);

--- a/scripts/convertmodel/xet_cache.mjs
+++ b/scripts/convertmodel/xet_cache.mjs
@@ -1,0 +1,170 @@
+// Persistent, content-addressed cache for Hugging Face Xet downloads.
+//
+// EXPERIMENTAL / prototype. The Xet protocol reconstructs a file from
+// deduplicated content-addressed blocks (CAS). Its payoff over a plain
+// `resolve` download only shows up when those blocks are *reused* — otherwise a
+// browser with no persistent store just re-fetches everything. This module adds
+// that store: an IndexedDB-backed cache plus a `fetch` wrapper that transparently
+// serves CAS block / reconstruction range requests from it.
+//
+// The cache is keyed by the request's origin + path + Range, deliberately
+// dropping the query string: CAS block URLs are presigned (a rotating signature
+// in the query), but the path already encodes the block hash, so this stays a
+// stable content address across sessions.
+//
+// Only the pure cache-key and caching-fetch logic is unit-tested (test/
+// xet_cache.test.mjs); the IndexedDB wrapper needs a real browser.
+
+// A GET with a Range header to a host other than the Hub is a CAS block or
+// reconstruction fetch — content-addressed and safe to cache. Token refresh and
+// file-info calls go to huggingface.co and are passed through untouched.
+function isHubHost(hostname) {
+  return hostname === "huggingface.co" || hostname.endsWith(".huggingface.co");
+}
+
+// Normalize a request into { url, method, headers } whether fetch was called
+// with a string/URL + init or a Request object.
+function reqInfo(input, init) {
+  if (typeof input === "string" || input instanceof URL) {
+    return {
+      url: String(input),
+      method: (init && init.method) || "GET",
+      headers: init && init.headers,
+    };
+  }
+  // A Request-like object.
+  return { url: input.url, method: input.method || "GET", headers: input.headers };
+}
+
+// Read a header by name from a Headers instance, a plain object, or an array of
+// [name, value] pairs — the three shapes fetch accepts.
+function headerGet(headers, name) {
+  if (!headers) return null;
+  const lower = name.toLowerCase();
+  if (typeof headers.get === "function") return headers.get(name);
+  if (Array.isArray(headers)) {
+    const found = headers.find(([k]) => String(k).toLowerCase() === lower);
+    return found ? found[1] : null;
+  }
+  for (const k of Object.keys(headers)) {
+    if (k.toLowerCase() === lower) return headers[k];
+  }
+  return null;
+}
+
+// The content-addressed cache key: origin + path + Range, without the query.
+export function casCacheKey(url, rangeHeader) {
+  const u = new URL(url);
+  return `${u.origin}${u.pathname}#${rangeHeader || ""}`;
+}
+
+// Which request headers to preserve so a cached response replays faithfully
+// (Xet issues Range requests and may read Content-Range).
+const REPLAY_HEADERS = ["content-type", "content-range", "content-length"];
+
+function pickHeaders(headers) {
+  const out = {};
+  for (const name of REPLAY_HEADERS) {
+    const v = headers.get(name);
+    if (v != null) out[name] = v;
+  }
+  return out;
+}
+
+// Decide whether a request is a cacheable CAS/reconstruction range fetch.
+export function isCacheable(url, method, rangeHeader) {
+  if ((method || "GET").toUpperCase() !== "GET") return false;
+  if (!rangeHeader) return false;
+  try {
+    return !isHubHost(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
+// Wrap a fetch so cacheable requests are served from / stored into `cache`
+// (any { get(key), put(key, entry) }). `hooks.onHit(key, bytes)` and
+// `hooks.onMiss(key)` are optional progress callbacks. A cache failure never
+// breaks the request — it just falls back to the network.
+export function makeCachingFetch(realFetch, cache, hooks = {}) {
+  return async (input, init) => {
+    const { url, method, headers } = reqInfo(input, init);
+    const range = headerGet(headers, "range");
+    if (!isCacheable(url, method, range)) {
+      return realFetch(input, init);
+    }
+    const key = casCacheKey(url, range);
+
+    let hit = null;
+    try {
+      hit = await cache.get(key);
+    } catch {
+      hit = null;
+    }
+    if (hit && hit.body) {
+      if (hooks.onHit) hooks.onHit(key, hit.body.byteLength);
+      return new Response(hit.body, { status: hit.status || 200, headers: hit.headers });
+    }
+
+    if (hooks.onMiss) hooks.onMiss(key);
+    const resp = await realFetch(input, init);
+    if (resp.ok || resp.status === 206) {
+      try {
+        const body = await resp.clone().arrayBuffer();
+        await cache.put(key, {
+          status: resp.status,
+          headers: pickHeaders(resp.headers),
+          body,
+        });
+      } catch {
+        // Non-fatal: serve the live response even if caching failed.
+      }
+    }
+    return resp;
+  };
+}
+
+// An IndexedDB-backed cache. Falls back to an in-memory Map when IndexedDB is
+// unavailable (e.g. private-mode restrictions), so the caller never has to
+// branch. Browser-only; not exercised by the node unit tests.
+export function openXetCache(dbName = "onnxsim-xet-cache", storeName = "blocks") {
+  if (typeof indexedDB === "undefined") return memoryCache();
+
+  let dbPromise;
+  const db = () => {
+    if (!dbPromise) {
+      dbPromise = new Promise((resolve, reject) => {
+        const req = indexedDB.open(dbName, 1);
+        req.onupgradeneeded = () => req.result.createObjectStore(storeName);
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+      });
+    }
+    return dbPromise;
+  };
+  const run = (mode, fn) =>
+    db().then(
+      (d) =>
+        new Promise((resolve, reject) => {
+          const tx = d.transaction(storeName, mode);
+          const req = fn(tx.objectStore(storeName));
+          req.onsuccess = () => resolve(req.result);
+          req.onerror = () => reject(req.error);
+        }),
+    );
+
+  return {
+    get: (key) => run("readonly", (s) => s.get(key)),
+    put: (key, value) => run("readwrite", (s) => s.put(value, key)),
+    clear: () => run("readwrite", (s) => s.clear()),
+  };
+}
+
+function memoryCache() {
+  const map = new Map();
+  return {
+    get: async (key) => map.get(key) || null,
+    put: async (key, value) => void map.set(key, value),
+    clear: async () => void map.clear(),
+  };
+}

--- a/scripts/regression/README.md
+++ b/scripts/regression/README.md
@@ -24,6 +24,7 @@ workflow on a weekly schedule and on demand.
 | `run_regression.py` | assigns a balanced shard of the model set (or the known-slow set) and runs each model through `worker.py` with a per-tool timeout. Exits non-zero if any model in the shard **crashed, timed out, or failed onnxsim's correctness check** — onnxslim outcomes are recorded but never affect the exit code. |
 | `summarize.py` | merges the per-shard CSVs into `regression-report.csv` and a Markdown run summary, including the onnxsim-vs-onnxslim comparison tables. |
 | `yolov5_regression.py` | standalone check that `onnxsim` can replace the `onnxslim.slim` call in [ultralytics/yolov5](https://github.com/ultralytics/yolov5)'s `export.py`: exports the raw graph, runs both simplifiers, and gates on onnxsim producing a valid graph numerically equivalent to the original. Latest run: [`RESULTS_yolov5.md`](./RESULTS_yolov5.md). |
+| `model_zoo.py` | reference a regression model by short name from Python or the CLI, downloading it from the [`onnxmodelzoo`](https://huggingface.co/onnxmodelzoo) org (cached) and returning the path to its main `.onnx`. See [Referencing a model by name](#referencing-a-model-by-name). |
 
 ## What counts as a failure
 
@@ -90,6 +91,34 @@ python scripts/regression/summarize.py "shard-*.csv" slow.csv
 
 Set `SLIM_CHECK=0` to skip onnxslim's (optional) equivalence check, which halves
 onnxslim's per-model work when you only care about its robustness and node counts.
+
+## Referencing a model by name
+
+`model_zoo.py` turns a short model name into a local `.onnx` path, so a script or
+test can pull one of the regression models without repeating the
+`snapshot_download` boilerplate:
+
+```python
+from model_zoo import fetch_model, list_models, resolve
+
+fetch_model("resnet18d_Opset18")   # -> /path/to/…/resnet18d.onnx (cached)
+resolve("resnet18d_Opset18")       # -> "onnxmodelzoo/resnet18d_Opset18"
+list_models()                      # -> the curated set's full repo ids
+```
+
+The name is resolved leniently: a short name is looked up in `models.json`, a
+bare name not listed there is assumed to live under `onnxmodelzoo/`, and an
+explicit `owner/repo` is used verbatim (so any Hugging Face repo works). The same
+is available from the command line:
+
+```bash
+python scripts/regression/model_zoo.py list            # curated repo ids
+python scripts/regression/model_zoo.py resolve resnet18d_Opset18
+python scripts/regression/model_zoo.py fetch resnet18d_Opset18   # prints .onnx path
+```
+
+Downloads require `huggingface_hub` (`pip install huggingface_hub`) and land in
+its cache, so repeated fetches of the same model are effectively free.
 
 ## Updating the model set
 

--- a/scripts/regression/model_zoo.py
+++ b/scripts/regression/model_zoo.py
@@ -1,0 +1,163 @@
+"""Reference regression models by short name.
+
+The regression sweep (see ``README.md``) runs onnxsim over a curated set of real
+models hosted in the Hugging Face `onnxmodelzoo <https://huggingface.co/onnxmodelzoo>`_
+org, listed in ``models.json``. Every place that needs one of those models has so
+far repeated the same ``snapshot_download`` + "find the largest ``.onnx``" dance
+(``worker.py``, ``x2paddle/worker.py``, …). This module gathers that into one
+call so a test or script can grab a model by its short name::
+
+    from model_zoo import fetch_model
+
+    onnx_path = fetch_model("resnet18d_Opset18")   # -> /path/to/resnet18d.onnx
+
+The name is resolved leniently:
+
+* a short name (``"resnet18d_Opset18"``) is looked up in ``models.json`` and, if
+  found, mapped to its full repo id;
+* a bare name not in ``models.json`` is assumed to live under ``onnxmodelzoo/``;
+* an explicit ``owner/repo`` (any org) is used verbatim, so arbitrary Hugging
+  Face repos work too.
+
+Downloads go through ``huggingface_hub`` and land in its cache, so repeated calls
+for the same model are effectively free.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import List, Optional
+
+# Default org for bare model names, matching the regression set in models.json.
+ORG = "onnxmodelzoo"
+
+# The curated model set. Kept next to this file so it travels with the scripts.
+MODELS_JSON = os.path.join(os.path.dirname(os.path.abspath(__file__)), "models.json")
+
+# What to pull from a repo: the graph plus any external-data / weight blobs it
+# references, skipping docs and metadata. Mirrors the regression workers so a
+# model fetched here behaves identically to one fetched by the sweep.
+ALLOW_PATTERNS = [
+    "*.onnx",
+    "*.onnx_data",
+    "*.onnx.data",
+    "*.data",
+    "*.pb",
+    "*.bin",
+    "*.weight",
+    "*.weights",
+]
+
+
+def list_models(models_json: str = MODELS_JSON) -> List[str]:
+    """Return the full repo ids of the curated regression set, in file order."""
+    with open(models_json) as f:
+        data = json.load(f)
+    return [m["id"] for m in data["models"]]
+
+
+def _short(model_id: str) -> str:
+    """The bare name of a repo id (``onnxmodelzoo/resnet18d`` -> ``resnet18d``)."""
+    return model_id.split("/", 1)[-1]
+
+
+def resolve(name: str, models_json: str = MODELS_JSON) -> str:
+    """Resolve a user-supplied model reference to a full ``owner/repo`` id.
+
+    * ``"owner/repo"`` (any slash) is returned unchanged.
+    * a short name present in ``models.json`` maps to its listed id.
+    * any other bare name is assumed to live under :data:`ORG`.
+    """
+    if "/" in name:
+        return name
+    try:
+        for model_id in list_models(models_json):
+            if _short(model_id) == name:
+                return model_id
+    except (OSError, ValueError, KeyError):
+        # No usable models.json (e.g. running outside the repo) -- fall through
+        # to the default-org assumption below rather than failing the lookup.
+        pass
+    return f"{ORG}/{name}"
+
+
+def fetch_model(
+    name: str,
+    *,
+    local_dir: Optional[str] = None,
+    revision: Optional[str] = None,
+    models_json: str = MODELS_JSON,
+) -> str:
+    """Download a regression model and return the path to its main ``.onnx`` file.
+
+    ``name`` is resolved by :func:`resolve`. The download is delegated to
+    ``huggingface_hub.snapshot_download`` (so it is cached); when several graphs
+    are present the largest is taken as the main model, matching the regression
+    workers.
+
+    Requires ``huggingface_hub`` -- a clear ``ImportError`` is raised if it is
+    missing so callers (e.g. pytest) can skip cleanly.
+    """
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as e:
+        raise ImportError(
+            "huggingface_hub is required to fetch regression models; "
+            "install it with `pip install huggingface_hub`"
+        ) from e
+
+    repo_id = resolve(name, models_json)
+    path = snapshot_download(
+        repo_id=repo_id,
+        revision=revision,
+        local_dir=local_dir,
+        allow_patterns=ALLOW_PATTERNS,
+    )
+    onnx_files = [
+        os.path.join(root, f)
+        for root, _, files in os.walk(path)
+        for f in files
+        if f.endswith(".onnx")
+    ]
+    if not onnx_files:
+        raise FileNotFoundError(f"no .onnx file found in {repo_id!r}")
+    # If several graphs are present, the largest is the main model.
+    return max(onnx_files, key=os.path.getsize)
+
+
+def _main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_list = sub.add_parser("list", help="print the curated regression model ids")
+    p_list.add_argument("--short", action="store_true", help="print bare names only")
+
+    p_resolve = sub.add_parser("resolve", help="resolve a name to a full repo id")
+    p_resolve.add_argument("name")
+
+    p_fetch = sub.add_parser("fetch", help="download a model, print its .onnx path")
+    p_fetch.add_argument("name")
+    p_fetch.add_argument("--local-dir", default=None)
+    p_fetch.add_argument("--revision", default=None)
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "list":
+        for model_id in list_models():
+            print(_short(model_id) if args.short else model_id)
+    elif args.cmd == "resolve":
+        print(resolve(args.name))
+    elif args.cmd == "fetch":
+        print(fetch_model(args.name, local_dir=args.local_dir, revision=args.revision))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(_main())
+    except BrokenPipeError:
+        # Downstream closed the pipe (e.g. `... | head`); exit quietly.
+        sys.exit(0)


### PR DESCRIPTION
This PR adds the ability to load ONNX models directly from the Hugging Face Hub into the converter page, complementing the existing file upload functionality.

## Summary

Users can now load models from the Hugging Face Hub in two ways:
1. Select from a curated dropdown of regression models (from `onnxmodelzoo` org)
2. Enter any Hugging Face repo ID or direct `.onnx` file URL

The implementation includes both browser-side and Python utilities for consistent model resolution across the codebase.

## Key Changes

**Browser-side (converter page):**
- `hf_models.mjs`: Pure data/networking module that parses model references, queries the Hub API, and downloads model bytes
  - `parseRef()`: Resolves user input (bare names, repo IDs, Hub URLs) to structured references
  - `fileUrl()`: Builds Hub resolve URLs with proper percent-encoding
  - `loadModelList()`: Fetches curated model list from local or GitHub source
  - `fetchModelBytes()`: Downloads models, auto-discovering the largest `.onnx` file in a repo
- `hf_load.mjs`: Wires the UI controls (dropdown, text input, load button) to the model fetching logic
- `index.html`: Refactored conversion logic into reusable `startConversion()` function, exposed as `window.__onnxsimStartConversion` for the Hugging Face loader
- `inference_browser.mjs`: Updated to support running inference on models loaded from Hugging Face (via `window.__onnxsimOriginal`)

**Python utilities (regression scripts):**
- `model_zoo.py`: New module providing consistent model resolution and downloading for Python scripts/tests
  - `resolve()`: Maps short names to full repo IDs (with fallback to `onnxmodelzoo` org)
  - `fetch_model()`: Downloads models via `huggingface_hub` and returns path to main `.onnx` file
  - CLI interface for listing, resolving, and fetching models

**Testing & CI:**
- `test/hf_models.test.mjs`: Comprehensive unit tests for the Hub integration (with stubbed fetch)
- Updated `package.json` test scripts and CI workflows to run the new tests
- Updated `.github/workflows/static.yml` to deploy `models.json` alongside the converter page
- Updated `.gitignore` to exclude the deployed model list

## Implementation Details

- The Hub's JSON API and file resolve endpoints have permissive CORS, so browser `fetch` is sufficient—no server proxy needed
- Model resolution is lenient: bare names default to `onnxmodelzoo/`, explicit `owner/repo` works for any org, and direct URLs are used verbatim
- When a repo has multiple `.onnx` files, the largest is selected (matching regression worker behavior)
- The converter page warns users if a model ships external-data blobs that the single-file in-browser converter cannot load
- Python and JavaScript implementations share the same resolution logic and defaults for consistency

https://claude.ai/code/session_01Y3FDZoVWsqvM8K1VwxVpL4