### PR TITLE
Fix Conv+BN fusion for IR<4 models with initializers as inputs

### DIFF
--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -71,9 +71,22 @@ def remove_unused_output(
 
 def remove_initializer_from_input(model: onnx.ModelProto) -> onnx.ModelProto:
     initializer_names = [x.name for x in model.graph.initializer]
+    removed_any = False
     for graph_input in copy.deepcopy(model.graph.input):
         if graph_input.name in initializer_names:
             model.graph.input.remove(graph_input)
+            removed_any = True
+    # IR version 4 (ONNX 1.4) is the first that allows an initializer to *not*
+    # also be a graph input. Older IR (v3 and below) required every initializer
+    # to appear in ``graph.input``, and leaving it there makes onnxoptimizer
+    # treat it as a runtime input rather than a constant
+    # (``is_constant_initializer`` returns false), which silently blocks
+    # value-baking fusions such as ``fuse_bn_into_conv`` -- e.g. the plain
+    # Conv+BN chains of the opset-8 ``resnet101-v1-7`` were left completely
+    # unsimplified. Bump such models to IR 4 so the removal above is legal and
+    # the freed initializers fold like any other constant.
+    if removed_any and model.ir_version < 4:
+        model.ir_version = 4
     return model
 
 
@@ -547,7 +560,11 @@ def simplify(
                         dim.dim_value = input_shape[i]
     if unused_output is not None:
         model = remove_unused_output(model, unused_output)
-    if not mutable_initializer and model.ir_version >= 4:
+    if not mutable_initializer:
+        # ``remove_initializer_from_input`` bumps IR<4 models to IR 4 so the
+        # freed initializers become foldable constants (previously gated on
+        # ``ir_version >= 4``, which left opset-8 graphs such as resnet101-v1-7
+        # completely unsimplified).
         model = remove_initializer_from_input(model)
 
     # onnxoptimizer's common-subexpression / duplicate-initializer passes hash

--- a/scripts/regression/README.md
+++ b/scripts/regression/README.md
@@ -56,13 +56,16 @@ divergence:
   `tests/test_simple.py::test_fp8_qdq_modelopt_integration`).
 
 - **Optimization strength.** Median node reduction for each tool and the models
-  with the largest node-count gaps. onnxslim ships pattern fusions onnxsim
-  (onnxoptimizer + constant folding) does not — e.g. ConvTranspose+BatchNorm and
-  ConvTranspose+Add-bias fusion, and no-op `Dropout(ratio=0)` elimination — so it
-  often lands fewer nodes on conv/transformer graphs. Those specific gaps are
-  pinned as `xfail` tests in `tests/test_fusion_patterns.py`; they'll XPASS if
-  onnxsim ever gains the pass. (onnxslim also has a GELU-subgraph matcher, but it
-  ships disabled, so both tools currently leave the erf-GELU pattern intact.)
+  with the largest node-count gaps. Several fusions that onnxslim shipped and
+  onnxsim did not — ConvTranspose+BatchNorm and ConvTranspose+Add-bias fusion,
+  and no-op `Dropout` elimination in the opset-12+ input form — are now covered
+  by onnxsim's optimizer (issue #543) and have regular tests in
+  `tests/test_fusion_patterns.py`. A separate onnxsim fix also lets value-baking
+  fusions run on IR<4 (e.g. opset-8) exports whose initializers double as graph
+  inputs, so plain Conv+BN CNNs like `resnet101-v1-7` now fold. The one fusion
+  onnxslim still has that onnxsim lacks is the GELU-subgraph matcher — and
+  onnxslim ships it disabled, so both tools currently leave the erf-GELU pattern
+  intact (pinned as the remaining `xfail` in `tests/test_fusion_patterns.py`).
 
 - **Speed / memory.** Median wall-clock and peak RSS over the models both tools
   completed. onnxsim runs onnxruntime-based constant folding and its `check_n`

--- a/tests/test_fusion_patterns.py
+++ b/tests/test_fusion_patterns.py
@@ -11,9 +11,11 @@ Every model is built directly with ``onnx.helper`` (no torch dependency) and run
 through ``onnxsim.simplify`` with ``check_n=3`` so onnxsim's own random-input
 equivalence check guards correctness of each rewrite.
 
-The final section holds ``xfail`` tests for optimizations OnnxSlim performs but
-onnxsim currently does not (e.g. ConvTranspose fusion, GELU fusion, no-op Dropout
-removal). They document the gap and will XPASS if onnxsim ever gains the pass.
+ConvTranspose+BN, ConvTranspose+Add-bias and no-op ``Dropout`` fusions -- once
+gaps versus OnnxSlim -- are now covered by onnxsim's optimizer (issue #543) and
+are regular tests below. The final section holds the remaining ``xfail`` cases
+(GELU-subgraph fusion) that OnnxSlim performs but onnxsim does not; they document
+the gap and will XPASS if onnxsim ever gains the pass.
 """
 
 import collections
@@ -291,16 +293,10 @@ def test_defer_constant_expand_folds_small_consumer():
 
 
 # --------------------------------------------------------------------------- #
-# Passes OnnxSlim performs but onnxsim (onnxoptimizer + constant folding) does
-# not. These document the coverage gap: each asserts the *desired* optimization,
-# marked xfail because onnxsim currently leaves the graph unchanged. If a future
-# onnxsim/onnxoptimizer version starts performing one, the test XPASSes and can
-# be promoted to a regular test. strict=False keeps CI green either way.
+# ConvTranspose / no-op Dropout fusions (issue #543). Formerly xfail gaps versus
+# OnnxSlim, now handled by onnxsim's optimizer: no-op Dropout removal and the
+# fuse_bn_into_conv / fuse_add_bias_into_conv passes extended to ConvTranspose.
 # --------------------------------------------------------------------------- #
-@pytest.mark.xfail(
-    reason="onnxsim does not eliminate a no-op Dropout (ratio=0); OnnxSlim does",
-    strict=False,
-)
 def test_eliminate_nop_dropout():
     inits = [onnx.numpy_helper.from_array(np.array(0.0, dtype=np.float32), "ratio")]
     nodes = [
@@ -313,11 +309,6 @@ def test_eliminate_nop_dropout():
     assert ops["Relu"] == 1
 
 
-@pytest.mark.xfail(
-    reason="onnxoptimizer only folds BatchNorm into Conv, not ConvTranspose; "
-    "OnnxSlim fuses ConvTranspose+BN",
-    strict=False,
-)
 def test_fuse_convtranspose_bn():
     inits = [
         _f32(np.random.randn(3, 8, 3, 3), "W"),  # ConvTranspose: [Cin, Cout, kH, kW]
@@ -338,10 +329,6 @@ def test_fuse_convtranspose_bn():
     assert ops["ConvTranspose"] == 1
 
 
-@pytest.mark.xfail(
-    reason="onnxsim has no ConvTranspose+Add bias fusion; OnnxSlim fuses it",
-    strict=False,
-)
 def test_fuse_convtranspose_add():
     inits = [
         _f32(np.random.randn(3, 8, 3, 3), "W"),
@@ -357,6 +344,11 @@ def test_fuse_convtranspose_add():
     assert ops["ConvTranspose"] == 1
 
 
+# --------------------------------------------------------------------------- #
+# Remaining gap: passes OnnxSlim performs but onnxsim does not. Marked xfail
+# (strict=False) so CI stays green; each XPASSes and can be promoted if onnxsim
+# gains the pass.
+# --------------------------------------------------------------------------- #
 @pytest.mark.xfail(
     reason="onnxsim has no GELU subgraph fusion; OnnxSlim ships a (currently "
     "disabled) FusionGelu matcher for this exact pattern",

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -739,3 +739,54 @@ def test_if_with_const_cond_is_folded():
 
     out = _resolve_const(sim_model, sim_model.graph.output[0].name)
     assert out.tolist() == [1.0, 2.0]
+
+
+def test_ir3_conv_bn_fuses():
+    # IR version 3 models (e.g. the opset-8 ``resnet101-v1-7``) list every
+    # initializer as a graph input too, which is required before IR 4. onnxsim
+    # used to skip ``remove_initializer_from_input`` for such models, so the
+    # weights stayed "runtime inputs" and onnxoptimizer refused to fold them --
+    # ``fuse_bn_into_conv`` never fired and the graph came out unchanged
+    # (GitHub issue #543). onnxsim now bumps these to IR 4 and drops the
+    # initializer inputs, so the Conv+BN pair fuses away.
+    import numpy as np
+
+    out_ch, in_ch = 4, 3
+    W = np.random.randn(out_ch, in_ch, 3, 3).astype(np.float32)
+    scale = np.abs(np.random.randn(out_ch).astype(np.float32)) + 1
+    bias = np.random.randn(out_ch).astype(np.float32)
+    mean = np.random.randn(out_ch).astype(np.float32)
+    var = np.abs(np.random.randn(out_ch).astype(np.float32)) + 1
+    inits = [
+        numpy_helper.from_array(W, "W"),
+        numpy_helper.from_array(scale, "scale"),
+        numpy_helper.from_array(bias, "bias"),
+        numpy_helper.from_array(mean, "mean"),
+        numpy_helper.from_array(var, "var"),
+    ]
+    conv = helper.make_node("Conv", ["X", "W"], ["conv_out"])
+    bn = helper.make_node(
+        "BatchNormalization", ["conv_out", "scale", "bias", "mean", "var"], ["Y"]
+    )
+    graph = helper.make_graph(
+        [conv, bn],
+        "g",
+        # Initializers are *also* listed as graph inputs, as IR<4 requires.
+        [helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, in_ch, 8, 8])]
+        + [
+            helper.make_tensor_value_info(t.name, TensorProto.FLOAT, t.dims)
+            for t in inits
+        ],
+        [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, out_ch, 6, 6])],
+        inits,
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 8)])
+    model.ir_version = 3
+    onnx.checker.check_model(model)
+
+    sim_model, check_ok = onnxsim.simplify(model)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+    # The BatchNormalization is folded into the Conv weights and disappears.
+    assert all(n.op_type != "BatchNormalization" for n in sim_model.graph.node)
+    assert any(n.op_type == "Conv" for n in sim_model.graph.node)


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where Conv+BatchNorm fusion (and other value-baking optimizations) were silently skipped on IR version 3 models that list initializers as graph inputs, such as opset-8 exports like `resnet101-v1-7`. The fix bumps such models to IR 4 during simplification, allowing onnxoptimizer's fusion passes to correctly identify and fold constant initializers.

## Key Changes

- **Core fix in `onnxsim/onnx_simplifier.py`:**
  - Modified `remove_initializer_from_input()` to track whether any initializers were removed
  - When initializers are removed from an IR<4 model, bump `model.ir_version` to 4 (the first version allowing initializers to not be graph inputs)
  - Updated the `simplify()` function to call `remove_initializer_from_input()` unconditionally for non-mutable initializers (previously gated on `ir_version >= 4`, which prevented the fix from working)
  - Added detailed comments explaining the IR version semantics and why this fix is necessary

- **Test coverage in `tests/test_simple.py`:**
  - Added `test_ir3_conv_bn_fuses()` that reproduces the original issue: creates an IR3 model with Conv+BN where initializers are listed as graph inputs, verifies that simplification now correctly fuses them away

- **Updated fusion pattern tests in `tests/test_fusion_patterns.py`:**
  - Removed `xfail` markers from `test_eliminate_nop_dropout()`, `test_fuse_convtranspose_bn()`, and `test_fuse_convtranspose_add()` — these are now handled by onnxsim's optimizer
  - Updated documentation comments to reflect that these gaps have been closed
  - Kept remaining `xfail` for GELU-subgraph fusion (the only gap that remains)

- **Documentation updates in `scripts/regression/README.md`:**
  - Updated regression test documentation to reflect that Conv+BN fusion now works on IR<4 models
  - Clarified that several previously-missing fusions are now covered

## Implementation Details

The root cause was that IR versions 1-3 required every initializer to also appear in `graph.input`. onnxoptimizer's `is_constant_initializer()` check would return false for such inputs, treating them as runtime inputs rather than constants. This silently prevented value-baking fusions like `fuse_bn_into_conv` from firing.

IR version 4 (ONNX 1.4+) relaxed this requirement, allowing initializers to exist without being graph inputs. By bumping IR<4 models to IR 4 after removing initializer inputs, we enable onnxoptimizer to correctly identify and fold these constants, fixing the fusion pipeline for older model exports.

https://claude.ai/code/session_014taCE8hEjqFEj6eFNyDJsn