### PR TITLE
Add documentation for Claude on ONNX Runtime wheel build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# Notes for Claude
+
+## The Python wheel build does NOT build ONNX Runtime
+
+Don't get confused by `ONNXSIM_BUILTIN_ORT` when working on the wheel build.
+
+- `CMakeLists.txt` defaults `ONNXSIM_BUILTIN_ORT` to **ON**, which would compile the
+  vendored ONNX Runtime C++ source under `third_party/onnxruntime-1.27.1` (via
+  `cmake/build_ort.cmake`). That default is for the standalone C++/WASM builds, **not**
+  the Python wheel.
+- `setup.py` explicitly passes **`-DONNXSIM_BUILTIN_ORT=OFF`** when building the wheel, so
+  the vendored ONNX Runtime is **never compiled** as part of `pip install` / wheel builds.
+  The extension is compiled with the `NO_BUILTIN_ORT` define, which `#ifdef`s out all the
+  `Ort::` C++ code in `onnxsim/onnxsim.cpp` (and elsewhere).
+- At runtime, `onnxruntime` is only an **optional** Python dependency
+  (`[project.optional-dependencies]` in `pyproject.toml`). onnxsim uses the pip-installed
+  `onnxruntime` package for constant folding / correctness checking when present, and
+  falls back to onnx's reference evaluator when it isn't.
+
+So: **building or vendoring the ONNX Runtime C++ library is not required to build, test, or
+ship the Python wheel.** If you see long ONNX Runtime C++ compilation, that's the
+`ONNXSIM_BUILTIN_ORT=ON` path (standalone C++/WASM), not the wheel path.


### PR DESCRIPTION
## Summary
Added a new `CLAUDE.md` file to document how the Python wheel build process handles ONNX Runtime compilation, clarifying a potentially confusing aspect of the build system.

## Key Changes
- Created `CLAUDE.md` with detailed notes explaining:
  - The distinction between `CMakeLists.txt` defaults (`ONNXSIM_BUILTIN_ORT=ON`) and the actual wheel build behavior (`ONNXSIM_BUILTIN_ORT=OFF`)
  - How `setup.py` explicitly disables vendored ONNX Runtime compilation for wheel builds
  - The use of `NO_BUILTIN_ORT` define to conditionally compile C++ code
  - Runtime behavior: `onnxruntime` is an optional dependency that falls back to onnx's reference evaluator when unavailable
  - Clarification that ONNX Runtime C++ compilation is not required for building, testing, or shipping the Python wheel

## Implementation Details
This is a documentation-only change intended to prevent confusion when working on the wheel build system. It clarifies that long ONNX Runtime C++ compilation times indicate the standalone C++/WASM build path (`ONNXSIM_BUILTIN_ORT=ON`), not the Python wheel path.

https://claude.ai/code/session_01ANEf1us4xM8oSzPTsaZNfC