### PR TITLE
Add support for linking prebuilt ONNX Runtime releases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CMAKE_CXX_STANDARD 20)
 
 option(ONNXSIM_PYTHON "" OFF)
 option(ONNXSIM_BUILTIN_ORT "" ON)
+option(ONNXSIM_PREBUILT_ORT "Link a prebuilt ONNX Runtime release instead of building it from source" OFF)
 option(ONNXSIM_WASM_NODE "For node (enable NODERAWFS etc.)" OFF)
 option(ONNXSIM_C_API "Build the C ABI shared library used by the Rust wrapper and other FFI consumers" OFF)
 option(ONNXSIM_COVERAGE "Instrument onnxsim's own C++ targets for gcov/llvm-cov coverage" OFF)
@@ -38,19 +39,36 @@ if (WIN32)
 endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+if (ONNXSIM_PREBUILT_ORT AND NOT ONNXSIM_BUILTIN_ORT)
+  message(FATAL_ERROR "ONNXSIM_PREBUILT_ORT requires ONNXSIM_BUILTIN_ORT=ON")
+endif()
+if (ONNXSIM_PREBUILT_ORT AND EMSCRIPTEN)
+  message(FATAL_ERROR "ONNXSIM_PREBUILT_ORT is not supported for Emscripten; the "
+                      "WebAssembly build must compile ONNX Runtime from source")
+endif()
+
 if (ONNXSIM_BUILTIN_ORT)
-  # The top-level project only enables CXX, but ONNX Runtime (added below as a
-  # subdirectory) compiles C and assembly sources. Enable the languages it needs
-  # before configuring it. Emscripten's toolchain handles this on its own.
-  if (NOT EMSCRIPTEN)
-    enable_language(C)
-    enable_language(ASM)
-  endif()
-  include(cmake/build_ort.cmake)
-  if (EMSCRIPTEN)
-    set(ORT_NAME onnxruntime_webassembly)
-  else()
+  if (ONNXSIM_PREBUILT_ORT)
+    # Link an official ONNX Runtime release (headers + libonnxruntime) and skip
+    # the from-source ORT build entirely. This defines an imported `onnxruntime`
+    # target and sets ONNXRUNTIME_INCLUDE_DIR, mirroring build_ort.cmake's
+    # outputs so the rest of this file is unchanged.
+    include(cmake/prebuilt_ort.cmake)
     set(ORT_NAME onnxruntime)
+  else()
+    # The top-level project only enables CXX, but ONNX Runtime (added below as a
+    # subdirectory) compiles C and assembly sources. Enable the languages it needs
+    # before configuring it. Emscripten's toolchain handles this on its own.
+    if (NOT EMSCRIPTEN)
+      enable_language(C)
+      enable_language(ASM)
+    endif()
+    include(cmake/build_ort.cmake)
+    if (EMSCRIPTEN)
+      set(ORT_NAME onnxruntime_webassembly)
+    else()
+      set(ORT_NAME onnxruntime)
+    endif()
   endif()
 endif()
 
@@ -60,6 +78,11 @@ add_subdirectory(third_party/onnx-optimizer EXCLUDE_FROM_ALL)
 add_library(onnxsim onnxsim/onnxsim.cpp onnxsim/contrib_schemas.cpp onnxsim/function_rewriter.cpp onnxsim/profiler.cpp onnxsim/model_info.cpp onnxsim/sym_expr.cpp onnxsim/sym_value_eval.cpp onnxsim/sym_shape_infer.cpp onnxsim/model_metrics.cpp)
 if (ONNXSIM_BUILTIN_ORT)
   target_include_directories(onnxsim PRIVATE ${ONNXRUNTIME_INCLUDE_DIR})
+  if (ONNXSIM_PREBUILT_ORT)
+    # Prebuilt releases ship the public headers flat under include/, so onnxsim.cpp
+    # includes onnxruntime_cxx_api.h directly instead of the nested source path.
+    target_compile_definitions(onnxsim PRIVATE ONNXSIM_ORT_FLAT_HEADERS)
+  endif()
 endif()
 target_include_directories(onnxsim PUBLIC onnxsim)
 if (NOT ONNXSIM_BUILTIN_ORT)

--- a/cmake/prebuilt_ort.cmake
+++ b/cmake/prebuilt_ort.cmake
@@ -1,0 +1,163 @@
+# Use a prebuilt ONNX Runtime release instead of compiling ONNX Runtime from
+# source. The full source build (cmake/build_ort.cmake) recompiles ONNX Runtime,
+# protobuf and friends, which is the slowest part of a native onnxsim build; the
+# official releases at https://github.com/microsoft/onnxruntime/releases ship a
+# ready-to-link libonnxruntime shared library and the public C/C++ API headers,
+# so pointing at one lets a build skip that step entirely.
+#
+# Inputs (cache variables):
+#   ONNXSIM_ORT_HOME    - path to an already-extracted release directory (the one
+#                         that contains include/ and lib/). When set it is used
+#                         as-is and nothing is downloaded.
+#   ONNXSIM_ORT_VERSION - release version to download when ONNXSIM_ORT_HOME is
+#                         unset (default 1.28.0).
+#   ONNXSIM_ORT_URL     - full download URL, overriding the auto-detected release
+#                         asset (useful for GPU builds or mirrors).
+#
+# Outputs:
+#   ONNXRUNTIME_INCLUDE_DIR - the release's public-header directory
+#   imported target `onnxruntime` - links libonnxruntime and carries the include
+#                                   directory, matching ORT_NAME in CMakeLists.txt
+#
+# The shipped lib/cmake/onnxruntime config package is deliberately *not* used:
+# its generated paths assume a CMake `install()` layout (lib64/, include/onnxruntime/)
+# that does not match the release tarball, so find_package(onnxruntime) fails on
+# the archive. Locating the artifacts directly is more robust.
+
+set(ONNXSIM_ORT_VERSION "1.28.0" CACHE STRING
+    "Prebuilt ONNX Runtime release version to use when ONNXSIM_PREBUILT_ORT is ON")
+set(ONNXSIM_ORT_HOME "" CACHE PATH
+    "Path to an extracted prebuilt ONNX Runtime release (skips the download)")
+set(ONNXSIM_ORT_URL "" CACHE STRING
+    "Override URL for the prebuilt ONNX Runtime release archive")
+
+# Map the host platform to the release asset name microsoft/onnxruntime publishes.
+# Only the pieces onnxsim actually needs (Linux/macOS/Windows CPU) are covered;
+# anything else should set ONNXSIM_ORT_HOME or ONNXSIM_ORT_URL explicitly.
+function(_onnxsim_ort_asset out_stem out_ext)
+  string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _arch)
+  if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if (_arch MATCHES "aarch64|arm64")
+      set(_a "onnxruntime-linux-aarch64-${ONNXSIM_ORT_VERSION}")
+    else()
+      set(_a "onnxruntime-linux-x64-${ONNXSIM_ORT_VERSION}")
+    endif()
+    set(_e "tgz")
+  elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(_a "onnxruntime-osx-universal2-${ONNXSIM_ORT_VERSION}")
+    set(_e "tgz")
+  elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    set(_a "onnxruntime-win-x64-${ONNXSIM_ORT_VERSION}")
+    set(_e "zip")
+  else()
+    message(FATAL_ERROR
+      "ONNXSIM_PREBUILT_ORT: no known release asset for platform "
+      "'${CMAKE_SYSTEM_NAME}/${CMAKE_SYSTEM_PROCESSOR}'. Set ONNXSIM_ORT_HOME to "
+      "an extracted release or ONNXSIM_ORT_URL to a download URL.")
+  endif()
+  set(${out_stem} "${_a}" PARENT_SCOPE)
+  set(${out_ext} "${_e}" PARENT_SCOPE)
+endfunction()
+
+set(_ort_home "${ONNXSIM_ORT_HOME}")
+
+if (NOT _ort_home)
+  _onnxsim_ort_asset(_ort_stem _ort_ext)
+  if (ONNXSIM_ORT_URL)
+    set(_ort_url "${ONNXSIM_ORT_URL}")
+  else()
+    set(_ort_url
+      "https://github.com/microsoft/onnxruntime/releases/download/v${ONNXSIM_ORT_VERSION}/${_ort_stem}.${_ort_ext}")
+  endif()
+
+  set(_ort_root "${CMAKE_BINARY_DIR}/prebuilt-ort")
+  set(_ort_home "${_ort_root}/${_ort_stem}")
+  set(_ort_archive "${_ort_root}/${_ort_stem}.${_ort_ext}")
+
+  # Extraction marker: the extracted tree contains include/, so treat its
+  # presence as "already downloaded and unpacked" and skip the network on
+  # reconfigure.
+  if (NOT EXISTS "${_ort_home}/include")
+    file(MAKE_DIRECTORY "${_ort_root}")
+    message(STATUS "Downloading prebuilt ONNX Runtime ${ONNXSIM_ORT_VERSION} from ${_ort_url}")
+    file(DOWNLOAD "${_ort_url}" "${_ort_archive}" SHOW_PROGRESS STATUS _ort_dl_status)
+    list(GET _ort_dl_status 0 _ort_dl_code)
+    if (NOT _ort_dl_code EQUAL 0)
+      list(GET _ort_dl_status 1 _ort_dl_msg)
+      message(FATAL_ERROR "Failed to download ONNX Runtime from ${_ort_url}: ${_ort_dl_msg}")
+    endif()
+    file(ARCHIVE_EXTRACT INPUT "${_ort_archive}" DESTINATION "${_ort_root}")
+    if (NOT EXISTS "${_ort_home}/include")
+      message(FATAL_ERROR
+        "Extracted ${_ort_archive} but ${_ort_home}/include is missing; the "
+        "archive layout may have changed. Set ONNXSIM_ORT_HOME manually.")
+    endif()
+  endif()
+endif()
+
+# Resolve the include directory (public headers live flat under include/).
+set(ONNXRUNTIME_INCLUDE_DIR "${_ort_home}/include")
+if (NOT EXISTS "${ONNXRUNTIME_INCLUDE_DIR}/onnxruntime_cxx_api.h")
+  message(FATAL_ERROR
+    "ONNXSIM_PREBUILT_ORT: ${ONNXRUNTIME_INCLUDE_DIR}/onnxruntime_cxx_api.h not "
+    "found. Is '${_ort_home}' an extracted ONNX Runtime release?")
+endif()
+
+# Resolve the shared library. Releases keep it in lib/; prefer the linker-name
+# symlink (libonnxruntime.so / .dylib / onnxruntime.lib) and fall back to a glob.
+if (WIN32)
+  set(_ort_libname "onnxruntime.lib")
+elseif (APPLE)
+  set(_ort_libname "libonnxruntime.dylib")
+else()
+  set(_ort_libname "libonnxruntime.so")
+endif()
+
+set(_ort_lib "")
+foreach(_libdir "${_ort_home}/lib" "${_ort_home}/lib64")
+  if (EXISTS "${_libdir}/${_ort_libname}")
+    set(_ort_lib "${_libdir}/${_ort_libname}")
+    break()
+  endif()
+  file(GLOB _ort_lib_candidates
+       "${_libdir}/libonnxruntime.so*"
+       "${_libdir}/libonnxruntime*.dylib"
+       "${_libdir}/onnxruntime.lib")
+  if (_ort_lib_candidates)
+    list(GET _ort_lib_candidates 0 _ort_lib)
+    break()
+  endif()
+endforeach()
+
+if (NOT _ort_lib)
+  message(FATAL_ERROR
+    "ONNXSIM_PREBUILT_ORT: could not find the onnxruntime library under "
+    "${_ort_home}/lib. Set ONNXSIM_ORT_HOME to a complete release.")
+endif()
+
+message(STATUS "Using prebuilt ONNX Runtime")
+message(STATUS "  headers: ${ONNXRUNTIME_INCLUDE_DIR}")
+message(STATUS "  library: ${_ort_lib}")
+
+# Expose an imported target named `onnxruntime` so the rest of CMakeLists.txt can
+# link ${ORT_NAME} uniformly, whether ORT was built from source or prefetched.
+add_library(onnxruntime SHARED IMPORTED GLOBAL)
+set_target_properties(onnxruntime PROPERTIES
+  IMPORTED_LOCATION "${_ort_lib}"
+  INTERFACE_INCLUDE_DIRECTORIES "${ONNXRUNTIME_INCLUDE_DIR}")
+
+# On Windows the import library and the runtime DLL are separate files; point the
+# loader at the DLL so downstream consumers can copy it next to their binaries.
+if (WIN32)
+  file(GLOB _ort_dll "${_ort_home}/lib/onnxruntime.dll")
+  if (_ort_dll)
+    list(GET _ort_dll 0 _ort_dll0)
+    set_target_properties(onnxruntime PROPERTIES IMPORTED_IMPLIB "${_ort_lib}"
+                                                 IMPORTED_LOCATION "${_ort_dll0}")
+  endif()
+endif()
+
+# Surface the library directory so callers can extend rpath / copy the runtime.
+get_filename_component(ONNXRUNTIME_LIB_DIR "${_ort_lib}" DIRECTORY)
+set(ONNXRUNTIME_LIB_DIR "${ONNXRUNTIME_LIB_DIR}" CACHE INTERNAL
+    "Directory holding the prebuilt onnxruntime shared library")

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -6,6 +6,7 @@
 #include <onnx/onnx_pb.h>
 
 #include <algorithm>
+#include <bit>
 #include <fstream>
 #include <functional>
 #include <mutex>
@@ -15,8 +16,18 @@
 #include <unordered_map>
 
 #ifndef NO_BUILTIN_ORT
-#include "onnxruntime/core/common/endian.h"
+// Prebuilt ONNX Runtime releases (github.com/microsoft/onnxruntime/releases)
+// ship the public headers flat under include/ (e.g. onnxruntime_cxx_api.h),
+// whereas the vendored source tree nests them under
+// include/onnxruntime/core/session/. ONNXSIM_ORT_FLAT_HEADERS, defined by CMake
+// when ONNXSIM_PREBUILT_ORT is enabled, selects the flat layout. Endianness is
+// checked via C++20 std::endian so neither path depends on ORT's internal
+// core/common/endian.h (which the prebuilt release does not ship).
+#ifdef ONNXSIM_ORT_FLAT_HEADERS
+#include "onnxruntime_cxx_api.h"
+#else
 #include "onnxruntime/core/session/onnxruntime_cxx_api.h"
+#endif
 #endif
 #include "contrib_schemas.h"
 #include "onnx/common/file_utils.h"
@@ -221,7 +232,7 @@ Ort::Value TensorProtoToTensor(const onnx::TensorProto& tensor_proto) {
       allocator, tensor_proto.dims().data(), tensor_proto.dims_size(),
       (ONNXTensorElementDataType)tensor_proto.data_type());
   if (tensor_proto.has_raw_data()) {
-    if (onnxruntime::endian::native == onnxruntime::endian::big) {
+    if constexpr (std::endian::native == std::endian::big) {
       throw std::invalid_argument("only little endian is supported");
     }
     memcpy(tensor.GetTensorMutableData<void>(), tensor_proto.raw_data().data(),

--- a/rust/README.md
+++ b/rust/README.md
@@ -128,6 +128,19 @@ three modes:
    then requires the ONNX Runtime source to already be present at
    `third_party/onnxruntime-1.27.1`).
 
+   **Fast path — prebuilt ONNX Runtime.** To skip compiling ONNX Runtime from
+   source, set `ONNXSIM_PREBUILT_ORT=1`. The build then links an official
+   [ONNX Runtime release](https://github.com/microsoft/onnxruntime/releases)
+   (downloaded and cached automatically) instead. onnx-optimizer, onnx and
+   protobuf are still built from source, but the slowest dependency is skipped:
+
+   ```sh
+   ONNXSIM_PREBUILT_ORT=1 cargo build
+   # optionally pin a version or reuse an already-extracted release:
+   ONNXSIM_PREBUILT_ORT=1 ONNXSIM_ORT_VERSION=1.28.0 cargo build
+   ONNXSIM_PREBUILT_ORT=1 ONNXSIM_ORT_HOME=/path/to/onnxruntime-linux-x64-1.28.0 cargo build
+   ```
+
 2. **Pre-built library.** If you already have `onnxsim_c` (and its dependencies)
    built, point the build script at the directory (or directories, `:`-separated)
    holding the shared libraries:
@@ -143,6 +156,11 @@ three modes:
    cmake --build build --target onnxsim_c
    ```
 
+   Add `-DONNXSIM_PREBUILT_ORT=ON` to link an official ONNX Runtime release
+   (downloaded and cached under the build tree) instead of compiling it from
+   source. `-DONNXSIM_ORT_VERSION=<ver>` pins the release and
+   `-DONNXSIM_ORT_HOME=<dir>` reuses an already-extracted one.
+
 3. **Skip building** (for `cargo check` / docs.rs). Set `ONNXSIM_NO_BUILD=1`
    (docs.rs sets `DOCS_RS` automatically). The crate type-checks but cannot be
    linked into a runnable binary.
@@ -155,6 +173,10 @@ three modes:
 | `ONNXSIM_LIB_DIR`         | `:`-separated dirs holding a pre-built `onnxsim_c`.      |
 | `ONNXSIM_SOURCE_DIR`      | Override the onnxsim C++ source path (default `../..`).  |
 | `ONNXSIM_SKIP_ORT_DOWNLOAD` | Forbid the automatic ONNX Runtime source download.    |
+| `ONNXSIM_PREBUILT_ORT`    | Link a prebuilt ONNX Runtime release instead of building it. |
+| `ONNXSIM_ORT_VERSION`     | Prebuilt release version to fetch (default `1.28.0`).    |
+| `ONNXSIM_ORT_HOME`        | Use an already-extracted prebuilt release (no download). |
+| `ONNXSIM_ORT_URL`         | Override the prebuilt release download URL.              |
 
 ## Examples & tests
 

--- a/rust/onnxsim-sys/build.rs
+++ b/rust/onnxsim-sys/build.rs
@@ -25,6 +25,10 @@ fn main() {
     println!("cargo:rerun-if-env-changed=ONNXSIM_LIB_DIR");
     println!("cargo:rerun-if-env-changed=ONNXSIM_SOURCE_DIR");
     println!("cargo:rerun-if-env-changed=ONNXSIM_SKIP_ORT_DOWNLOAD");
+    println!("cargo:rerun-if-env-changed=ONNXSIM_PREBUILT_ORT");
+    println!("cargo:rerun-if-env-changed=ONNXSIM_ORT_HOME");
+    println!("cargo:rerun-if-env-changed=ONNXSIM_ORT_VERSION");
+    println!("cargo:rerun-if-env-changed=ONNXSIM_ORT_URL");
 
     // Mode 1: skip building entirely (docs.rs / `cargo check`).
     if env::var_os("DOCS_RS").is_some() || env::var_os("ONNXSIM_NO_BUILD").is_some() {
@@ -51,12 +55,23 @@ fn main() {
         source_dir.join("onnxsim/capi/onnxsim_c_api.cpp").display()
     );
 
-    // onnxsim vendors ONNX Runtime by downloading a source tarball (see
-    // build_wasm.sh) rather than as a git submodule, so `submodules: recursive`
-    // does not provide it. Fetch it here if the builtin-ORT build needs it.
-    ensure_onnxruntime_source(&source_dir);
+    // ONNXSIM_PREBUILT_ORT swaps the from-source ONNX Runtime build for an
+    // official prebuilt release (see cmake/prebuilt_ort.cmake), which is much
+    // faster the first time. In that mode ORT is not compiled here, so the
+    // vendored source tarball is not needed.
+    let prebuilt_ort = env::var_os("ONNXSIM_PREBUILT_ORT")
+        .map(|v| is_truthy(&v))
+        .unwrap_or(false);
 
-    let dst = cmake::Config::new(&source_dir)
+    if !prebuilt_ort {
+        // onnxsim vendors ONNX Runtime by downloading a source tarball (see
+        // build_wasm.sh) rather than as a git submodule, so `submodules: recursive`
+        // does not provide it. Fetch it here if the builtin-ORT build needs it.
+        ensure_onnxruntime_source(&source_dir);
+    }
+
+    let mut config = cmake::Config::new(&source_dir);
+    config
         .define("ONNXSIM_C_API", "ON")
         .define("ONNXSIM_BUILTIN_ORT", "ON")
         .define("ONNXSIM_PYTHON", "OFF")
@@ -64,8 +79,20 @@ fn main() {
         // No install() rules exist for onnxsim_c, so build the target in place
         // and locate the artifacts under the CMake build tree ourselves.
         .build_target("onnxsim_c")
-        .very_verbose(false)
-        .build();
+        .very_verbose(false);
+
+    if prebuilt_ort {
+        config.define("ONNXSIM_PREBUILT_ORT", "ON");
+        // Forward the optional knobs so callers can pin a version, point at an
+        // already-extracted release, or override the download URL.
+        for var in ["ONNXSIM_ORT_HOME", "ONNXSIM_ORT_VERSION", "ONNXSIM_ORT_URL"] {
+            if let Some(val) = env::var_os(var) {
+                config.define(var, val);
+            }
+        }
+    }
+
+    let dst = config.build();
 
     let build_dir = dst.join("build");
     for dir in find_lib_dirs(&build_dir) {
@@ -167,6 +194,20 @@ fn extract_zip(zip_path: &Path, dest_dir: &Path) {
 /// Run a command, returning true on a successful exit status.
 fn run(cmd: &mut Command) -> bool {
     matches!(cmd.status(), Ok(status) if status.success())
+}
+
+/// Interpret an environment variable as a boolean flag. Anything other than the
+/// usual "off" spellings (unset is handled by the caller) counts as enabled, so
+/// `ONNXSIM_PREBUILT_ORT=1`, `=ON`, and `=true` all turn the feature on.
+fn is_truthy(val: &std::ffi::OsStr) -> bool {
+    match val.to_str() {
+        Some(s) => !matches!(
+            s.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "off" | "false" | "no"
+        ),
+        // Non-UTF-8 but present: treat as set/enabled.
+        None => true,
+    }
 }
 
 /// Root of the onnxsim C++ project (the directory holding the top-level


### PR DESCRIPTION
## Summary
This PR adds an optional fast path for building onnxsim by linking official prebuilt ONNX Runtime releases instead of compiling from source. This significantly speeds up builds by skipping the slowest dependency compilation step while still building other dependencies (onnx-optimizer, onnx, protobuf) from source.

## Key Changes

- **New CMake module** (`cmake/prebuilt_ort.cmake`): Handles downloading, extracting, and linking prebuilt ONNX Runtime releases from the official GitHub releases. Supports:
  - Automatic platform detection (Linux x64/aarch64, macOS universal2, Windows x64)
  - Version pinning via `ONNXSIM_ORT_VERSION` (defaults to 1.28.0)
  - Reusing already-extracted releases via `ONNXSIM_ORT_HOME`
  - Custom download URLs via `ONNXSIM_ORT_URL`

- **CMakeLists.txt updates**: 
  - Added `ONNXSIM_PREBUILT_ORT` option to enable the prebuilt path
  - Conditional logic to use prebuilt release instead of `build_ort.cmake` when enabled
  - Added compile definition `ONNXSIM_ORT_FLAT_HEADERS` to handle header layout differences

- **Rust build script** (`rust/onnxsim-sys/build.rs`):
  - Added environment variable tracking for the new prebuilt ORT options
  - Conditional logic to skip vendored ORT source download when using prebuilt
  - Forwards prebuilt ORT configuration to CMake

- **Source code compatibility** (`onnxsim/onnxsim.cpp`):
  - Added conditional include paths to handle both flat (prebuilt) and nested (source) header layouts
  - Replaced internal `onnxruntime::endian` dependency with standard C++20 `std::endian` for endianness detection, eliminating dependency on ORT internal headers

- **Documentation** (`rust/README.md`):
  - Added usage examples and documentation for the new prebuilt ORT build mode
  - Documented all new environment variables and CMake options

## Implementation Details

- The prebuilt module deliberately avoids using ORT's shipped CMake config package (`lib/cmake/onnxruntime`) since its paths assume an install layout that doesn't match the release tarball structure
- Downloads are cached under the CMake build tree and extraction is skipped on reconfigure if already present
- Windows builds handle the separate import library (.lib) and runtime DLL (.dll) correctly
- The feature is fully optional and backward compatible; existing builds continue to work unchanged

https://claude.ai/code/session_01JSbDN8b49aPpGxrQQVVa6L