### PR TITLE
Surface ccache statistics in GitHub Actions summary

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -94,7 +94,19 @@ jobs:
           EMPROFILE=1 ./build_wasm.sh
           rm scripts/convertmodel/onnxsim.*
           cp build-wasm-node-OFF/onnxsim.* scripts/convertmodel
-      - run: |
+      # Surface ccache statistics on the run's summary page, the same way
+      # mozilla-actions/sccache-action does for sccache. `ccache -s` still
+      # goes to the step log too, so the numbers are available in both places.
+      - name: ccache statistics
+        if: always()
+        run: |
+          {
+            echo "### ccache statistics"
+            echo ""
+            echo '```'
+            ccache -s
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
           ccache -s
 
       # Build the patched Netron (embedding protocol + embedded mode) and serve


### PR DESCRIPTION
## Summary
Enhance the GitHub Actions workflow to display ccache statistics on the run's summary page, making build cache performance metrics more visible and accessible.

## Changes
- Added a new `ccache statistics` step that runs after the build completes (using `if: always()`)
- Captures `ccache -s` output and formats it as a markdown code block
- Appends the formatted statistics to `$GITHUB_STEP_SUMMARY` for display on the run's summary page
- Maintains the existing `ccache -s` output in the step log for backward compatibility

## Implementation Details
The change follows the same pattern used by `mozilla-actions/sccache-action` for surfacing cache statistics. The statistics are now available in two places:
1. The GitHub Actions run summary page (via `GITHUB_STEP_SUMMARY`)
2. The step log (traditional location)

This makes it easier to quickly review build cache effectiveness without having to navigate into the step logs.

https://claude.ai/code/session_01PtaxsMr6cx5TrEtFA8yhFz