### PR TITLE
Enable MAC/FLOP metrics comparison between original and converted models

### DIFF
--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -125,6 +125,15 @@
                     window.open(build_issue_url(), "_blank", "noopener");
                 };
                 let result_name = "";
+                let original_name = "";
+                // Decode a "data:...;base64,<b64>" URL back into a Uint8Array.
+                const dataUrlToBytes = (data_url) => {
+                    const b64 = data_url.slice(data_url.indexOf(",") + 1);
+                    const bin = atob(b64);
+                    const bytes = new Uint8Array(bin.length);
+                    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+                    return bytes;
+                };
                 worker.onmessage = (e) => {
                     switch (e.data[0]) {
                         case "ready":
@@ -146,6 +155,7 @@
                             dl_btn.disabled = false;
                             const data_url = e.data[1];
                             const trace_json = e.data[2];
+                            const original_data_url = e.data[3];
                             dl_btn.onclick = () => {
                                 const a = document.createElement("a");
                                 a.href = data_url;
@@ -161,10 +171,7 @@
                             // original upload). Decode the base64 data URL back
                             // into a Uint8Array and publish it for the panel.
                             try {
-                                const b64 = data_url.slice(data_url.indexOf(",") + 1);
-                                const bin = atob(b64);
-                                const bytes = new Uint8Array(bin.length);
-                                for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+                                const bytes = dataUrlToBytes(data_url);
                                 window.__onnxsimConverted = { bytes, name: result_name };
                                 window.dispatchEvent(new CustomEvent("onnxsim:converted", {
                                     detail: { name: result_name },
@@ -172,6 +179,22 @@
                             } catch (err) {
                                 log_output.value += "failed to keep converted model for inference: " + err + "\n";
                                 log_output.scrollTop = log_output.scrollHeight;
+                            }
+                            // Keep the MAC-annotated *original* bytes (when the
+                            // worker produced them) so the "Run inference" panel's
+                            // "original" source can report MACs/throughput and be
+                            // compared against the converted result.
+                            if (original_data_url) {
+                                try {
+                                    const bytes = dataUrlToBytes(original_data_url);
+                                    window.__onnxsimOriginalAnnotated = { bytes, name: original_name };
+                                    window.dispatchEvent(new CustomEvent("onnxsim:original-annotated", {
+                                        detail: { name: original_name },
+                                    }));
+                                } catch (err) {
+                                    log_output.value += "failed to keep annotated original for inference: " + err + "\n";
+                                    log_output.scrollTop = log_output.scrollHeight;
+                                }
                             }
                             // Render the onnxsim simplification profile, if one
                             // came back, as an inline flame graph.
@@ -199,6 +222,12 @@
                     if (!file) return;
                     const optimizer = document.querySelector('input[name="optimizer"]:checked').value;
                     result_name = (file.name.endsWith(".onnx") ? file.name.substring(0, file.name.length - 5) : file.name) + "." + optimizer + ".onnx"
+                    original_name = file.name;
+                    // Drop any previous run's cached models so the inference panel
+                    // never serves a stale converted/annotated result for the new
+                    // upload while this conversion is still in flight.
+                    window.__onnxsimConverted = null;
+                    window.__onnxsimOriginalAnnotated = null;
 
                     input.disabled = true;
                     dl_btn.disabled = true;
@@ -337,7 +366,10 @@
             <a href="https://github.com/onnxsim/onnxsim/pull/527" target="_blank" rel="noopener">PR #527</a>,
             e.g. annotated via <code>onnxsim.model_info.annotate_metadata</code>),
             they are shown below with the achieved throughput (GFLOP/s = model
-            FLOPs ÷ average latency).
+            FLOPs ÷ average latency). With <b>annotate model info</b> on (the
+            default), the converter bakes these metrics into <i>both</i> the
+            converted result <i>and</i> the original upload, so you can run each
+            and compare their MACs alongside the measured inference speed.
         </p>
         <div>
             <label for="inference-source">model</label>

--- a/scripts/convertmodel/inference_browser.mjs
+++ b/scripts/convertmodel/inference_browser.mjs
@@ -143,6 +143,20 @@ async function resolveModelBytes(source, fileInput) {
   }
   const file = fileInput.files && fileInput.files[0];
   if (!file) throw new Error("Pick an .onnx file first.");
+  // Prefer the MAC-annotated copy of the original that the converter produced
+  // for this upload (window.__onnxsimOriginalAnnotated, published in index.html
+  // when a conversion finishes with "annotate model info" on). It is the same
+  // model plus onnxsim.* metadata_props, so it runs identically but lets the
+  // panel report MACs/throughput — enabling an original-vs-converted speed
+  // comparison. The name guard avoids serving a stale annotation for a model
+  // that has since been swapped out.
+  const annotated = window.__onnxsimOriginalAnnotated;
+  if (annotated && annotated.bytes && annotated.name === file.name) {
+    return {
+      bytes: annotated.bytes,
+      label: `original (${file.name}, MAC-annotated)`,
+    };
+  }
   return {
     bytes: new Uint8Array(await file.arrayBuffer()),
     label: `original (${file.name})`,

--- a/scripts/convertmodel/interface.cpp
+++ b/scripts/convertmodel/interface.cpp
@@ -206,6 +206,35 @@ em::val onnxoptimizer_optimize_fixed(const std::string& data, em::val passes_ary
     return em::val(em::typed_memory_view(result.size(), reinterpret_cast<uint8_t*>(result.data())));
 }
 
+// Annotate a model's MAC/FLOP model-info metrics into its metadata_props
+// without simplifying/optimizing it, and return the annotated bytes. The page
+// uses this to give the *original* uploaded model the same onnxsim.* metrics
+// the converted model gets, so the "Run inference" panel can report throughput
+// (GFLOP/s) for both and compare their inference speed. Execution is unaffected
+// — only metadata_props are added — so the annotated bytes run identically.
+// Returns null on a parse/serialize failure (annotation itself is best-effort:
+// a model whose shapes cannot be inferred simply gains no metrics).
+em::val onnxsim_annotate_model_info(const std::string& data) {
+    onnx::ModelProto xmodel;
+    std::cerr << "parsing message" << std::endl;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    try {
+        AnnotateModelInfo(xmodel);
+    } catch (const std::exception& e) {
+        std::cerr << "annotate model info failed: " << e.what() << std::endl;
+    }
+    std::cerr << "serializing model" << std::endl;
+    static std::string result;
+    if (!xmodel.SerializeToString(&result)) {
+        std::cerr << "Serialize failed" << std::endl;
+        return em::val::null();
+    }
+    return em::val(em::typed_memory_view(result.size(), reinterpret_cast<uint8_t*>(result.data())));
+}
+
 std::vector<std::string> onnxoptimizer_passes() {
     return onnx::optimization::GetAvailablePasses();
 }
@@ -216,6 +245,7 @@ std::vector<std::string> onnxoptimizer_fuse_elimination_passes() {
 
 EMSCRIPTEN_BINDINGS(module) {
     function("onnxsimplify_export", &onnxsimplify_export);
+    function("onnxsim_annotate_model_info", &onnxsim_annotate_model_info);
     function("onnxoptimizer_optimize", &onnxoptimizer_optimize);
     function("onnxoptimizer_optimize_fixed", &onnxoptimizer_optimize_fixed);
     em::function("onnxoptimizer_passes", &onnxoptimizer_passes);

--- a/scripts/convertmodel/test/README.md
+++ b/scripts/convertmodel/test/README.md
@@ -41,6 +41,23 @@ message shape; it needs no dependencies or network:
 npm run test:netron
 ```
 
+## MAC / FLOP metrics
+
+`npm run test:macs` unit-tests `macs.mjs`, the dependency-free protobuf reader
+behind the inference panel's MAC/FLOP display. It reads onnxsim's per-model and
+per-node metrics out of a model's `metadata_props` (onnxsim
+[PR #527](https://github.com/onnxsim/onnxsim/pull/527)), substitutes dynamic
+dimensions with 1, and turns a model's FLOPs plus a measured latency into
+GFLOP/s.
+
+With **annotate model info** on (the default), the converter bakes these metrics
+into *both* outputs of a conversion: the converted result and — via the WASM
+`onnxsim_annotate_model_info` binding — the original upload
+(`window.__onnxsimOriginalAnnotated`). The inference panel then reports MACs and
+throughput for either **model** source, so the original and converted models can
+be compared on inference speed. Annotation only adds `metadata_props`, so the
+annotated bytes execute identically to the upload.
+
 ## Profiling traces
 
 Both the browser panels can emit a [Chrome Trace Event][cte] JSON that the page

--- a/scripts/convertmodel/worker.js
+++ b/scripts/convertmodel/worker.js
@@ -70,6 +70,24 @@ create_onnxsim({
         console.log("to data url start")
         const data_url = "data:application/octet-stream;base64," + model.toBase64();
         console.log("to data url end")
-        postMessage(["convert-done", data_url, trace]);
+        // When "annotate model info" is on, also bake the MAC/FLOP metrics into
+        // the *original* uploaded model so the "Run inference" panel can report
+        // its throughput too — letting the user compare original vs converted
+        // inference speed. Annotation only adds metadata_props, so the bytes run
+        // identically. Best-effort: a failure here just leaves the original
+        // un-annotated (the panel falls back to the raw upload).
+        let original_data_url = "";
+        if (e.data[8]) {
+            try {
+                const annotated = runtime.onnxsim_annotate_model_info(buf);
+                if (annotated) {
+                    original_data_url =
+                        "data:application/octet-stream;base64," + annotated.toBase64();
+                }
+            } catch (err) {
+                postMessage(["stderr", "annotate original model failed: " + err]);
+            }
+        }
+        postMessage(["convert-done", data_url, trace, original_data_url]);
     });
 });


### PR DESCRIPTION
## Summary

This change enables the inference panel to display and compare MAC/FLOP metrics for both the original uploaded model and the converted result. When "annotate model info" is enabled (the default), the converter now bakes onnxsim's MAC/FLOP metrics into both outputs, allowing users to measure and compare inference speed between the two versions.

## Key Changes

- **New WASM binding** (`onnxsim_annotate_model_info` in `interface.cpp`): Adds a function that annotates a model's MAC/FLOP metrics into its metadata_props without simplifying it. This allows the original upload to gain the same onnxsim.* metrics as the converted model while remaining functionally identical.

- **Worker annotation** (`worker.js`): When "annotate model info" is enabled, the worker now calls the new annotation function on the original uploaded bytes and returns the annotated data URL alongside the converted result.

- **Index.html updates**:
  - Extracted base64 data URL decoding into a reusable `dataUrlToBytes` helper function
  - Handles the new `original_data_url` parameter from the worker
  - Publishes the annotated original model via `window.__onnxsimOriginalAnnotated` and a custom event
  - Clears cached models on new uploads to prevent serving stale results

- **Inference panel** (`inference_browser.mjs`): Prefers the MAC-annotated copy of the original when available, falling back to the raw upload if annotation wasn't performed or failed.

- **Documentation**: Updated the inference panel's help text to explain that both the converted and original models can now report throughput metrics for comparison.

## Implementation Details

- Annotation is best-effort: if it fails (e.g., due to shape inference issues), the panel gracefully falls back to the unannotated original
- Annotation only adds `metadata_props`, so the annotated bytes execute identically to the original
- The name guard in the inference panel ensures stale annotations aren't served when the user uploads a different model
- Includes test infrastructure documentation for the MAC/FLOP metrics feature

https://claude.ai/code/session_01Bnqy9rweyQPxC31LYyRGjZ