### PR TITLE
Close more of the onnxslim node-count gap: fold Unsqueeze chains &amp; use Gemm for transformer FCs (#543)

### DIFF
--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -2006,6 +2006,19 @@ onnx::ModelProto Simplify(
         passes.push_back(pass);
       }
     }
+    // Opt into the batched MatMul+bias -> Gemm rewrite. onnx-optimizer registers
+    // it as PassType::Other (so it is absent from GetFuseAndEliminationPass),
+    // because it is a graph-shape rewrite rather than a pure node reduction.
+    // Transformer linear layers apply a 2-D weight to rank-3 activations, which
+    // the 2-D-only ``fuse_matmul_add_bias_into_gemm`` cannot fuse; converting
+    // them to ``Gemm`` lets runtimes dispatch their tuned GEMM kernels (the
+    // reshape scaffolding it introduces is folded/deduplicated by the rest of
+    // the fixed point). Still honour an explicit ``--skip-optimization`` for it.
+    const std::string batched_gemm = "fuse_matmul_add_bias_into_gemm_batched";
+    if (!is_disabled(*skip_optimizers, batched_gemm) &&
+        !is_disabled(always_disabled_passes, batched_gemm)) {
+      passes.push_back(batched_gemm);
+    }
     config.optimizer_passes = passes;
   }
 

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -2006,14 +2006,15 @@ onnx::ModelProto Simplify(
         passes.push_back(pass);
       }
     }
-    // Opt into the batched MatMul+bias -> Gemm rewrite. onnx-optimizer registers
-    // it as PassType::Other (so it is absent from GetFuseAndEliminationPass),
-    // because it is a graph-shape rewrite rather than a pure node reduction.
-    // Transformer linear layers apply a 2-D weight to rank-3 activations, which
-    // the 2-D-only ``fuse_matmul_add_bias_into_gemm`` cannot fuse; converting
-    // them to ``Gemm`` lets runtimes dispatch their tuned GEMM kernels (the
-    // reshape scaffolding it introduces is folded/deduplicated by the rest of
-    // the fixed point). Still honour an explicit ``--skip-optimization`` for it.
+    // Opt into the batched MatMul+bias -> Gemm rewrite. onnx-optimizer
+    // registers it as PassType::Other (so it is absent from
+    // GetFuseAndEliminationPass), because it is a graph-shape rewrite rather
+    // than a pure node reduction. Transformer linear layers apply a 2-D weight
+    // to rank-3 activations, which the 2-D-only
+    // ``fuse_matmul_add_bias_into_gemm`` cannot fuse; converting them to
+    // ``Gemm`` lets runtimes dispatch their tuned GEMM kernels (the reshape
+    // scaffolding it introduces is folded/deduplicated by the rest of the fixed
+    // point). Still honour an explicit ``--skip-optimization`` for it.
     const std::string batched_gemm = "fuse_matmul_add_bias_into_gemm_batched";
     if (!is_disabled(*skip_optimizers, batched_gemm) &&
         !is_disabled(always_disabled_passes, batched_gemm)) {

--- a/tests/test_fusion_patterns.py
+++ b/tests/test_fusion_patterns.py
@@ -95,6 +95,22 @@ def test_fuse_matmul_add_into_gemm():
     assert ops["MatMul"] == 0 and ops["Add"] == 0
 
 
+def test_batched_matmul_add_into_gemm():
+    # A transformer linear layer applies a 2-D weight to a rank-3 activation and
+    # adds a bias (exported bias-first, as HuggingFace does). onnxsim converts
+    # the batched MatMul+Add into a Gemm (fuse_matmul_add_bias_into_gemm_batched,
+    # opted in by onnxsim) so runtimes can dispatch tuned GEMM kernels.
+    inits = [_f32(np.random.randn(8, 16), "W"), _f32(np.random.randn(16), "b")]
+    nodes = [
+        onnx.helper.make_node("MatMul", ["X", "W"], ["mm"]),
+        onnx.helper.make_node("Add", ["b", "mm"], ["Y"]),
+    ]
+    model = _model(nodes, [_vi("X", [2, 4, 8])], [_vi("Y", [2, 4, 16])], inits)
+    _, ops = _simplify(model)
+    assert ops["Gemm"] == 1
+    assert ops["MatMul"] == 0
+
+
 def test_fuse_pad_into_conv():
     # A constant zero-value Pad on the spatial dims is folded into the Conv pads
     # attribute (fuse_pad_into_conv), removing the Pad node.


### PR DESCRIPTION
Follow-up to #545 for the node-count gap vs onnxslim tracked in #543. Depends on onnxsim/optimizer#7 (this PR bumps the `onnx-optimizer` submodule to it).

## FasterRCNN-10: +96 → +13
Dynamic-shape detection graphs feed `NonMaxSuppression` through `Unsqueeze(Unsqueeze(scalar))` chains whose input has no static shape, which blocked `fuse_consecutive_unsqueezes`. With the optimizer relaxation, onnxsim folds those chains: **2718 → 2635 nodes**, onnxsim's equivalence check still passing. The residual +13 is dynamic-shape *scaffolding* arithmetic (`Gather → Mul(dim, k) → Unsqueeze` on symbolic dims) — the SymExpr/#532 domain, not a pattern fusion.

## Transformers now use Gemm
onnxsim emitted **zero** Gemms on encoder/decoder graphs. `fuse_matmul_add_bias_into_gemm` only handles 2-D MatMul, and the batched (rank-3) variant `fuse_matmul_add_bias_into_gemm_batched` is registered `PassType::Other`, so it's excluded from the default set. This opts onnxsim into it (still honoring `--skip-optimization fuse_matmul_add_bias_into_gemm_batched`). Combined with the optimizer fix to match `Add(bias, MatMul)` operand order, **bart_Opset18 now converts 96 batched MatMul+Add pairs into Gemms** (MatMul 132→36, Add 158→62) so runtimes can dispatch tuned GEMM kernels — Gemm is cheaper than a batched MatMul. Equivalence check passes; the reshape scaffolding it introduces is folded/deduplicated by the rest of the fixed point (net ~parity on node count).

## Tests
`tests/test_fusion_patterns.py` gains an end-to-end batched-MatMul→Gemm test (17 pass, GELU still the lone xfail). Verified no regression on resnet101 (241) and FasterRCNN (2635) with a real build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014taCE8hEjqFEj6eFNyDJsn

---
_Generated by [Claude Code](https://claude.ai/code/session_014taCE8hEjqFEj6eFNyDJsn)_