### PR TITLE
Skip initializer folding for ancient opsets to avoid invalid ops

### DIFF
--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -69,13 +69,29 @@ def remove_unused_output(
     return model
 
 
+def _default_domain_opset(model: onnx.ModelProto) -> int:
+    """Opset version imported for the default (ai.onnx) domain, or 0 if none."""
+    for imp in model.opset_import:
+        if imp.domain in ("", "ai.onnx"):
+            return imp.version
+    return 0
+
+
+# Value-baking fusions such as ``fuse_bn_into_conv`` materialise helper nodes --
+# notably ``Cast`` -- using the modern operator encoding, where ``Cast``'s ``to``
+# attribute is an INT (a ``TensorProto`` data-type enum). That encoding only
+# became valid in opset 6; before that ``to`` was a STRING type name. Enabling
+# those fusions on an older-opset graph therefore emits nodes the graph's own
+# opset rejects, and onnx / onnxruntime abort with e.g. "Mismatched attribute
+# type in 'Cast_0 : to'. Expected: 'STRING', actual: 'INT'" (the onnx-caffe2
+# opset-3 ``resnet50-caffe2-v1-3`` hit exactly this). Below this opset we leave
+# IR<4 models untouched so onnxoptimizer keeps treating their initializers as
+# runtime inputs and skips the value-baking fusions -- the graph passes through
+# unchanged rather than crashing.
+_MIN_OPSET_FOR_INITIALIZER_FOLD = 6
+
+
 def remove_initializer_from_input(model: onnx.ModelProto) -> onnx.ModelProto:
-    initializer_names = [x.name for x in model.graph.initializer]
-    removed_any = False
-    for graph_input in copy.deepcopy(model.graph.input):
-        if graph_input.name in initializer_names:
-            model.graph.input.remove(graph_input)
-            removed_any = True
     # IR version 4 (ONNX 1.4) is the first that allows an initializer to *not*
     # also be a graph input. Older IR (v3 and below) required every initializer
     # to appear in ``graph.input``, and leaving it there makes onnxoptimizer
@@ -83,8 +99,21 @@ def remove_initializer_from_input(model: onnx.ModelProto) -> onnx.ModelProto:
     # (``is_constant_initializer`` returns false), which silently blocks
     # value-baking fusions such as ``fuse_bn_into_conv`` -- e.g. the plain
     # Conv+BN chains of the opset-8 ``resnet101-v1-7`` were left completely
-    # unsimplified. Bump such models to IR 4 so the removal above is legal and
-    # the freed initializers fold like any other constant.
+    # unsimplified. Bump such models to IR 4 so the removal below is legal and
+    # the freed initializers fold like any other constant -- but only when the
+    # opset is new enough for the ops those fusions insert; on an ancient-opset
+    # graph the bump would let a fusion emit a node the opset rejects (see
+    # ``_MIN_OPSET_FOR_INITIALIZER_FOLD``), so leave such models alone.
+    if model.ir_version < 4 and (
+        _default_domain_opset(model) < _MIN_OPSET_FOR_INITIALIZER_FOLD
+    ):
+        return model
+    initializer_names = [x.name for x in model.graph.initializer]
+    removed_any = False
+    for graph_input in copy.deepcopy(model.graph.input):
+        if graph_input.name in initializer_names:
+            model.graph.input.remove(graph_input)
+            removed_any = True
     if removed_any and model.ir_version < 4:
         model.ir_version = 4
     return model
@@ -564,7 +593,8 @@ def simplify(
         # ``remove_initializer_from_input`` bumps IR<4 models to IR 4 so the
         # freed initializers become foldable constants (previously gated on
         # ``ir_version >= 4``, which left opset-8 graphs such as resnet101-v1-7
-        # completely unsimplified).
+        # completely unsimplified) -- except for opsets too old to encode the
+        # nodes those fusions insert, which it leaves untouched.
         model = remove_initializer_from_input(model)
 
     # onnxoptimizer's common-subexpression / duplicate-initializer passes hash

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -790,3 +790,55 @@ def test_ir3_conv_bn_fuses():
     # The BatchNormalization is folded into the Conv weights and disappears.
     assert all(n.op_type != "BatchNormalization" for n in sim_model.graph.node)
     assert any(n.op_type == "Conv" for n in sim_model.graph.node)
+
+
+def _ir3_matmul_model(opset: int) -> onnx.ModelProto:
+    # A minimal IR-3 model whose weight ``W`` is *also* listed as a graph input,
+    # as IR<4 required. ``opset`` selects the ai.onnx version under test.
+    import numpy as np
+
+    W = numpy_helper.from_array(np.ones((2, 2), dtype=np.float32), "W")
+    graph = helper.make_graph(
+        [helper.make_node("MatMul", ["X", "W"], ["Y"])],
+        "g",
+        [
+            helper.make_tensor_value_info("X", TensorProto.FLOAT, [2, 2]),
+            helper.make_tensor_value_info("W", TensorProto.FLOAT, [2, 2]),
+        ],
+        [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [2, 2])],
+        [W],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", opset)])
+    model.ir_version = 3
+    return model
+
+
+def test_remove_initializer_from_input_skips_ancient_opset():
+    # The opset-3 onnx-caffe2 ``resnet50-caffe2-v1-3`` regressed once IR<4
+    # folding was enabled: bumping such a model to IR 4 lets onnxoptimizer's
+    # value-baking fusions fire, and ``fuse_bn_into_conv`` emits ``Cast`` nodes
+    # using the modern INT ``to`` attribute -- illegal under opset 3, where
+    # ``to`` is a STRING -- so onnx/onnxruntime abort with "Mismatched attribute
+    # type in 'Cast_0 : to'. Expected: 'STRING', actual: 'INT'". Opsets below
+    # ``_MIN_OPSET_FOR_INITIALIZER_FOLD`` must therefore be left untouched: the
+    # initializer stays a graph input (so the fusions stay disabled) and the IR
+    # version is not bumped.
+    from onnxsim.onnx_simplifier import remove_initializer_from_input
+
+    model = _ir3_matmul_model(opset=3)
+    out = remove_initializer_from_input(model)
+    assert out.ir_version == 3
+    assert "W" in [i.name for i in out.graph.input]
+
+
+def test_remove_initializer_from_input_folds_modern_opset():
+    # An opset >= 6 IR-3 model (e.g. the opset-8 ``resnet101-v1-7``) is safe to
+    # fold: the initializer-input is dropped and the model bumped to IR 4 so the
+    # freed constant becomes foldable and value-baking fusions can fire.
+    from onnxsim.onnx_simplifier import remove_initializer_from_input
+
+    model = _ir3_matmul_model(opset=8)
+    out = remove_initializer_from_input(model)
+    assert out.ir_version == 4
+    assert "W" not in [i.name for i in out.graph.input]
+    assert all(n.op_type != "Cast" for n in sim_model.graph.node)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -841,4 +841,3 @@ def test_remove_initializer_from_input_folds_modern_opset():
     out = remove_initializer_from_input(model)
     assert out.ir_version == 4
     assert "W" not in [i.name for i in out.graph.input]
-    assert all(n.op_type != "Cast" for n in sim_model.graph.node)


### PR DESCRIPTION
## Summary

Fixes a regression where IR<4 models with ancient opsets (< 6) would crash when bumped to IR 4 for initializer folding. The value-baking fusions enabled by that bump emit `Cast` nodes using the modern INT encoding for the `to` attribute, which is invalid in opsets below 6 where `to` must be a STRING.

## Changes

- **Added opset version checking** in `remove_initializer_from_input()`: Models with IR < 4 and opset < 6 are now left untouched, preserving their initializers as graph inputs so onnxoptimizer skips value-baking fusions that would emit invalid ops.

- **New helper function** `_default_domain_opset()`: Extracts the ai.onnx opset version from a model's opset imports.

- **New constant** `_MIN_OPSET_FOR_INITIALIZER_FOLD = 6`: Documents the minimum opset required for safe initializer folding, with detailed comments explaining the `Cast` attribute encoding incompatibility.

- **Added test coverage**:
  - `test_remove_initializer_from_input_skips_ancient_opset()`: Verifies opset-3 IR-3 models stay unchanged
  - `test_remove_initializer_from_input_folds_modern_opset()`: Verifies opset-8 IR-3 models are properly folded to IR-4
  - Helper function `_ir3_matmul_model()`: Creates minimal IR-3 test models with configurable opsets

## Implementation Details

The fix is conservative: only models with both IR < 4 AND opset < 6 are skipped. Modern opsets (≥ 6) continue to benefit from initializer folding even in IR-3, enabling optimizations like `fuse_bn_into_conv` on models like resnet101-v1-7. This prevents regressions on ancient models like the onnx-caffe2 opset-3 resnet50 while maintaining optimization coverage for newer models.

https://claude.ai/code/session_018zUMiRHAicRVYt5YQBykMR