### PR TITLE
Upgrade ONNX Runtime to version 1.28.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,8 +57,8 @@ jobs:
       - name: Cache ONNX Runtime source
         uses: actions/cache@v6
         with:
-          path: third_party/onnxruntime-1.27.1
-          key: onnxruntime-src-1.27.1
+          path: third_party/onnxruntime-1.28.0
+          key: onnxruntime-src-1.28.0
       - name: Build the workspace (compiles and links the native library)
         run: cargo build --release --workspace
       - name: Run tests (unit + linked integration tests)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 Don't get confused by `ONNXSIM_BUILTIN_ORT` when working on the wheel build.
 
 - `CMakeLists.txt` defaults `ONNXSIM_BUILTIN_ORT` to **ON**, which would compile the
-  vendored ONNX Runtime C++ source under `third_party/onnxruntime-1.27.1` (via
+  vendored ONNX Runtime C++ source under `third_party/onnxruntime-1.28.0` (via
   `cmake/build_ort.cmake`). That default is for the standalone C++/WASM builds, **not**
   the Python wheel.
 - `setup.py` explicitly passes **`-DONNXSIM_BUILTIN_ORT=OFF`** when building the wheel, so

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -17,7 +17,7 @@ fi
 
 set -u -o pipefail
 
-ORT_VER=1.27.1
+ORT_VER=1.28.0
 if [ ! -d "third_party/onnxruntime-${ORT_VER}" ] ; then
     pushd third_party
     wget -q "https://github.com/microsoft/onnxruntime/archive/refs/tags/v${ORT_VER}.zip"

--- a/cmake/build_ort.cmake
+++ b/cmake/build_ort.cmake
@@ -23,8 +23,8 @@ else()
   # to the single libonnxruntime_webassembly.a
   option(onnxruntime_BUILD_SHARED_LIB "" ON)
 endif()
-set(ONNXRUNTIME_INCLUDE_DIR third_party/onnxruntime-1.27.1/include)
-add_subdirectory(third_party/onnxruntime-1.27.1/cmake)
+set(ONNXRUNTIME_INCLUDE_DIR third_party/onnxruntime-1.28.0/include)
+add_subdirectory(third_party/onnxruntime-1.28.0/cmake)
 
 if (NOT EMSCRIPTEN)
   set(BUILD_SHARED_LIBS ON)

--- a/rust/README.md
+++ b/rust/README.md
@@ -126,7 +126,7 @@ three modes:
 
    Set `ONNXSIM_SKIP_ORT_DOWNLOAD=1` to forbid the automatic download (the build
    then requires the ONNX Runtime source to already be present at
-   `third_party/onnxruntime-1.27.1`).
+   `third_party/onnxruntime-1.28.0`).
 
    **Fast path — prebuilt ONNX Runtime.** To skip compiling ONNX Runtime from
    source, set `ONNXSIM_PREBUILT_ORT=1`. The build then links an official

--- a/rust/onnxsim-sys/build.rs
+++ b/rust/onnxsim-sys/build.rs
@@ -18,7 +18,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// ONNX Runtime version onnxsim builds against; must match `cmake/build_ort.cmake`.
-const ONNXRUNTIME_VERSION: &str = "1.27.1";
+const ONNXRUNTIME_VERSION: &str = "1.28.0";
 
 fn main() {
     println!("cargo:rerun-if-env-changed=ONNXSIM_NO_BUILD");


### PR DESCRIPTION
## Summary
Updates the vendored ONNX Runtime dependency from version 1.27.1 to 1.28.0 across all build configurations and documentation.

## Changes
- Updated ONNX Runtime version constant in `rust/onnxsim-sys/build.rs` from 1.27.1 to 1.28.0
- Updated build script `build_wasm.sh` to download and use ONNX Runtime 1.28.0
- Updated CMake configuration in `cmake/build_ort.cmake` to reference the new version directory
- Updated GitHub Actions workflow cache paths and keys to use 1.28.0
- Updated documentation in `CLAUDE.md` and `rust/README.md` to reflect the new version path

## Notes
This upgrade affects the standalone C++/WASM builds that use `ONNXSIM_BUILTIN_ORT=ON`. The Python wheel build is unaffected as it uses `ONNXSIM_BUILTIN_ORT=OFF` and relies on the pip-installed `onnxruntime` package instead.

https://claude.ai/code/session_013JeLNcPTKYkSqCsJGGoxmA