### PR TITLE
Move constant-folding executor boundary to DLPack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,11 @@ if (ONNXSIM_BUILTIN_ORT)
   endif()
 endif()
 target_include_directories(onnxsim PUBLIC onnxsim)
+# dlpack.h (at third_party/dlpack/dlpack.h) is the tensor-exchange type at the
+# ModelExecutor / C-ABI executor boundary (see docs/dlpack-executor.md). The
+# include root is third_party/ so `#include "dlpack/dlpack.h"` resolves. PUBLIC
+# so the C API and any target that includes onnxsim.h / dlpack_bridge.h finds it.
+target_include_directories(onnxsim PUBLIC third_party)
 if (NOT ONNXSIM_BUILTIN_ORT)
   target_compile_definitions(onnxsim PUBLIC NO_BUILTIN_ORT)
 endif()
@@ -221,4 +226,11 @@ if (ONNXSIM_TESTS)
                                       onnxsim/sym_value_eval.cpp onnxsim/sym_expr.cpp)
   target_include_directories(sym_shape_infer_test PRIVATE onnxsim)
   add_test(NAME sym_shape_infer_test COMMAND sym_shape_infer_test)
+
+  # The ONNX<->DLPack dtype mapping (dlpack_dtype.h) is pure: it operates on the
+  # integer ONNX dtype codes and depends only on dlpack.h, so its test builds
+  # and runs standalone -- including under Emscripten -- without ONNX / ORT.
+  add_executable(dlpack_dtype_test onnxsim/dlpack_dtype_test.cpp)
+  target_include_directories(dlpack_dtype_test PRIVATE onnxsim third_party)
+  add_test(NAME dlpack_dtype_test COMMAND dlpack_dtype_test)
 endif()

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,9 @@
 recursive-include onnxsim *.h *.hpp *.cc *.cpp
 recursive-include cmake *
 recursive-include third_party/onnx-optimizer *
+# Vendored DLPack header. onnxsim.h / dlpack_bridge.h include <dlpack/dlpack.h>,
+# so the wheel build compiles onnxsim.cpp against it; it must ship in the sdist.
+recursive-include third_party/dlpack *.h
 recursive-exclude third_party/onnx-optimizer/*build* *
 include CMakeLists.txt
 include VERSION

--- a/docs/dlpack-executor.md
+++ b/docs/dlpack-executor.md
@@ -1,0 +1,199 @@
+# DLPack tensor exchange at the constant-folding executor boundary
+
+## Why
+
+onnxsim's constant folder repeatedly builds a throwaway sub-model for each
+"fold group" and asks a `ModelExecutor` to evaluate it. Historically that
+boundary exchanged tensors as `onnx::TensorProto`:
+
+```cpp
+// old
+virtual std::vector<onnx::TensorProto> _Run(
+    const onnx::ModelProto& model,
+    const std::vector<onnx::TensorProto>& inputs) const = 0;
+```
+
+That representation forces a protobuf materialization on both sides of every
+executor call. The worst offender was the output path (`TensorToTensorProto`),
+which appended results **element by element** with `add_float_data(dptr[i])`,
+reallocating the repeated field as it grew — far more expensive than a memcpy.
+The input path copied too (`TensorProtoToTensor` allocated an ORT buffer and
+memcpy'd into it, after copying each initializer into the feed vector).
+
+Two goals motivated moving the boundary to DLPack:
+
+1. **Avoid the TensorProto tax** on the hot folding path — borrow buffers in,
+   move ORT's own output buffers out.
+2. **Embeddability.** onnxsim can be dropped into another ONNX-based compiler or
+   runtime stack (a different ORT build, IREE, TVM, a hardware vendor runtime)
+   by having that host implement *one* executor callback that speaks a standard
+   tensor ABI, without ever touching `onnx::TensorProto` or the vendored ORT.
+
+DLPack (`DLManagedTensor`) is that ABI. It is a small, stable C struct — data
+pointer, device, dtype, shape, strides, deleter — usable identically in native
+builds, WebAssembly, and across an FFI. Nothing about it is Python-specific.
+
+## The boundary
+
+```cpp
+// onnxsim.h
+struct ModelExecutor {
+  virtual ~ModelExecutor() = default;
+  virtual std::vector<DLManagedTensorPtr> Run(
+      const onnx::ModelProto& model,
+      const std::vector<const DLManagedTensor*>& inputs) const = 0;
+};
+```
+
+- **Positional, not named.** `inputs[i]` feeds `model.graph().input(i)`; the
+  result has one tensor per `model.graph().output()`, in order. DLPack has no
+  name field, and `RunOps` already relied on positional order, so nothing is
+  lost.
+- **`DLManagedTensorPtr`** is `std::unique_ptr<DLManagedTensor,
+  DLManagedTensorDeleter>`; releasing it invokes the tensor's own DLPack
+  `deleter` exactly once. Ownership is therefore RAII on the C++ side and an
+  explicit deleter contract at the C ABI.
+
+### Ownership / lifetime contract
+
+- **Inputs are borrowed** for the duration of the call. The executor must not
+  free them or retain them past return. onnxsim keeps the backing buffers
+  (initializer `raw_data`) alive across the call.
+- **Outputs are freshly owned** by the caller. Each carries a `deleter` that
+  releases whatever the producer attached — a borrowed-buffer no-op, an
+  `Ort::Value`, or a host allocation.
+- All tensors at this boundary are **CPU (`kDLCPU`), contiguous, and
+  little-endian**.
+
+### What stays `TensorProto`
+
+The **model** still crosses as a serialized `ModelProto` — ONNX initializers are
+inherently protobuf, and the sub-model is tiny. Only the **runtime feeds and
+fetches** become DLPack. Likewise, folded results are ultimately baked back into
+the model as `raw_data` initializers; that final write is the one unavoidable
+copy (`ToTensorProto`, a single `set_raw_data`).
+
+## dtype mapping
+
+`dlpack_dtype.h` maps the stable ONNX dtype wire numbers to `DLDataType` and
+back, bijectively, with `lanes == 1`. It depends only on `dlpack.h` (not the
+onnx headers), so it is unit-tested standalone (`dlpack_dtype_test`).
+
+| ONNX dtype | DLDataType (code, bits) | bytes |
+|------------|--------------------------|-------|
+| FLOAT16    | kDLFloat, 16             | 2     |
+| FLOAT      | kDLFloat, 32             | 4     |
+| DOUBLE     | kDLFloat, 64             | 8     |
+| BFLOAT16   | kDLBfloat, 16            | 2     |
+| INT8       | kDLInt, 8                | 1     |
+| INT16      | kDLInt, 16               | 2     |
+| INT32      | kDLInt, 32               | 4     |
+| INT64      | kDLInt, 64               | 8     |
+| UINT8      | kDLUInt, 8               | 1     |
+| UINT16     | kDLUInt, 16              | 2     |
+| UINT32     | kDLUInt, 32              | 4     |
+| UINT64     | kDLUInt, 64              | 8     |
+| BOOL       | kDLBool, 8               | 1     |
+
+Rejected at this boundary (no contiguous little-endian layout the folder
+exchanges): STRING, COMPLEX64/128, FLOAT8\*, INT4/UINT4/FLOAT4, UNDEFINED. This
+matches — and slightly extends (adds FLOAT16/BFLOAT16/UINT32) — the dtype set the
+old TensorProto↔ORT converters handled.
+
+## Adapters
+
+One boundary, several adapters (`dlpack_bridge.h` holds the conversions):
+
+| Adapter | Where | Input | Output | Copies |
+|---------|-------|-------|--------|--------|
+| `CppModelExecutor` | onnxsim.cpp (built-in ORT) | `BorrowAsOrtValue` wraps the feed buffer via ORT's borrowing `CreateTensor` — **zero copy** | `FromOrtValue` moves ORT's own output buffer into the managed tensor — **zero copy** | none at the boundary |
+| `CApiModelExecutor` | capi/onnxsim_c_api.cpp | host receives borrowed `DLManagedTensor*` | host returns owned `DLManagedTensor*`, released via their deleters | host's choice |
+| `PyModelExecutor` | cpp2py_export.cc | `ToTensorProto` → bytes | bytes → `FromTensorProtoOwning` | protobuf round trip (see below) |
+
+The Python adapter still pays a `TensorProto` round trip because the Python side
+(onnxruntime's Python API, onnx's reference evaluator) speaks `TensorProto`, not
+DLPack. Python is not the zero-copy target; a future dlpack-native Python
+executor could bypass it via `__dlpack__`.
+
+### C ABI executor callback (the embeddability seam)
+
+`onnxsim_simplify_with_executor` accepts:
+
+```c
+typedef int (*OnnxsimExecuteFn)(
+    void* user_data, const void* model_data, size_t model_size,
+    const DLManagedTensor* const* inputs, size_t num_inputs,
+    DLManagedTensor*** out_outputs, size_t* out_num_outputs);
+typedef void (*OnnxsimExecuteFreeFn)(
+    void* user_data, DLManagedTensor** outputs, size_t num_outputs);
+```
+
+A NULL `execute_fn` falls back to the built-in executor, so the new entry point
+is a drop-in superset of `onnxsim_simplify`. The host implements one function in
+terms of its own tensors; onnxsim adopts each returned tensor (releasing it via
+its DLPack deleter) and then calls `OnnxsimExecuteFreeFn` to release the array
+container. The Rust `-sys` crate can add a matching declaration to expose this
+(not done in this prototype).
+
+## JsModelExecutor / onnxruntime-web: the separate-heap caveat
+
+A planned `JsModelExecutor` would run constant folding in onnxruntime-web. This
+is the case DLPack helps most — **but with a hard constraint**: onnxsim-wasm and
+onnxruntime-web are *separate WASM modules with separate linear memories*. A
+`DLManagedTensor.data` pointer minted in onnxsim's heap is meaningless inside
+ort-web's heap, so true zero-copy across that boundary is impossible without a
+shared `SharedArrayBuffer` memory. Per fold group the realistic path is:
+
+1. onnxsim → JS: `emscripten::typed_memory_view` over onnxsim's heap at the
+   tensor's `data` offset → a JS typed-array **view, zero copy on onnxsim's
+   side**.
+2. JS → ort-web: `new ort.Tensor(dtype, view, dims)` copies into ORT's heap on
+   feed — **one copy, unavoidable across modules**.
+3. `session.run(...)`.
+4. ort-web → JS: read back with `preferredOutputLocation: 'cpu'` — **one copy
+   out**.
+5. JS → onnxsim: `.set()` into a buffer onnxsim `_malloc`'d and exposed as a
+   view — **one copy in**.
+
+So DLPack does **not** remove the memory-domain copies across the ort-web
+boundary — nothing can, across two modules. What it removes is the **protobuf
+serialize/parse** on every tensor (copy *plus* varint encode/decode). Net
+change: `protobuf-encode + 2 domain copies + protobuf-decode` → `2 domain
+copies`.
+
+Consequences for the design:
+
+- The **built-in in-wasm `CppModelExecutor` is the zero-copy ideal** (same heap
+  → `CreateTensor` borrows directly). `JsModelExecutor` deliberately trades that
+  away for what ort-web offers (WebGPU EP, kernels the vendored ORT lacks). The
+  same `DLManagedTensor` descriptor serves both; only the deleter differs
+  (borrow vs. heap free).
+- **WebGPU:** an on-device ort-web output has no portable CPU DLPack pointer.
+  First cut: force `preferredOutputLocation: 'cpu'` so outputs cross as
+  `kDLCPU`. (`kDLWebGPU` exists in `dlpack.h` but the C++ folder cannot consume
+  a GPU buffer.)
+- **Batch a whole fold group in one embind crossing** (an array of descriptors),
+  not one call per tensor — embind calls have real overhead, and `RunOps`
+  already groups nodes per session.
+
+## Files
+
+- `third_party/dlpack/dlpack.h` — vendored DLPack ABI header (include root
+  `third_party/`, so `#include "dlpack/dlpack.h"`).
+- `onnxsim/dlpack_dtype.h` — pure ONNX↔DLPack dtype mapping (+ `dlpack_dtype_test.cpp`).
+- `onnxsim/dlpack_bridge.h` — `TensorProto`↔`DLManagedTensor` and
+  `Ort::Value`↔`DLManagedTensor` converters.
+- `onnxsim/onnxsim.h` — `ModelExecutor::Run` (DLPack) + `DLManagedTensorPtr`.
+- `onnxsim/onnxsim.cpp` — `CppModelExecutor` adapter; `RunOps` bridge; old
+  element-wise converters removed.
+- `onnxsim/cpp2py_export.cc` — `PyModelExecutor` adapts DLPack ↔ bytes.
+- `onnxsim/capi/onnxsim_c_api.{h,cpp}` — `OnnxsimExecuteFn` +
+  `onnxsim_simplify_with_executor`.
+
+## Follow-ups
+
+- Expose `onnxsim_simplify_with_executor` from the Rust `-sys`/safe crates.
+- Implement `JsModelExecutor` (embind adapter: `DLManagedTensor` ⇆ `ort.Tensor`,
+  batched per fold group).
+- Optional dlpack-native Python executor via `__dlpack__` to drop the Python
+  adapter's protobuf round trip.

--- a/docs/dlpack-executor.md
+++ b/docs/dlpack-executor.md
@@ -137,7 +137,8 @@ container. The Rust `-sys` crate can add a matching declaration to expose this
 
 ## JsModelExecutor / onnxruntime-web: the separate-heap caveat
 
-A planned `JsModelExecutor` would run constant folding in onnxruntime-web. This
+`JsModelExecutor` (added in #555, `scripts/convertmodel/js_model_executor.cpp`,
+and ported to this boundary here) runs constant folding in onnxruntime-web. This
 is the case DLPack helps most — **but with a hard constraint**: onnxsim-wasm and
 onnxruntime-web are *separate WASM modules with separate linear memories*. A
 `DLManagedTensor.data` pointer minted in onnxsim's heap is meaningless inside
@@ -205,9 +206,16 @@ The Rust crates expose the seam:
   construction/teardown round trip is unit-tested and verified leak/UAF-free
   under AddressSanitizer.
 
+The `JsModelExecutor`'s `Run` now takes borrowed `DLManagedTensor*` feeds
+(reading dtype/shape/bytes directly, names recovered positionally from
+`graph().input()`) and returns owning managed tensors built from the runner's
+output bytes via `FromTensorProtoOwning`. See `docs/wasm_ort_web.md` for the
+onnxruntime-web build variant and its Asyncify sync-C++/async-JS bridge.
+
 ## Follow-ups
 
-- Implement `JsModelExecutor` (embind adapter: `DLManagedTensor` ⇆ `ort.Tensor`,
-  batched per fold group).
+- Batch a whole fold group's tensors into one embind crossing in
+  `JsModelExecutor` (currently one JS array built per call; the per-tensor
+  `Uint8Array` copies are unavoidable across the separate heaps).
 - Optional dlpack-native Python executor via `__dlpack__` to drop the Python
   adapter's protobuf round trip.

--- a/docs/dlpack-executor.md
+++ b/docs/dlpack-executor.md
@@ -212,10 +212,14 @@ The `JsModelExecutor`'s `Run` now takes borrowed `DLManagedTensor*` feeds
 output bytes via `FromTensorProtoOwning`. See `docs/wasm_ort_web.md` for the
 onnxruntime-web build variant and its Asyncify sync-C++/async-JS bridge.
 
+`JsModelExecutor` batches a whole fold group's tensors into a single embind
+crossing per direction — one concatenated byte blob plus one flat
+`[dtype, ndim, dims...]` metadata array — instead of building a JS object per
+tensor. The per-fold-group data copies across the two separate heaps remain
+(they are unavoidable), but the number of embind round trips is now O(1) rather
+than O(tensors × fields). See `docs/wasm_ort_web.md`.
+
 ## Follow-ups
 
-- Batch a whole fold group's tensors into one embind crossing in
-  `JsModelExecutor` (currently one JS array built per call; the per-tensor
-  `Uint8Array` copies are unavoidable across the separate heaps).
 - Optional dlpack-native Python executor via `__dlpack__` to drop the Python
   adapter's protobuf round trip.

--- a/docs/dlpack-executor.md
+++ b/docs/dlpack-executor.md
@@ -190,9 +190,23 @@ Consequences for the design:
 - `onnxsim/capi/onnxsim_c_api.{h,cpp}` — `OnnxsimExecuteFn` +
   `onnxsim_simplify_with_executor`.
 
+## Rust binding
+
+The Rust crates expose the seam:
+
+- `onnxsim-sys`: the DLPack structs (`DLManagedTensor` et al.), `OnnxsimExecuteFn`
+  / `OnnxsimExecuteFreeFn`, and `onnxsim_simplify_with_executor`, mirroring the C
+  header one-to-one.
+- `onnxsim` (safe): `simplify_with_executor(model, options, |submodel, inputs|
+  -> Result<Vec<Tensor>, E>)`. Inputs arrive as borrowed `TensorRef`s (dtype +
+  shape + little-endian bytes); outputs are owned `Tensor`s. Trampolines convert
+  to/from `DLManagedTensor` with an RAII deleter, guard the FFI boundary with
+  `catch_unwind`, and validate output byte lengths. The DLManagedTensor
+  construction/teardown round trip is unit-tested and verified leak/UAF-free
+  under AddressSanitizer.
+
 ## Follow-ups
 
-- Expose `onnxsim_simplify_with_executor` from the Rust `-sys`/safe crates.
 - Implement `JsModelExecutor` (embind adapter: `DLManagedTensor` ⇆ `ort.Tensor`,
   batched per fold group).
 - Optional dlpack-native Python executor via `__dlpack__` to drop the Python

--- a/docs/wasm_ort_web.md
+++ b/docs/wasm_ort_web.md
@@ -12,12 +12,16 @@ onnxsim's constant folding runs sub-models through a `ModelExecutor` abstraction
 - `CppModelExecutor` — calls a statically linked ONNX Runtime C++ library. This
   is what the default WASM build uses (`ONNXSIM_BUILTIN_ORT=ON`), which compiles
   ONNX Runtime from source into onnxsim's own `.wasm`.
-- `PyModelExecutor` — the Python "trampoline": `_Run` calls back into the pip
+- `PyModelExecutor` — the Python "trampoline": `Run` calls back into the pip
   `onnxruntime` package, so the wheel links no ONNX Runtime C++
   (`NO_BUILTIN_ORT`).
 
+The `ModelExecutor` boundary exchanges tensors as DLPack `DLManagedTensor`
+(`onnxsim.h` / `onnxsim/dlpack_bridge.h`, see `docs/dlpack-executor.md`), so no
+tensor is serialized to `TensorProto` across it.
+
 This variant adds the WebAssembly analogue of the Python trampoline: a
-`JsModelExecutor` whose `_Run` delegates each fold group to the page's
+`JsModelExecutor` whose `Run` delegates each fold group to the page's
 **onnxruntime-web** module. Built this way, the onnxsim WASM module links **no**
 ONNX Runtime:
 
@@ -28,11 +32,11 @@ ONNX Runtime:
 ## How it works
 
 ```
-Simplify → RunOps → executor._Run(subModel, inputs)      (C++, onnxsim.cpp)
+Simplify → RunOps → executor.Run(subModel, DLManagedTensor feeds)  (C++, onnxsim.cpp)
                         │
                         │  JsModelExecutor (js_model_executor.cpp)
-                        │   - serialize subModel + inputs to JS-owned buffers
-                        │   - Module.onnxsimOrtWebRun(modelBytes, inputs)
+                        │   - concat all feed bytes + a flat meta array (one copy each)
+                        │   - Module.onnxsimOrtWebRun(modelBytes, inputsData, inputsMeta)
                         │   - .await() the returned Promise  ← needs Asyncify
                         ▼
         onnxsimOrtWebRun (ort_executor.mjs, makeOrtRunner)  (JS)
@@ -42,14 +46,20 @@ Simplify → RunOps → executor._Run(subModel, inputs)      (C++, onnxsim.cpp)
                  onnxruntime-web (wasm/WebGPU EP)
 ```
 
-The C++↔JS contract (see `js_model_executor.cpp` and `ort_executor.mjs`):
+The C++↔JS contract (see `js_model_executor.cpp` and `ort_executor.mjs`) is
+**batched**: all of a fold group's tensors cross in a single concatenated byte
+blob plus one flat metadata array, in both directions, so the number of embind
+round trips is O(1) rather than O(tensors × fields):
 
-- **Input** `{ name, dataType, dims: number[], data: Uint8Array }` per feed,
-  where `dataType` is the ONNX `TensorProto.DataType` enum value and `data` is
-  raw little-endian element bytes.
-- **Output** is a map `{ [name]: { dataType, dims, data } }`. `JsModelExecutor`
-  reads it back in `graph().output()` order, because `RunOps` names the returned
-  tensors positionally in that order.
+- **Input**: `onnxsimOrtWebRun(modelBytes, inputsData, inputsMeta)`, where
+  `inputsData` is every feed's raw little-endian bytes concatenated and
+  `inputsMeta` is a `Float64Array` of `[dtype, ndim, dims...]` per feed
+  (`dtype` = ONNX `TensorProto.DataType`).
+- **Output**: `{ data: Uint8Array, meta: Float64Array }` in the same layout.
+- Tensors are **positional** — no names cross. Input i binds to
+  `session.inputNames[i]`; outputs are emitted in `session.outputNames` order.
+  Both equal the sub-model's graph input/output order, which is how the built-in
+  executor maps feeds and how `RunOps` names returned tensors.
 
 Supported dtypes match `CppModelExecutor`: FLOAT, DOUBLE, INT64, UINT64, INT32,
 UINT8, INT8, UINT16, INT16, BOOL.
@@ -58,15 +68,16 @@ UINT8, INT8, UINT16, INT16, BOOL.
 
 The Python trampoline is straightforward because `onnxruntime`'s `run()` is
 synchronous. `onnxruntime-web` is asynchronous (`await create`, `await run`),
-but `ModelExecutor::_Run` is a synchronous call deep inside `Simplify`. The
+but `ModelExecutor::Run` is a synchronous call deep inside `Simplify`. The
 bridge is **Asyncify** (`-sASYNCIFY`): `emscripten::val::await()` unwinds the
-wasm stack at the `_Run` call, lets the JS Promise settle, then rewinds. A
+wasm stack at the `Run` call, lets the JS Promise settle, then rewinds. A
 consequence is that the exported `onnxsimplify_export` becomes async (returns a
 Promise); `worker.js` awaits it when `onnxsim_needs_ort_web()` is true.
 
 Because the wasm heap can move/grow while suspended (`ALLOW_MEMORY_GROWTH=1`),
-`_Run` copies the model bytes and every input into JS-owned `Uint8Array`s
-*before* the await, so nothing points into the wasm heap across the suspend.
+`Run` copies the model bytes and the batched input blob + metadata into JS-owned
+buffers *before* the await, so nothing points into the wasm heap across the
+suspend.
 
 ## Building
 

--- a/onnxsim/capi/onnxsim_c_api.cpp
+++ b/onnxsim/capi/onnxsim_c_api.cpp
@@ -125,8 +125,58 @@ class CApiGraphRewriter : public GraphRewriter {
   void* user_data_;
 };
 
+// Adapts the C OnnxsimExecuteFn callback to the C++ ModelExecutor interface,
+// exchanging tensors as DLPack DLManagedTensor with no TensorProto round trip.
+// Mirrors CApiGraphRewriter: a (fn, free_fn, user_data) triple. The whole C API
+// requires the built-in ORT (see the #error at the top), but this adapter needs
+// no ORT itself -- it just marshals to the host callback.
+class CApiModelExecutor : public ModelExecutor {
+ public:
+  CApiModelExecutor(OnnxsimExecuteFn fn, OnnxsimExecuteFreeFn free_fn,
+                    void* user_data)
+      : fn_(fn), free_fn_(free_fn), user_data_(user_data) {}
+
+  std::vector<DLManagedTensorPtr> Run(
+      const onnx::ModelProto& model,
+      const std::vector<const DLManagedTensor*>& inputs) const override {
+    const std::string model_str = model.SerializeAsString();
+    DLManagedTensor** out_outputs = nullptr;
+    size_t num_outputs = 0;
+    const int rc =
+        fn_(user_data_, model_str.data(), model_str.size(), inputs.data(),
+            inputs.size(), &out_outputs, &num_outputs);
+    if (rc != 0) {
+      throw std::runtime_error(
+          "the custom constant-folding executor callback failed (returned " +
+          std::to_string(rc) + ")");
+    }
+    if (num_outputs != 0 && out_outputs == nullptr) {
+      throw std::runtime_error(
+          "the custom executor reported outputs but returned a NULL array");
+    }
+    // Adopt each returned tensor into an owning handle first (so the DLPack
+    // deleters run even if a later step throws), then let the host release the
+    // array container.
+    std::vector<DLManagedTensorPtr> outputs;
+    outputs.reserve(num_outputs);
+    for (size_t i = 0; i < num_outputs; ++i) {
+      outputs.emplace_back(out_outputs[i]);
+    }
+    if (free_fn_ != nullptr) {
+      free_fn_(user_data_, out_outputs, num_outputs);
+    }
+    return outputs;
+  }
+
+ private:
+  OnnxsimExecuteFn fn_;
+  OnnxsimExecuteFreeFn free_fn_;
+  void* user_data_;
+};
+
 // Shared body of onnxsim_simplify / onnxsim_simplify_with_rules: parse the
-// model, simplify it (optionally with `rewriter`), and hand back a freshly
+// model, simplify it (optionally with `rewriter`, and through `executor` when
+// non-NULL -- otherwise the built-in ORT executor), and hand back a freshly
 // malloc'd buffer of serialized bytes. All out-parameters follow the C API
 // contract documented in the header.
 OnnxsimStatus SimplifyToBuffer(const void* model_data, size_t model_size,
@@ -136,7 +186,8 @@ OnnxsimStatus SimplifyToBuffer(const void* model_data, size_t model_size,
                                int constant_folding, int shape_inference,
                                size_t tensor_size_threshold,
                                int target_opset_version,
-                               const GraphRewriter* rewriter, void** out_data,
+                               const GraphRewriter* rewriter,
+                               const ModelExecutor* executor, void** out_data,
                                size_t* out_size, char** out_error) {
   if (out_data != nullptr) {
     *out_data = nullptr;
@@ -161,7 +212,7 @@ OnnxsimStatus SimplifyToBuffer(const void* model_data, size_t model_size,
       return ONNXSIM_ERROR;
     }
     onnx::ModelProto result = Simplify(
-        *GetBuiltinModelExecutor(), model,
+        executor != nullptr ? *executor : *GetBuiltinModelExecutor(), model,
         BuildSkipOptimizers(skip_optimizers, num_skip_optimizers,
                             skip_optimizers_is_null),
         constant_folding != 0, shape_inference != 0, tensor_size_threshold,
@@ -240,7 +291,33 @@ OnnxsimStatus onnxsim_simplify(
                           constant_folding, shape_inference,
                           tensor_size_threshold, target_opset_version,
                           rewriter.has_value() ? &rewriter.value() : nullptr,
-                          out_data, out_size, out_error);
+                          /*executor=*/nullptr, out_data, out_size, out_error);
+}
+
+OnnxsimStatus onnxsim_simplify_with_executor(
+    const void* model_data, size_t model_size,
+    const char* const* skip_optimizers, size_t num_skip_optimizers,
+    int skip_optimizers_is_null, int constant_folding, int shape_inference,
+    size_t tensor_size_threshold, int target_opset_version,
+    OnnxsimRewriteFn rewrite_fn, OnnxsimRewriteFreeFn rewrite_free_fn,
+    void* rewrite_user_data, OnnxsimExecuteFn execute_fn,
+    OnnxsimExecuteFreeFn execute_free_fn, void* execute_user_data,
+    void** out_data, size_t* out_size, char** out_error) {
+  std::optional<CApiGraphRewriter> rewriter;
+  if (rewrite_fn != nullptr) {
+    rewriter.emplace(rewrite_fn, rewrite_free_fn, rewrite_user_data);
+  }
+  std::optional<CApiModelExecutor> executor;
+  if (execute_fn != nullptr) {
+    executor.emplace(execute_fn, execute_free_fn, execute_user_data);
+  }
+  return SimplifyToBuffer(
+      model_data, model_size, skip_optimizers, num_skip_optimizers,
+      skip_optimizers_is_null, constant_folding, shape_inference,
+      tensor_size_threshold, target_opset_version,
+      rewriter.has_value() ? &rewriter.value() : nullptr,
+      executor.has_value() ? &executor.value() : nullptr, out_data, out_size,
+      out_error);
 }
 
 OnnxsimStatus onnxsim_simplify_with_rules(
@@ -283,7 +360,8 @@ OnnxsimStatus onnxsim_simplify_with_rules(
                             num_skip_optimizers, skip_optimizers_is_null,
                             constant_folding, shape_inference,
                             tensor_size_threshold, target_opset_version,
-                            rewriter.get(), out_data, out_size, out_error);
+                            rewriter.get(), /*executor=*/nullptr, out_data,
+                            out_size, out_error);
   } catch (const std::exception& e) {
     SetError(out_error, e.what());
     return ONNXSIM_ERROR;

--- a/onnxsim/capi/onnxsim_c_api.cpp
+++ b/onnxsim/capi/onnxsim_c_api.cpp
@@ -179,16 +179,13 @@ class CApiModelExecutor : public ModelExecutor {
 // non-NULL -- otherwise the built-in ORT executor), and hand back a freshly
 // malloc'd buffer of serialized bytes. All out-parameters follow the C API
 // contract documented in the header.
-OnnxsimStatus SimplifyToBuffer(const void* model_data, size_t model_size,
-                               const char* const* skip_optimizers,
-                               size_t num_skip_optimizers,
-                               int skip_optimizers_is_null,
-                               int constant_folding, int shape_inference,
-                               size_t tensor_size_threshold,
-                               int target_opset_version,
-                               const GraphRewriter* rewriter,
-                               const ModelExecutor* executor, void** out_data,
-                               size_t* out_size, char** out_error) {
+OnnxsimStatus SimplifyToBuffer(
+    const void* model_data, size_t model_size,
+    const char* const* skip_optimizers, size_t num_skip_optimizers,
+    int skip_optimizers_is_null, int constant_folding, int shape_inference,
+    size_t tensor_size_threshold, int target_opset_version,
+    const GraphRewriter* rewriter, const ModelExecutor* executor,
+    void** out_data, size_t* out_size, char** out_error) {
   if (out_data != nullptr) {
     *out_data = nullptr;
   }
@@ -311,13 +308,13 @@ OnnxsimStatus onnxsim_simplify_with_executor(
   if (execute_fn != nullptr) {
     executor.emplace(execute_fn, execute_free_fn, execute_user_data);
   }
-  return SimplifyToBuffer(
-      model_data, model_size, skip_optimizers, num_skip_optimizers,
-      skip_optimizers_is_null, constant_folding, shape_inference,
-      tensor_size_threshold, target_opset_version,
-      rewriter.has_value() ? &rewriter.value() : nullptr,
-      executor.has_value() ? &executor.value() : nullptr, out_data, out_size,
-      out_error);
+  return SimplifyToBuffer(model_data, model_size, skip_optimizers,
+                          num_skip_optimizers, skip_optimizers_is_null,
+                          constant_folding, shape_inference,
+                          tensor_size_threshold, target_opset_version,
+                          rewriter.has_value() ? &rewriter.value() : nullptr,
+                          executor.has_value() ? &executor.value() : nullptr,
+                          out_data, out_size, out_error);
 }
 
 OnnxsimStatus onnxsim_simplify_with_rules(
@@ -356,12 +353,11 @@ OnnxsimStatus onnxsim_simplify_with_rules(
         onnxsim::MakeFunctionProtoRewriter(
             BuildRewriteRules(pattern_data, pattern_sizes, replacement_data,
                               replacement_sizes, num_rules));
-    return SimplifyToBuffer(model_data, model_size, skip_optimizers,
-                            num_skip_optimizers, skip_optimizers_is_null,
-                            constant_folding, shape_inference,
-                            tensor_size_threshold, target_opset_version,
-                            rewriter.get(), /*executor=*/nullptr, out_data,
-                            out_size, out_error);
+    return SimplifyToBuffer(
+        model_data, model_size, skip_optimizers, num_skip_optimizers,
+        skip_optimizers_is_null, constant_folding, shape_inference,
+        tensor_size_threshold, target_opset_version, rewriter.get(),
+        /*executor=*/nullptr, out_data, out_size, out_error);
   } catch (const std::exception& e) {
     SetError(out_error, e.what());
     return ONNXSIM_ERROR;

--- a/onnxsim/capi/onnxsim_c_api.h
+++ b/onnxsim/capi/onnxsim_c_api.h
@@ -161,12 +161,13 @@ onnxsim_simplify(const void* model_data, size_t model_size,
 
 /*
  * Same as onnxsim_simplify, but drives constant folding through a host-provided
- * executor callback instead of the built-in ONNX Runtime (see OnnxsimExecuteFn).
- * This is the seam for embedding onnxsim in another ONNX-based stack. Passing a
- * NULL execute_fn falls back to the built-in executor, making this a drop-in
- * superset of onnxsim_simplify. execute_free_fn (may be NULL) releases each
- * output array; execute_user_data is passed through to both callbacks. All
- * other parameters and the out_* contract match onnxsim_simplify.
+ * executor callback instead of the built-in ONNX Runtime (see
+ * OnnxsimExecuteFn). This is the seam for embedding onnxsim in another
+ * ONNX-based stack. Passing a NULL execute_fn falls back to the built-in
+ * executor, making this a drop-in superset of onnxsim_simplify. execute_free_fn
+ * (may be NULL) releases each output array; execute_user_data is passed through
+ * to both callbacks. All other parameters and the out_* contract match
+ * onnxsim_simplify.
  */
 ONNXSIM_C_API OnnxsimStatus onnxsim_simplify_with_executor(
     const void* model_data, size_t model_size,

--- a/onnxsim/capi/onnxsim_c_api.h
+++ b/onnxsim/capi/onnxsim_c_api.h
@@ -12,6 +12,8 @@
 
 #include <stddef.h>
 
+#include "dlpack/dlpack.h"
+
 #if defined(_WIN32)
 #if defined(ONNXSIM_C_API_BUILD)
 #define ONNXSIM_C_API __declspec(dllexport)
@@ -72,6 +74,53 @@ typedef void (*OnnxsimRewriteFreeFn)(void* user_data, void* model_data,
                                      size_t model_size);
 
 /*
+ * Optional custom constant-folding executor callback (the embeddability seam).
+ *
+ * When supplied to onnxsim_simplify_with_executor it REPLACES the built-in
+ * ONNX Runtime constant folder: onnxsim hands each fold group's throwaway
+ * sub-model plus its input tensors to this callback, which evaluates it in the
+ * host's own ONNX runtime and returns the resulting tensors. This lets onnxsim
+ * be embedded in another compiler/runtime stack (a different ORT build, IREE,
+ * TVM, a hardware vendor's runtime) without depending on the vendored ORT, and
+ * without serializing tensors to TensorProto: tensors cross as DLPack
+ * DLManagedTensors (see third_party/dlpack/dlpack.h, docs/dlpack-executor.md).
+ *
+ * Call contract, per fold group:
+ *   - `model_data`/`model_size`: the sub-model as a serialized ONNX ModelProto.
+ *     Its graph.input() are fed positionally by `inputs`; produce one output
+ *     per graph.output(), in that order.
+ *   - `inputs`/`num_inputs`: input tensors, BORROWED for the duration of the
+ *     call. The callback must NOT free them or retain them past return.
+ *   - On success return 0 and set `*out_outputs` to an array of `num` owned
+ *     DLManagedTensor* (set `*out_num_outputs = num`). onnxsim takes ownership
+ *     of each tensor and releases it via that tensor's own DLPack `deleter`; it
+ *     then calls the paired OnnxsimExecuteFreeFn (if any) to release the array
+ *     container itself. All tensors must be CPU (kDLCPU), contiguous, and of a
+ *     dtype onnxsim supports (float16/float/double/bfloat16, 8/16/32/64-bit
+ *     ints, bool).
+ *   - Return non-zero to signal failure; simplification aborts with
+ *     ONNXSIM_ERROR.
+ *
+ * `user_data` is passed through untouched on every call.
+ */
+typedef int (*OnnxsimExecuteFn)(void* user_data, const void* model_data,
+                                size_t model_size,
+                                const DLManagedTensor* const* inputs,
+                                size_t num_inputs,
+                                DLManagedTensor*** out_outputs,
+                                size_t* out_num_outputs);
+
+/*
+ * Releases the output array a OnnxsimExecuteFn returned (the container, not the
+ * tensors -- each DLManagedTensor is released through its own deleter). Called
+ * with the same `user_data` and the exact `outputs`/`num_outputs` the execute
+ * callback produced. May be NULL, in which case onnxsim does not free the array
+ * (e.g. when the callback returns a reused/static buffer).
+ */
+typedef void (*OnnxsimExecuteFreeFn)(void* user_data, DLManagedTensor** outputs,
+                                     size_t num_outputs);
+
+/*
  * Simplify a model given as a serialized ONNX ModelProto.
  *
  * skip_optimizers semantics mirror the C++/Python API:
@@ -109,6 +158,25 @@ onnxsim_simplify(const void* model_data, size_t model_size,
                  int target_opset_version, OnnxsimRewriteFn rewrite_fn,
                  OnnxsimRewriteFreeFn rewrite_free_fn, void* rewrite_user_data,
                  void** out_data, size_t* out_size, char** out_error);
+
+/*
+ * Same as onnxsim_simplify, but drives constant folding through a host-provided
+ * executor callback instead of the built-in ONNX Runtime (see OnnxsimExecuteFn).
+ * This is the seam for embedding onnxsim in another ONNX-based stack. Passing a
+ * NULL execute_fn falls back to the built-in executor, making this a drop-in
+ * superset of onnxsim_simplify. execute_free_fn (may be NULL) releases each
+ * output array; execute_user_data is passed through to both callbacks. All
+ * other parameters and the out_* contract match onnxsim_simplify.
+ */
+ONNXSIM_C_API OnnxsimStatus onnxsim_simplify_with_executor(
+    const void* model_data, size_t model_size,
+    const char* const* skip_optimizers, size_t num_skip_optimizers,
+    int skip_optimizers_is_null, int constant_folding, int shape_inference,
+    size_t tensor_size_threshold, int target_opset_version,
+    OnnxsimRewriteFn rewrite_fn, OnnxsimRewriteFreeFn rewrite_free_fn,
+    void* rewrite_user_data, OnnxsimExecuteFn execute_fn,
+    OnnxsimExecuteFreeFn execute_free_fn, void* execute_user_data,
+    void** out_data, size_t* out_size, char** out_error);
 
 /*
  * Same as onnxsim_simplify, but also applies a set of data-driven rewrite rules

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -17,6 +17,7 @@
 #include <tuple>
 #include <vector>
 
+#include "dlpack_bridge.h"
 #include "function_rewriter.h"
 #include "model_info.h"
 #include "onnx/defs/schema.h"
@@ -214,27 +215,36 @@ void RunPythonNodeInference(onnx::InferenceContext& ctx,
 struct PyModelExecutor : public ModelExecutor {
   using ModelExecutor::ModelExecutor;
 
-  std::vector<onnx::TensorProto> _Run(
+  // Adapts the DLPack executor boundary to the Python protocol, which still
+  // exchanges tensors as serialized TensorProto bytes (the Python side --
+  // onnxruntime's Python API, onnx's reference evaluator -- speaks TensorProto,
+  // not DLPack). So this adapter pays a protobuf round trip that the C++/C-ABI
+  // executors avoid; Python is not the zero-copy target. A future
+  // dlpack-native Python executor could bypass it via __dlpack__.
+  std::vector<DLManagedTensorPtr> Run(
       const onnx::ModelProto& model,
-      const std::vector<onnx::TensorProto>& inputs) const override {
+      const std::vector<const DLManagedTensor*>& inputs) const override {
     std::vector<py::bytes> inputs_bytes;
-    std::transform(inputs.begin(), inputs.end(),
-                   std::back_inserter(inputs_bytes),
-                   [](const onnx::TensorProto& x) {
-                     const std::string str = x.SerializeAsString();
-                     return py::bytes(str.data(), str.size());
-                   });
+    inputs_bytes.reserve(inputs.size());
+    for (const DLManagedTensor* in : inputs) {
+      const std::string str =
+          onnxsim::dlpack::ToTensorProto(in->dl_tensor).SerializeAsString();
+      inputs_bytes.emplace_back(str.data(), str.size());
+    }
     std::string model_str = model.SerializeAsString();
     auto output_bytes =
         _PyRun(py::bytes(model_str.data(), model_str.size()), inputs_bytes);
-    std::vector<onnx::TensorProto> output_tps;
-    std::transform(output_bytes.begin(), output_bytes.end(),
-                   std::back_inserter(output_tps), [](const py::bytes& x) {
-                     onnx::TensorProto tp;
-                     tp.ParseFromString(std::string(x.c_str(), x.size()));
-                     return tp;
-                   });
-    return output_tps;
+    std::vector<DLManagedTensorPtr> outputs;
+    outputs.reserve(output_bytes.size());
+    for (const py::bytes& x : output_bytes) {
+      onnx::TensorProto tp;
+      tp.ParseFromString(std::string(x.c_str(), x.size()));
+      // Owning conversion: the parsed proto is a temporary, so the managed
+      // tensor must keep it alive itself.
+      outputs.emplace_back(
+          onnxsim::dlpack::FromTensorProtoOwning(std::move(tp)));
+    }
+    return outputs;
   }
 
   virtual std::vector<py::bytes> _PyRun(

--- a/onnxsim/dlpack_bridge.h
+++ b/onnxsim/dlpack_bridge.h
@@ -1,0 +1,290 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Bridges between onnxsim's tensor representations and DLPack DLManagedTensor,
+ * used at the ModelExecutor boundary so constant folding can hand tensors to an
+ * executor (and take results back) without serializing them to TensorProto.
+ *
+ * Two layers:
+ *   1. onnx::TensorProto <-> DLManagedTensor (always available). The input
+ *      direction *borrows* the initializer's raw_data (zero copy); the output
+ *      direction writes results back with a single set_raw_data (one memcpy,
+ *      versus the old element-by-element add_*_data loop).
+ *   2. Ort::Value <-> DLManagedTensor (only with the built-in ONNX Runtime).
+ *      The input direction wraps the DLPack buffer as an ORT tensor with the
+ *      borrowing CreateTensor overload (zero copy); the output direction hands
+ *      out ORT's own output buffer by moving the Ort::Value into the managed
+ *      tensor's manager_ctx (zero copy) and freeing it in the deleter.
+ *
+ * DLManagedTensors returned here are always CPU (kDLCPU), contiguous, and
+ * little-endian. Callers own every returned DLManagedTensor* and must release
+ * it exactly once via `self->deleter(self)` (see DLPack's contract).
+ *
+ * See docs/dlpack-executor.md for the boundary design and the separate-heap
+ * analysis that applies to a JS/onnxruntime-web executor.
+ */
+#ifndef ONNXSIM_DLPACK_BRIDGE_H_
+#define ONNXSIM_DLPACK_BRIDGE_H_
+
+#include <onnx/onnx_pb.h>
+
+#include <bit>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "dlpack/dlpack.h"
+#include "dlpack_dtype.h"
+
+#ifndef NO_BUILTIN_ORT
+#ifdef ONNXSIM_ORT_FLAT_HEADERS
+#include "onnxruntime_cxx_api.h"
+#else
+#include "onnxruntime/core/session/onnxruntime_cxx_api.h"
+#endif
+#endif
+
+namespace onnxsim {
+namespace dlpack {
+
+// Number of elements described by a DLPack shape.
+inline int64_t NumElements(const int64_t* shape, int32_t ndim) {
+  int64_t n = 1;
+  for (int32_t i = 0; i < ndim; ++i) n *= shape[i];
+  return n;
+}
+
+// True when `t` is laid out row-major contiguous (or has no strides, which
+// DLPack defines as contiguous). onnxsim only exchanges contiguous tensors.
+inline bool IsContiguous(const DLTensor& t) {
+  if (t.strides == nullptr) return true;
+  int64_t expected = 1;
+  for (int32_t i = t.ndim - 1; i >= 0; --i) {
+    if (t.shape[i] == 1) continue;  // stride is irrelevant for unit dims
+    if (t.strides[i] != expected) return false;
+    expected *= t.shape[i];
+  }
+  return true;
+}
+
+// Backing store for a DLManagedTensor built from an onnx::TensorProto.
+//   * `shape` outlives the DLTensor (whose shape pointer aliases it).
+//   * `owned_proto` is populated only for the *owning* conversion, where the
+//     managed tensor must keep the source proto alive itself (its raw_data is
+//     what the DLTensor points at).
+//   * `owned_bytes` holds materialized bytes when the source proto stored its
+//     data in a typed repeated field rather than raw_data.
+struct TensorProtoManagerCtx {
+  onnx::TensorProto owned_proto;
+  std::vector<int64_t> shape;
+  std::vector<uint8_t> owned_bytes;
+};
+
+// Pack an onnx::TensorProto that keeps its data in a typed repeated field (no
+// raw_data) into little-endian bytes. Mirrors the dtype set the previous
+// TensorProto->ORT converter handled; FLOAT16/BFLOAT16 without raw_data are
+// rejected (they were unsupported before too and essentially never occur --
+// half-precision initializers are always raw_data).
+inline std::vector<uint8_t> PackTypedFields(const onnx::TensorProto& tp) {
+  std::vector<uint8_t> out;
+  auto blit = [&out](const void* src, size_t n) {
+    const auto* p = static_cast<const uint8_t*>(src);
+    out.insert(out.end(), p, p + n);
+  };
+  switch (tp.data_type()) {
+#define ONNXSIM_PACK(onnx_dtype, storage, cpp_type)             \
+  case onnx::TensorProto::onnx_dtype: {                         \
+    std::vector<cpp_type> vec;                                  \
+    vec.reserve(tp.storage##_data_size());                      \
+    for (const auto& x : tp.storage##_data()) vec.push_back(x); \
+    blit(vec.data(), vec.size() * sizeof(cpp_type));            \
+    break;                                                      \
+  }
+    ONNXSIM_PACK(FLOAT, float, float)
+    ONNXSIM_PACK(DOUBLE, double, double)
+    ONNXSIM_PACK(INT64, int64, int64_t)
+    ONNXSIM_PACK(UINT64, uint64, uint64_t)
+    ONNXSIM_PACK(INT32, int32, int32_t)
+    ONNXSIM_PACK(UINT8, int32, uint8_t)
+    ONNXSIM_PACK(INT8, int32, int8_t)
+    ONNXSIM_PACK(UINT16, int32, uint16_t)
+    ONNXSIM_PACK(INT16, int32, int16_t)
+    ONNXSIM_PACK(BOOL, int32, int8_t)
+#undef ONNXSIM_PACK
+    default:
+      throw std::invalid_argument(
+          "dlpack bridge: TensorProto with dtype " +
+          std::to_string(tp.data_type()) +
+          " has no raw_data and cannot be materialized");
+  }
+  return out;
+}
+
+// Fill a DLManagedTensor from `src`, using `ctx` (already allocated, possibly
+// already owning a moved-in proto) as backing store. `src` must reference a
+// buffer that stays valid for the managed tensor's lifetime -- either an
+// external proto (borrowing) or ctx->owned_proto (owning).
+inline DLManagedTensor* BuildFromProto(const onnx::TensorProto& src,
+                                       TensorProtoManagerCtx* ctx) {
+  if constexpr (std::endian::native != std::endian::little) {
+    delete ctx;
+    throw std::invalid_argument("dlpack bridge: only little endian is supported");
+  }
+  if (src.data_location() == onnx::TensorProto::EXTERNAL) {
+    delete ctx;
+    throw std::invalid_argument(
+        "dlpack bridge: external-data TensorProto is not supported");
+  }
+  DLDataType dt;
+  if (!TryOnnxToDL(src.data_type(), &dt)) {
+    delete ctx;
+    throw std::invalid_argument("dlpack bridge: unsupported dtype " +
+                                std::to_string(src.data_type()));
+  }
+
+  ctx->shape.assign(src.dims().begin(), src.dims().end());
+  const void* data_ptr;
+  if (src.has_raw_data()) {
+    data_ptr = src.raw_data().data();  // borrow src's buffer
+  } else {
+    ctx->owned_bytes = PackTypedFields(src);
+    data_ptr = ctx->owned_bytes.data();
+  }
+
+  auto* managed = new DLManagedTensor;
+  managed->dl_tensor.data = const_cast<void*>(data_ptr);
+  managed->dl_tensor.device = DLDevice{kDLCPU, 0};
+  managed->dl_tensor.ndim = static_cast<int32_t>(ctx->shape.size());
+  managed->dl_tensor.dtype = dt;
+  managed->dl_tensor.shape = ctx->shape.data();
+  managed->dl_tensor.strides = nullptr;
+  managed->dl_tensor.byte_offset = 0;
+  managed->manager_ctx = ctx;
+  managed->deleter = [](DLManagedTensor* self) {
+    delete static_cast<TensorProtoManagerCtx*>(self->manager_ctx);
+    delete self;
+  };
+  return managed;
+}
+
+// Build a DLManagedTensor that BORROWS `tp`'s buffer with no copy (when `tp`
+// stores raw_data; typed fields are materialized once). `tp` must outlive the
+// returned tensor. Use for feeds whose TensorProto the caller keeps alive
+// (e.g. initializer tensors held by RunOps). Caller frees via deleter.
+inline DLManagedTensor* FromTensorProtoBorrowing(const onnx::TensorProto& tp) {
+  return BuildFromProto(tp, new TensorProtoManagerCtx);
+}
+
+// Build a DLManagedTensor that OWNS its source proto (moved into the managed
+// tensor), so it is safe standalone. Use when the source proto is a temporary
+// (e.g. a TensorProto just parsed from bytes in the Python trampoline).
+inline DLManagedTensor* FromTensorProtoOwning(onnx::TensorProto tp) {
+  auto* ctx = new TensorProtoManagerCtx;
+  ctx->owned_proto = std::move(tp);
+  return BuildFromProto(ctx->owned_proto, ctx);
+}
+
+// Copy a DLPack tensor into a fresh onnx::TensorProto, writing the payload as
+// raw_data in a single memcpy. The tensor must be CPU, contiguous, and of a
+// supported dtype. `name` is optional (RunOps sets output names afterwards).
+inline onnx::TensorProto ToTensorProto(const DLTensor& t,
+                                       const std::string& name = "") {
+  if (t.device.device_type != kDLCPU) {
+    throw std::invalid_argument(
+        "dlpack bridge: only kDLCPU tensors can be converted to TensorProto");
+  }
+  if (!IsContiguous(t)) {
+    throw std::invalid_argument(
+        "dlpack bridge: non-contiguous DLTensor cannot be converted");
+  }
+  int32_t onnx_dtype;
+  if (!TryDLToOnnx(t.dtype, &onnx_dtype)) {
+    throw std::invalid_argument(
+        "dlpack bridge: unsupported DLDataType code=" +
+        std::to_string(t.dtype.code) + " bits=" + std::to_string(t.dtype.bits));
+  }
+  onnx::TensorProto tp;
+  if (!name.empty()) tp.set_name(name);
+  tp.set_data_type(onnx_dtype);
+  for (int32_t i = 0; i < t.ndim; ++i) tp.add_dims(t.shape[i]);
+
+  const size_t nbytes = NumElements(t.shape, t.ndim) * SizeOf(t.dtype);
+  const auto* base =
+      static_cast<const uint8_t*>(t.data) + t.byte_offset;
+  tp.set_raw_data(base, nbytes);  // single copy into the persisted model
+  return tp;
+}
+
+#ifndef NO_BUILTIN_ORT
+// A process-wide CPU OrtMemoryInfo for wrapping/borrowing host buffers.
+inline Ort::MemoryInfo& CpuMemoryInfo() {
+  static Ort::MemoryInfo info =
+      Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeDefault);
+  return info;
+}
+
+// Wrap a DLPack tensor as an Ort::Value that BORROWS its buffer -- no copy. The
+// DLManagedTensor's storage must outlive the returned Ort::Value. Used to feed
+// initializer tensors into a constant-folding session.
+inline Ort::Value BorrowAsOrtValue(const DLTensor& t) {
+  if (t.device.device_type != kDLCPU) {
+    throw std::invalid_argument("dlpack bridge: ORT input must be kDLCPU");
+  }
+  if (!IsContiguous(t)) {
+    throw std::invalid_argument("dlpack bridge: ORT input must be contiguous");
+  }
+  int32_t onnx_dtype;
+  if (!TryDLToOnnx(t.dtype, &onnx_dtype)) {
+    throw std::invalid_argument("dlpack bridge: unsupported DLDataType for ORT");
+  }
+  const size_t nbytes = NumElements(t.shape, t.ndim) * SizeOf(t.dtype);
+  auto* base = static_cast<uint8_t*>(t.data) + t.byte_offset;
+  return Ort::Value::CreateTensor(
+      CpuMemoryInfo(), base, nbytes, t.shape, static_cast<size_t>(t.ndim),
+      static_cast<ONNXTensorElementDataType>(onnx_dtype));
+}
+
+// Manager context that keeps an Ort::Value (and thus its output buffer) alive
+// for as long as the DLManagedTensor that hands the buffer out.
+struct OrtValueManagerCtx {
+  Ort::Value value{nullptr};
+  std::vector<int64_t> shape;
+};
+
+// Hand out an ORT output tensor as a DLManagedTensor without copying: ownership
+// of the Ort::Value moves into the managed tensor, whose deleter releases it.
+// Throws for non-tensor or unsupported-dtype outputs.
+inline DLManagedTensor* FromOrtValue(Ort::Value&& value) {
+  auto info = value.GetTensorTypeAndShapeInfo();
+  DLDataType dt;
+  if (!TryOnnxToDL(static_cast<int32_t>(info.GetElementType()), &dt)) {
+    throw std::invalid_argument(
+        "dlpack bridge: unsupported ORT output element type");
+  }
+  auto* ctx = new OrtValueManagerCtx;
+  ctx->shape = info.GetShape();
+  ctx->value = std::move(value);
+
+  auto* managed = new DLManagedTensor;
+  managed->dl_tensor.data = ctx->value.GetTensorMutableData<void>();
+  managed->dl_tensor.device = DLDevice{kDLCPU, 0};
+  managed->dl_tensor.ndim = static_cast<int32_t>(ctx->shape.size());
+  managed->dl_tensor.dtype = dt;
+  managed->dl_tensor.shape = ctx->shape.data();
+  managed->dl_tensor.strides = nullptr;
+  managed->dl_tensor.byte_offset = 0;
+  managed->manager_ctx = ctx;
+  managed->deleter = [](DLManagedTensor* self) {
+    delete static_cast<OrtValueManagerCtx*>(self->manager_ctx);
+    delete self;
+  };
+  return managed;
+}
+#endif  // NO_BUILTIN_ORT
+
+}  // namespace dlpack
+}  // namespace onnxsim
+
+#endif  // ONNXSIM_DLPACK_BRIDGE_H_

--- a/onnxsim/dlpack_bridge.h
+++ b/onnxsim/dlpack_bridge.h
@@ -130,7 +130,8 @@ inline DLManagedTensor* BuildFromProto(const onnx::TensorProto& src,
                                        TensorProtoManagerCtx* ctx) {
   if constexpr (std::endian::native != std::endian::little) {
     delete ctx;
-    throw std::invalid_argument("dlpack bridge: only little endian is supported");
+    throw std::invalid_argument(
+        "dlpack bridge: only little endian is supported");
   }
   if (src.data_location() == onnx::TensorProto::EXTERNAL) {
     delete ctx;
@@ -201,9 +202,9 @@ inline onnx::TensorProto ToTensorProto(const DLTensor& t,
   }
   int32_t onnx_dtype;
   if (!TryDLToOnnx(t.dtype, &onnx_dtype)) {
-    throw std::invalid_argument(
-        "dlpack bridge: unsupported DLDataType code=" +
-        std::to_string(t.dtype.code) + " bits=" + std::to_string(t.dtype.bits));
+    throw std::invalid_argument("dlpack bridge: unsupported DLDataType code=" +
+                                std::to_string(t.dtype.code) +
+                                " bits=" + std::to_string(t.dtype.bits));
   }
   onnx::TensorProto tp;
   if (!name.empty()) tp.set_name(name);
@@ -211,8 +212,7 @@ inline onnx::TensorProto ToTensorProto(const DLTensor& t,
   for (int32_t i = 0; i < t.ndim; ++i) tp.add_dims(t.shape[i]);
 
   const size_t nbytes = NumElements(t.shape, t.ndim) * SizeOf(t.dtype);
-  const auto* base =
-      static_cast<const uint8_t*>(t.data) + t.byte_offset;
+  const auto* base = static_cast<const uint8_t*>(t.data) + t.byte_offset;
   tp.set_raw_data(base, nbytes);  // single copy into the persisted model
   return tp;
 }
@@ -237,7 +237,8 @@ inline Ort::Value BorrowAsOrtValue(const DLTensor& t) {
   }
   int32_t onnx_dtype;
   if (!TryDLToOnnx(t.dtype, &onnx_dtype)) {
-    throw std::invalid_argument("dlpack bridge: unsupported DLDataType for ORT");
+    throw std::invalid_argument(
+        "dlpack bridge: unsupported DLDataType for ORT");
   }
   const size_t nbytes = NumElements(t.shape, t.ndim) * SizeOf(t.dtype);
   auto* base = static_cast<uint8_t*>(t.data) + t.byte_offset;

--- a/onnxsim/dlpack_dtype.h
+++ b/onnxsim/dlpack_dtype.h
@@ -69,20 +69,47 @@ inline bool TryOnnxToDL(int32_t onnx_dtype, DLDataType* out) {
     out->lanes = 1;
   };
   switch (onnx_dtype) {
-    case ONNX_FLOAT: set(kDLFloat, 32); return true;
-    case ONNX_DOUBLE: set(kDLFloat, 64); return true;
-    case ONNX_FLOAT16: set(kDLFloat, 16); return true;
-    case ONNX_BFLOAT16: set(kDLBfloat, 16); return true;
-    case ONNX_INT8: set(kDLInt, 8); return true;
-    case ONNX_INT16: set(kDLInt, 16); return true;
-    case ONNX_INT32: set(kDLInt, 32); return true;
-    case ONNX_INT64: set(kDLInt, 64); return true;
-    case ONNX_UINT8: set(kDLUInt, 8); return true;
-    case ONNX_UINT16: set(kDLUInt, 16); return true;
-    case ONNX_UINT32: set(kDLUInt, 32); return true;
-    case ONNX_UINT64: set(kDLUInt, 64); return true;
-    case ONNX_BOOL: set(kDLBool, 8); return true;
-    default: return false;
+    case ONNX_FLOAT:
+      set(kDLFloat, 32);
+      return true;
+    case ONNX_DOUBLE:
+      set(kDLFloat, 64);
+      return true;
+    case ONNX_FLOAT16:
+      set(kDLFloat, 16);
+      return true;
+    case ONNX_BFLOAT16:
+      set(kDLBfloat, 16);
+      return true;
+    case ONNX_INT8:
+      set(kDLInt, 8);
+      return true;
+    case ONNX_INT16:
+      set(kDLInt, 16);
+      return true;
+    case ONNX_INT32:
+      set(kDLInt, 32);
+      return true;
+    case ONNX_INT64:
+      set(kDLInt, 64);
+      return true;
+    case ONNX_UINT8:
+      set(kDLUInt, 8);
+      return true;
+    case ONNX_UINT16:
+      set(kDLUInt, 16);
+      return true;
+    case ONNX_UINT32:
+      set(kDLUInt, 32);
+      return true;
+    case ONNX_UINT64:
+      set(kDLUInt, 64);
+      return true;
+    case ONNX_BOOL:
+      set(kDLBool, 8);
+      return true;
+    default:
+      return false;
   }
 }
 

--- a/onnxsim/dlpack_dtype.h
+++ b/onnxsim/dlpack_dtype.h
@@ -1,0 +1,129 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Pure, dependency-free mapping between ONNX tensor element types and DLPack
+ * DLDataType. This header intentionally depends on nothing but dlpack.h: it
+ * operates on the *integer* ONNX dtype codes (the stable wire numbers of
+ * onnx::TensorProto::DataType) rather than on the onnx headers, so it compiles
+ * and is unit-tested on its own -- including under Emscripten and in the wheel
+ * build -- without configuring ONNX or ONNX Runtime.
+ *
+ * The onnx::TensorProto glue that actually reads/writes tensor buffers lives in
+ * dlpack_bridge.h and calls into these functions with `tp.data_type()`.
+ *
+ * Supported set (bijective ONNX code <-> DLDataType, lanes == 1):
+ *   FLOAT16/FLOAT/DOUBLE/BFLOAT16, all signed/unsigned 8/16/32/64 ints, BOOL.
+ * Everything else (STRING, COMPLEX*, FLOAT8*, INT4/UINT4/FLOAT4, UNDEFINED) is
+ * rejected here -- these have no raw contiguous little-endian layout onnxsim's
+ * constant folder exchanges, mirroring the dtype set the old TensorProto<->ORT
+ * converters handled.
+ */
+#ifndef ONNXSIM_DLPACK_DTYPE_H_
+#define ONNXSIM_DLPACK_DTYPE_H_
+
+#include <cstdint>
+
+#include "dlpack/dlpack.h"
+
+namespace onnxsim {
+namespace dlpack {
+
+// Stable ONNX TensorProto::DataType wire numbers, mirrored so this header does
+// not need the onnx protobuf headers. Kept in sync with onnx/onnx.proto3.
+enum OnnxDtype : int32_t {
+  ONNX_UNDEFINED = 0,
+  ONNX_FLOAT = 1,
+  ONNX_UINT8 = 2,
+  ONNX_INT8 = 3,
+  ONNX_UINT16 = 4,
+  ONNX_INT16 = 5,
+  ONNX_INT32 = 6,
+  ONNX_INT64 = 7,
+  ONNX_STRING = 8,
+  ONNX_BOOL = 9,
+  ONNX_FLOAT16 = 10,
+  ONNX_DOUBLE = 11,
+  ONNX_UINT32 = 12,
+  ONNX_UINT64 = 13,
+  ONNX_COMPLEX64 = 14,
+  ONNX_COMPLEX128 = 15,
+  ONNX_BFLOAT16 = 16,
+};
+
+// Number of bytes one element of `dt` occupies. Uses the common array-library
+// convention that storage size is ceil(bits*lanes / 8) (so bool -> 1 byte).
+inline size_t SizeOf(DLDataType dt) {
+  return (static_cast<size_t>(dt.bits) * dt.lanes + 7) / 8;
+}
+
+inline bool operator==(DLDataType a, DLDataType b) {
+  return a.code == b.code && a.bits == b.bits && a.lanes == b.lanes;
+}
+
+// Map an ONNX dtype code to a DLDataType. Returns true and fills `*out` for a
+// supported type; returns false (leaving `*out` untouched) otherwise.
+inline bool TryOnnxToDL(int32_t onnx_dtype, DLDataType* out) {
+  auto set = [out](uint8_t code, uint8_t bits) {
+    out->code = code;
+    out->bits = bits;
+    out->lanes = 1;
+  };
+  switch (onnx_dtype) {
+    case ONNX_FLOAT: set(kDLFloat, 32); return true;
+    case ONNX_DOUBLE: set(kDLFloat, 64); return true;
+    case ONNX_FLOAT16: set(kDLFloat, 16); return true;
+    case ONNX_BFLOAT16: set(kDLBfloat, 16); return true;
+    case ONNX_INT8: set(kDLInt, 8); return true;
+    case ONNX_INT16: set(kDLInt, 16); return true;
+    case ONNX_INT32: set(kDLInt, 32); return true;
+    case ONNX_INT64: set(kDLInt, 64); return true;
+    case ONNX_UINT8: set(kDLUInt, 8); return true;
+    case ONNX_UINT16: set(kDLUInt, 16); return true;
+    case ONNX_UINT32: set(kDLUInt, 32); return true;
+    case ONNX_UINT64: set(kDLUInt, 64); return true;
+    case ONNX_BOOL: set(kDLBool, 8); return true;
+    default: return false;
+  }
+}
+
+// Inverse of TryOnnxToDL. Returns true and fills `*out` with the ONNX dtype
+// code for a supported DLDataType (lanes must be 1); false otherwise.
+inline bool TryDLToOnnx(DLDataType dt, int32_t* out) {
+  if (dt.lanes != 1) return false;
+  auto ok = [out](int32_t v) {
+    *out = v;
+    return true;
+  };
+  switch (dt.code) {
+    case kDLFloat:
+      if (dt.bits == 16) return ok(ONNX_FLOAT16);
+      if (dt.bits == 32) return ok(ONNX_FLOAT);
+      if (dt.bits == 64) return ok(ONNX_DOUBLE);
+      return false;
+    case kDLBfloat:
+      if (dt.bits == 16) return ok(ONNX_BFLOAT16);
+      return false;
+    case kDLInt:
+      if (dt.bits == 8) return ok(ONNX_INT8);
+      if (dt.bits == 16) return ok(ONNX_INT16);
+      if (dt.bits == 32) return ok(ONNX_INT32);
+      if (dt.bits == 64) return ok(ONNX_INT64);
+      return false;
+    case kDLUInt:
+      if (dt.bits == 8) return ok(ONNX_UINT8);
+      if (dt.bits == 16) return ok(ONNX_UINT16);
+      if (dt.bits == 32) return ok(ONNX_UINT32);
+      if (dt.bits == 64) return ok(ONNX_UINT64);
+      return false;
+    case kDLBool:
+      if (dt.bits == 8) return ok(ONNX_BOOL);
+      return false;
+    default:
+      return false;
+  }
+}
+
+}  // namespace dlpack
+}  // namespace onnxsim
+
+#endif  // ONNXSIM_DLPACK_DTYPE_H_

--- a/onnxsim/dlpack_dtype_test.cpp
+++ b/onnxsim/dlpack_dtype_test.cpp
@@ -70,13 +70,12 @@ int main() {
 
   // Unsupported ONNX dtypes must be rejected, not silently mismapped.
   const std::vector<int32_t> unsupported = {
-      ONNX_UNDEFINED, ONNX_STRING, ONNX_COMPLEX64, ONNX_COMPLEX128,
-      17 /*FLOAT8E4M3FN*/, 21 /*UINT4*/, 22 /*INT4*/, 999 /*garbage*/,
+      ONNX_UNDEFINED,      ONNX_STRING,  ONNX_COMPLEX64, ONNX_COMPLEX128,
+      17 /*FLOAT8E4M3FN*/, 21 /*UINT4*/, 22 /*INT4*/,    999 /*garbage*/,
   };
   for (int32_t code : unsupported) {
     DLDataType dt;
-    Check(!TryOnnxToDL(code, &dt),
-          "reject onnx dtype " + std::to_string(code));
+    Check(!TryOnnxToDL(code, &dt), "reject onnx dtype " + std::to_string(code));
   }
 
   // Vector (lanes != 1) and unknown DLDataTypes must be rejected by the

--- a/onnxsim/dlpack_dtype_test.cpp
+++ b/onnxsim/dlpack_dtype_test.cpp
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Dependency-free unit test for the ONNX<->DLPack dtype mapping. Like
+ * sym_expr_test, it builds and runs standalone (no ONNX / ONNX Runtime), so it
+ * is wired into the ONNXSIM_TESTS target and runnable under Emscripten.
+ */
+#include "dlpack_dtype.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace onnxsim::dlpack;
+
+namespace {
+
+int g_failures = 0;
+
+void Check(bool cond, const std::string& what) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL: %s\n", what.c_str());
+    ++g_failures;
+  }
+}
+
+struct Row {
+  int32_t onnx;
+  uint8_t code;
+  uint8_t bits;
+  size_t bytes;
+  const char* name;
+};
+
+}  // namespace
+
+int main() {
+  // Every supported ONNX dtype: forward map produces the expected DLDataType,
+  // the element size is right, and the inverse map round-trips back to the same
+  // ONNX code.
+  const std::vector<Row> supported = {
+      {ONNX_FLOAT, kDLFloat, 32, 4, "float32"},
+      {ONNX_DOUBLE, kDLFloat, 64, 8, "float64"},
+      {ONNX_FLOAT16, kDLFloat, 16, 2, "float16"},
+      {ONNX_BFLOAT16, kDLBfloat, 16, 2, "bfloat16"},
+      {ONNX_INT8, kDLInt, 8, 1, "int8"},
+      {ONNX_INT16, kDLInt, 16, 2, "int16"},
+      {ONNX_INT32, kDLInt, 32, 4, "int32"},
+      {ONNX_INT64, kDLInt, 64, 8, "int64"},
+      {ONNX_UINT8, kDLUInt, 8, 1, "uint8"},
+      {ONNX_UINT16, kDLUInt, 16, 2, "uint16"},
+      {ONNX_UINT32, kDLUInt, 32, 4, "uint32"},
+      {ONNX_UINT64, kDLUInt, 64, 8, "uint64"},
+      {ONNX_BOOL, kDLBool, 8, 1, "bool"},
+  };
+
+  for (const auto& r : supported) {
+    DLDataType dt;
+    Check(TryOnnxToDL(r.onnx, &dt), std::string("forward ") + r.name);
+    Check(dt.code == r.code, std::string("code ") + r.name);
+    Check(dt.bits == r.bits, std::string("bits ") + r.name);
+    Check(dt.lanes == 1, std::string("lanes ") + r.name);
+    Check(SizeOf(dt) == r.bytes, std::string("size ") + r.name);
+
+    int32_t back = ONNX_UNDEFINED;
+    Check(TryDLToOnnx(dt, &back), std::string("inverse ") + r.name);
+    Check(back == r.onnx, std::string("round-trip ") + r.name);
+  }
+
+  // Unsupported ONNX dtypes must be rejected, not silently mismapped.
+  const std::vector<int32_t> unsupported = {
+      ONNX_UNDEFINED, ONNX_STRING, ONNX_COMPLEX64, ONNX_COMPLEX128,
+      17 /*FLOAT8E4M3FN*/, 21 /*UINT4*/, 22 /*INT4*/, 999 /*garbage*/,
+  };
+  for (int32_t code : unsupported) {
+    DLDataType dt;
+    Check(!TryOnnxToDL(code, &dt),
+          "reject onnx dtype " + std::to_string(code));
+  }
+
+  // Vector (lanes != 1) and unknown DLDataTypes must be rejected by the
+  // inverse map.
+  {
+    int32_t out = 0;
+    Check(!TryDLToOnnx(DLDataType{kDLFloat, 32, 4}, &out), "reject lanes=4");
+    Check(!TryDLToOnnx(DLDataType{kDLInt, 4, 1}, &out), "reject int4");
+    Check(!TryDLToOnnx(DLDataType{kDLComplex, 64, 1}, &out), "reject complex");
+    Check(!TryDLToOnnx(DLDataType{kDLOpaqueHandle, 64, 1}, &out),
+          "reject opaque");
+  }
+
+  if (g_failures == 0) {
+    std::printf("dlpack_dtype_test: all checks passed\n");
+    return 0;
+  }
+  std::fprintf(stderr, "dlpack_dtype_test: %d failure(s)\n", g_failures);
+  return 1;
+}

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -30,6 +30,7 @@
 #endif
 #endif
 #include "contrib_schemas.h"
+#include "dlpack_bridge.h"
 #include "onnx/common/file_utils.h"
 #include "onnx/defs/printer.h"
 #include "onnx/defs/schema.h"
@@ -187,86 +188,12 @@ auto FindValueInfoProtoByName(const onnx::ModelProto& model,
 }
 
 #ifndef NO_BUILTIN_ORT
-onnx::TensorProto TensorToTensorProto(const Ort::Value& tensor) {
-  onnx::TensorProto tensor_proto;
-  for (const auto& dim : tensor.GetTensorTypeAndShapeInfo().GetShape()) {
-    tensor_proto.add_dims(dim);
-  }
-  onnx::TensorProto::DataType onnx_dtype =
-      (onnx::TensorProto::DataType)tensor.GetTensorTypeAndShapeInfo()
-          .GetElementType();
-  tensor_proto.set_data_type(onnx_dtype);
-
-  switch (onnx_dtype) {
-#define CASE_DTYPE(onnx_dtype, storage_dtype, cpp_type)                   \
-  case onnx::TensorProto::onnx_dtype: {                                   \
-    const auto* dptr = tensor.GetTensorData<cpp_type>();                  \
-    for (size_t i = 0;                                                    \
-         i < tensor.GetTensorTypeAndShapeInfo().GetElementCount(); i++) { \
-      tensor_proto.add_##storage_dtype##_data(dptr[i]);                   \
-    }                                                                     \
-    break;                                                                \
-  }
-
-    CASE_DTYPE(FLOAT, float, float)
-    CASE_DTYPE(DOUBLE, double, double)
-    CASE_DTYPE(INT64, int64, int64_t)
-    CASE_DTYPE(UINT64, uint64, uint64_t)
-    CASE_DTYPE(INT32, int32, int32_t)
-    CASE_DTYPE(UINT8, int32, uint8_t)
-    CASE_DTYPE(INT8, int32, int8_t)
-    CASE_DTYPE(UINT16, int32, uint16_t)
-    CASE_DTYPE(INT16, int32, int16_t)
-    CASE_DTYPE(BOOL, int32, int8_t)
-#undef CASE_DTYPE
-    default:
-      throw std::invalid_argument("Unknown dtype " +
-                                  std::to_string(tensor_proto.data_type()));
-  }
-  return tensor_proto;
-}
-
-Ort::Value TensorProtoToTensor(const onnx::TensorProto& tensor_proto) {
-  Ort::AllocatorWithDefaultOptions allocator;
-  auto tensor = Ort::Value::CreateTensor(
-      allocator, tensor_proto.dims().data(), tensor_proto.dims_size(),
-      (ONNXTensorElementDataType)tensor_proto.data_type());
-  if (tensor_proto.has_raw_data()) {
-    if constexpr (std::endian::native == std::endian::big) {
-      throw std::invalid_argument("only little endian is supported");
-    }
-    memcpy(tensor.GetTensorMutableData<void>(), tensor_proto.raw_data().data(),
-           tensor_proto.raw_data().size());
-  } else {
-    switch (tensor_proto.data_type()) {
-#define CASE_DTYPE(onnx_dtype, storage_dtype, cpp_type)         \
-  case onnx::TensorProto::onnx_dtype: {                         \
-    std::vector<cpp_type> vec;                                  \
-    for (const auto& x : tensor_proto.storage_dtype##_data()) { \
-      vec.push_back(x);                                         \
-    }                                                           \
-    memcpy(tensor.GetTensorMutableData<void>(), vec.data(),     \
-           vec.size() * sizeof(cpp_type));                      \
-    break;                                                      \
-  }
-      CASE_DTYPE(FLOAT, float, float)
-      CASE_DTYPE(DOUBLE, double, double)
-      CASE_DTYPE(INT64, int64, int64_t)
-      CASE_DTYPE(UINT64, uint64, uint64_t)
-      CASE_DTYPE(INT32, int32, int32_t)
-      CASE_DTYPE(UINT8, int32, uint8_t)
-      CASE_DTYPE(INT8, int32, int8_t)
-      CASE_DTYPE(UINT16, int32, uint16_t)
-      CASE_DTYPE(INT16, int32, int16_t)
-      CASE_DTYPE(BOOL, int32, int8_t)
-#undef CASE_DTYPE
-      default:
-        throw std::invalid_argument("Unknown dtype " +
-                                    std::to_string(tensor_proto.data_type()));
-    }
-  }
-  return tensor;
-}
+// The TensorProto<->Ort::Value converters that used to live here have moved to
+// dlpack_bridge.h and now exchange data through DLManagedTensor:
+//   * inputs: onnxsim::dlpack::BorrowAsOrtValue wraps the feed buffer with the
+//     borrowing CreateTensor overload -- no copy in;
+//   * outputs: onnxsim::dlpack::FromOrtValue moves ORT's own output allocation
+//     into the returned tensor -- no copy out (and no per-element add_*_data).
 
 std::shared_ptr<Ort::Env> GetEnv() {
   static std::shared_ptr<Ort::Env> env = std::make_shared<Ort::Env>();
@@ -309,9 +236,9 @@ bool EnableOrtProfilingFromEnv(Ort::SessionOptions& sess_opts) {
 }
 
 struct CppModelExecutor : public ModelExecutor {
-  std::vector<onnx::TensorProto> _Run(
+  std::vector<DLManagedTensorPtr> Run(
       const onnx::ModelProto& model,
-      const std::vector<onnx::TensorProto>& inputs) const override {
+      const std::vector<const DLManagedTensor*>& inputs) const override {
     // The RunOps call site already profiles each fold group's session run as a
     // single ``OrtSession`` span (see RunOps); for the built-in executor break
     // that down further into ``OrtSessionInit`` (building the session, where
@@ -341,9 +268,14 @@ struct CppModelExecutor : public ModelExecutor {
     }
     Ort::RunOptions run_opts;
     run_opts.SetRunLogSeverityLevel(3);
+    // Borrow each feed's buffer directly into an Ort::Value -- no copy. The
+    // DLManagedTensors are owned by the caller (RunOps) and outlive this call,
+    // so the borrowed pointers stay valid through session.Run.
     std::vector<Ort::Value> input_tensors;
-    std::transform(inputs.begin(), inputs.end(),
-                   std::back_inserter(input_tensors), TensorProtoToTensor);
+    input_tensors.reserve(inputs.size());
+    for (const DLManagedTensor* in : inputs) {
+      input_tensors.push_back(onnxsim::dlpack::BorrowAsOrtValue(in->dl_tensor));
+    }
     std::vector<Ort::Value> output_tensors;
     {
       onnxsim::ProfiledScope run_scope("OrtSessionRun");
@@ -365,10 +297,16 @@ struct CppModelExecutor : public ModelExecutor {
       }
     }
 
-    std::vector<onnx::TensorProto> output_tps;
-    std::transform(output_tensors.begin(), output_tensors.end(),
-                   std::back_inserter(output_tps), TensorToTensorProto);
-    return output_tps;
+    // Hand ORT's own output buffers out as DLManagedTensors: FromOrtValue moves
+    // each Ort::Value into the managed tensor, so nothing is copied here (the
+    // one unavoidable copy happens when RunOps bakes the result into the
+    // model's initializers as raw_data).
+    std::vector<DLManagedTensorPtr> outputs;
+    outputs.reserve(output_tensors.size());
+    for (auto& v : output_tensors) {
+      outputs.emplace_back(onnxsim::dlpack::FromOrtValue(std::move(v)));
+    }
+    return outputs;
   }
 };
 
@@ -522,13 +460,32 @@ std::vector<onnx::TensorProto> RunOps(
   // trampoline that Python's simplify() injects), so the session run is
   // profiled regardless of binding. The ProfiledScope is a no-op unless
   // ONNXSIM_PROFILE is set.
-  std::vector<onnx::TensorProto> output_tps;
+  // Bridge to the DLPack executor boundary. Each feed borrows its initializer's
+  // buffer (no copy); `input_tps` is fully built above and not mutated again, so
+  // the borrowed pointers stay valid. `input_dls` owns the managed tensors and
+  // must outlive the executor call (the executor borrows them). Outputs come
+  // back as DLManagedTensors and are baked into TensorProto raw_data here -- the
+  // single, unavoidable copy, since folded results become model initializers.
+  std::vector<DLManagedTensorPtr> input_dls;
+  input_dls.reserve(input_tps.size());
+  for (const auto& tp : input_tps) {
+    input_dls.emplace_back(onnxsim::dlpack::FromTensorProtoBorrowing(tp));
+  }
+  std::vector<const DLManagedTensor*> input_ptrs;
+  input_ptrs.reserve(input_dls.size());
+  for (const auto& p : input_dls) input_ptrs.push_back(p.get());
+
+  std::vector<DLManagedTensorPtr> output_dls;
   {
     onnxsim::ProfiledScope session_scope("OrtSession");
-    output_tps = executor._Run(op_model, input_tps);
+    output_dls = executor.Run(op_model, input_ptrs);
   }
-  for (size_t i = 0; i < output_names.size() && i < output_tps.size(); i++) {
-    output_tps[i].set_name(output_names[i]);
+  std::vector<onnx::TensorProto> output_tps;
+  output_tps.reserve(output_dls.size());
+  for (size_t i = 0; i < output_dls.size(); i++) {
+    output_tps.push_back(onnxsim::dlpack::ToTensorProto(
+        output_dls[i]->dl_tensor,
+        i < output_names.size() ? output_names[i] : std::string()));
   }
   return output_tps;
 }

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -461,11 +461,12 @@ std::vector<onnx::TensorProto> RunOps(
   // profiled regardless of binding. The ProfiledScope is a no-op unless
   // ONNXSIM_PROFILE is set.
   // Bridge to the DLPack executor boundary. Each feed borrows its initializer's
-  // buffer (no copy); `input_tps` is fully built above and not mutated again, so
-  // the borrowed pointers stay valid. `input_dls` owns the managed tensors and
-  // must outlive the executor call (the executor borrows them). Outputs come
-  // back as DLManagedTensors and are baked into TensorProto raw_data here -- the
-  // single, unavoidable copy, since folded results become model initializers.
+  // buffer (no copy); `input_tps` is fully built above and not mutated again,
+  // so the borrowed pointers stay valid. `input_dls` owns the managed tensors
+  // and must outlive the executor call (the executor borrows them). Outputs
+  // come back as DLManagedTensors and are baked into TensorProto raw_data here
+  // -- the single, unavoidable copy, since folded results become model
+  // initializers.
   std::vector<DLManagedTensorPtr> input_dls;
   input_dls.reserve(input_tps.size());
   for (const auto& tp : input_tps) {

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -6,13 +6,44 @@
 #include <optional>
 #include <vector>
 
+#include "dlpack/dlpack.h"
+
+// RAII owner for a DLManagedTensor: releasing it invokes the tensor's own
+// DLPack deleter exactly once (per the DLPack contract), which frees whatever
+// the producer attached -- a borrowed-buffer no-op, an Ort::Value, a host
+// allocation, etc. Move-only.
+struct DLManagedTensorDeleter {
+  void operator()(DLManagedTensor* t) const {
+    if (t != nullptr && t->deleter != nullptr) {
+      t->deleter(t);
+    }
+  }
+};
+using DLManagedTensorPtr =
+    std::unique_ptr<DLManagedTensor, DLManagedTensorDeleter>;
+
+// The constant-folding executor boundary. onnxsim runs each fold group by
+// building a throwaway sub-model and asking an executor to evaluate it. Tensors
+// cross this boundary as DLPack DLManagedTensors rather than onnx::TensorProto,
+// so an executor can borrow onnxsim's buffers (and hand its results back)
+// without a protobuf serialize/parse round trip. This is also the seam an
+// embedder implements to plug in its own ONNX runtime (see the C ABI executor
+// callback in capi/onnxsim_c_api.h, and docs/dlpack-executor.md).
 struct ModelExecutor {
   virtual ~ModelExecutor() = default;
 
-  // public it for pybind11
-  virtual std::vector<onnx::TensorProto> _Run(
+  // Evaluate `model`, whose graph inputs are fed by `inputs` (positional, i.e.
+  // inputs[i] feeds model.graph().input(i)), and return one tensor per graph
+  // output (positional, matching model.graph().output()).
+  //
+  // Ownership: `inputs` are BORROWED for the duration of the call -- the
+  // executor must not retain them past return. Each returned DLManagedTensorPtr
+  // is freshly owned by the caller. Tensors are CPU, contiguous, little-endian.
+  //
+  // public for pybind11 / nanobind trampolines
+  virtual std::vector<DLManagedTensorPtr> Run(
       const onnx::ModelProto& model,
-      const std::vector<onnx::TensorProto>& inputs) const = 0;
+      const std::vector<const DLManagedTensor*>& inputs) const = 0;
 };
 
 // A user-supplied whole-graph rewriter. When one is passed to ``Simplify`` it

--- a/rust/onnxsim-sys/src/lib.rs
+++ b/rust/onnxsim-sys/src/lib.rs
@@ -38,6 +38,162 @@ pub type OnnxsimRewriteFn = unsafe extern "C" fn(
 pub type OnnxsimRewriteFreeFn =
     unsafe extern "C" fn(user_data: *mut c_void, model_data: *mut c_void, model_size: usize);
 
+// --- DLPack ABI ------------------------------------------------------------
+//
+// These structs mirror `third_party/dlpack/dlpack.h` and are the tensor
+// exchange type at the constant-folding executor boundary (see
+// `onnxsim_simplify_with_executor`). Only the plain (unversioned)
+// `DLManagedTensor` is used across the C API. Layout must match the C header
+// exactly; the `#[repr(C)]` attributes and field order are load-bearing.
+
+/// DLPack device type. onnxsim's executor boundary only ever produces or
+/// consumes [`DLDeviceType::kDLCPU`] tensors.
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DLDeviceType {
+    /// CPU device.
+    kDLCPU = 1,
+    /// CUDA GPU device.
+    kDLCUDA = 2,
+    /// Pinned CUDA CPU memory.
+    kDLCUDAHost = 3,
+    /// OpenCL device.
+    kDLOpenCL = 4,
+    /// Vulkan buffer.
+    kDLVulkan = 7,
+    /// Metal (Apple GPU).
+    kDLMetal = 8,
+    /// Verilog simulator buffer.
+    kDLVPI = 9,
+    /// AMD ROCm GPU.
+    kDLROCM = 10,
+    /// Pinned ROCm CPU memory.
+    kDLROCMHost = 11,
+    /// Reserved extension device.
+    kDLExtDev = 12,
+    /// CUDA managed/unified memory.
+    kDLCUDAManaged = 13,
+    /// oneAPI unified shared memory.
+    kDLOneAPI = 14,
+    /// WebGPU buffer.
+    kDLWebGPU = 15,
+    /// Qualcomm Hexagon DSP.
+    kDLHexagon = 16,
+    /// Microsoft MAIA device.
+    kDLMAIA = 17,
+}
+
+/// DLPack type-code family (`DLDataType::code`). onnxsim uses `kDLInt`,
+/// `kDLUInt`, `kDLFloat`, `kDLBfloat`, and `kDLBool`.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DLDataTypeCode {
+    /// Signed integer.
+    kDLInt = 0,
+    /// Unsigned integer.
+    kDLUInt = 1,
+    /// IEEE floating point.
+    kDLFloat = 2,
+    /// Opaque handle.
+    kDLOpaqueHandle = 3,
+    /// bfloat16.
+    kDLBfloat = 4,
+    /// Complex number.
+    kDLComplex = 5,
+    /// Boolean.
+    kDLBool = 6,
+}
+
+/// A DLPack device (`DLDevice`).
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct DLDevice {
+    /// Device family.
+    pub device_type: DLDeviceType,
+    /// Device index (0 for CPU).
+    pub device_id: c_int,
+}
+
+/// A DLPack element type (`DLDataType`): `code` is a [`DLDataTypeCode`] value,
+/// `bits` the element width, `lanes` the vector width (always 1 here).
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct DLDataType {
+    /// Type-code family; one of [`DLDataTypeCode`].
+    pub code: u8,
+    /// Number of bits in one element (e.g. 32 for float32).
+    pub bits: u8,
+    /// Number of lanes (1 for scalars).
+    pub lanes: u16,
+}
+
+/// A non-owning DLPack tensor (`DLTensor`).
+///
+/// `shape` and `strides` point to `ndim` `i64` values; a null `strides` means
+/// the tensor is row-major contiguous. Data begins at `data + byte_offset`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct DLTensor {
+    /// Pointer to the element buffer.
+    pub data: *mut c_void,
+    /// Device the buffer lives on.
+    pub device: DLDevice,
+    /// Number of dimensions.
+    pub ndim: c_int,
+    /// Element data type.
+    pub dtype: DLDataType,
+    /// Pointer to `ndim` shape values.
+    pub shape: *mut i64,
+    /// Pointer to `ndim` stride values (elements, not bytes), or null if
+    /// contiguous.
+    pub strides: *mut i64,
+    /// Offset in bytes from `data` to the first element.
+    pub byte_offset: u64,
+}
+
+/// An owning, memory-managed DLPack tensor (`DLManagedTensor`).
+///
+/// The producer sets `deleter`; the consumer calls it exactly once when done,
+/// which releases both `manager_ctx` and the `DLManagedTensor` itself.
+#[repr(C)]
+pub struct DLManagedTensor {
+    /// The tensor being managed.
+    pub dl_tensor: DLTensor,
+    /// Producer-defined context reclaimed by `deleter`.
+    pub manager_ctx: *mut c_void,
+    /// Destructor; releases `manager_ctx` and `self`. May be null.
+    pub deleter: Option<unsafe extern "C" fn(this: *mut DLManagedTensor)>,
+}
+
+/// Custom constant-folding executor callback (mirrors `OnnxsimExecuteFn`).
+///
+/// Replaces the built-in ONNX Runtime constant folder: for each fold group,
+/// onnxsim hands over the sub-model (`model_data`/`model_size`, a serialized
+/// `ModelProto`) and its input tensors (`inputs`/`num_inputs`, borrowed for the
+/// call only), and the callback returns one owned [`DLManagedTensor`] per graph
+/// output through `*out_outputs`/`*out_num_outputs`. Return `0` on success,
+/// non-zero to abort. onnxsim releases each returned tensor via its own DLPack
+/// `deleter`, then calls the paired [`OnnxsimExecuteFreeFn`] on the array.
+pub type OnnxsimExecuteFn = unsafe extern "C" fn(
+    user_data: *mut c_void,
+    model_data: *const c_void,
+    model_size: usize,
+    inputs: *const *const DLManagedTensor,
+    num_inputs: usize,
+    out_outputs: *mut *mut *mut DLManagedTensor,
+    out_num_outputs: *mut usize,
+) -> c_int;
+
+/// Frees the output array produced by an [`OnnxsimExecuteFn`] (mirrors
+/// `OnnxsimExecuteFreeFn`) — the array container only; each tensor is released
+/// through its own deleter. Called with the same `user_data` and the exact
+/// `outputs`/`num_outputs` the execute callback returned.
+pub type OnnxsimExecuteFreeFn = unsafe extern "C" fn(
+    user_data: *mut c_void,
+    outputs: *mut *mut DLManagedTensor,
+    num_outputs: usize,
+);
+
 extern "C" {
     /// Simplify a serialized ONNX `ModelProto`.
     ///
@@ -67,6 +223,42 @@ extern "C" {
         rewrite_fn: Option<OnnxsimRewriteFn>,
         rewrite_free_fn: Option<OnnxsimRewriteFreeFn>,
         rewrite_user_data: *mut c_void,
+        out_data: *mut *mut c_void,
+        out_size: *mut usize,
+        out_error: *mut *mut c_char,
+    ) -> c_int;
+
+    /// Simplify a serialized ONNX `ModelProto`, driving constant folding through
+    /// a host-provided executor callback instead of the built-in ONNX Runtime.
+    ///
+    /// This is the seam for embedding onnxsim in another ONNX-based stack. A
+    /// `None` `execute_fn` falls back to the built-in executor, making this a
+    /// drop-in superset of [`onnxsim_simplify`]. See `onnxsim_c_api.h` for the
+    /// full contract; the rewrite parameters match [`onnxsim_simplify`].
+    ///
+    /// # Safety
+    /// All non-null pointers must be valid; `model_data` must point to at least
+    /// `model_size` bytes. When `execute_fn` is `Some`, it (and the matching
+    /// `execute_free_fn`) must obey the [`OnnxsimExecuteFn`] contract: inputs are
+    /// borrowed for the call, each returned [`DLManagedTensor`] is owned by
+    /// onnxsim (released via its deleter), and all tensors are CPU, contiguous,
+    /// and of a supported dtype. Otherwise as [`onnxsim_simplify`].
+    pub fn onnxsim_simplify_with_executor(
+        model_data: *const c_void,
+        model_size: usize,
+        skip_optimizers: *const *const c_char,
+        num_skip_optimizers: usize,
+        skip_optimizers_is_null: c_int,
+        constant_folding: c_int,
+        shape_inference: c_int,
+        tensor_size_threshold: usize,
+        target_opset_version: c_int,
+        rewrite_fn: Option<OnnxsimRewriteFn>,
+        rewrite_free_fn: Option<OnnxsimRewriteFreeFn>,
+        rewrite_user_data: *mut c_void,
+        execute_fn: Option<OnnxsimExecuteFn>,
+        execute_free_fn: Option<OnnxsimExecuteFreeFn>,
+        execute_user_data: *mut c_void,
         out_data: *mut *mut c_void,
         out_size: *mut usize,
         out_error: *mut *mut c_char,

--- a/rust/onnxsim/src/lib.rs
+++ b/rust/onnxsim/src/lib.rs
@@ -75,6 +75,34 @@
 //!     Ok(())
 //! }
 //! ```
+//!
+//! # Custom executor
+//!
+//! [`simplify_with_executor`] drives constant folding through a closure of yours
+//! instead of the built-in ONNX Runtime — the seam for embedding onnxsim on top
+//! of another ONNX runtime. Each fold group calls the closure with the sub-model
+//! as serialized `ModelProto` bytes and its input tensors as borrowed
+//! [`TensorRef`]s; the closure evaluates it and returns one owned [`Tensor`] per
+//! graph output. Tensors cross as DLPack under the hood, so nothing is
+//! serialized to `TensorProto` on the way in or out.
+//!
+//! ```no_run
+//! fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+//!     let model = std::fs::read("model.onnx")?;
+//!     let simplified = onnxsim::simplify_with_executor(
+//!         &model,
+//!         &onnxsim::Options::new(),
+//!         |submodel: &[u8], inputs: &[onnxsim::TensorRef]| {
+//!             // Evaluate `submodel` with `inputs` in your runtime of choice and
+//!             // return the outputs as `onnxsim::Tensor`s (in graph-output order).
+//!             let _ = (submodel, inputs);
+//!             Ok::<_, onnxsim::Error>(Vec::<onnxsim::Tensor>::new())
+//!         },
+//!     )?;
+//!     let _ = simplified;
+//!     Ok(())
+//! }
+//! ```
 
 use std::ffi::{CStr, CString};
 use std::fmt;
@@ -715,6 +743,484 @@ impl FfiSkipOptimizers {
     }
 }
 
+// --- Custom executor -------------------------------------------------------
+//
+// The executor boundary lets you drive constant folding through your own ONNX
+// runtime instead of the built-in ONNX Runtime. Tensors cross as DLPack
+// DLManagedTensors; this module wraps that in a safe API where inputs arrive as
+// borrowed [`TensorRef`]s and outputs are returned as owned [`Tensor`]s.
+
+/// Element type of a tensor at the executor boundary.
+///
+/// This is the set onnxsim's constant folder exchanges (it matches the C++
+/// dtype table); other ONNX dtypes (string, complex, float8, 4-bit) never cross
+/// this boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataType {
+    /// IEEE half precision (float16).
+    Float16,
+    /// IEEE single precision (float32).
+    Float32,
+    /// IEEE double precision (float64).
+    Float64,
+    /// bfloat16.
+    Bfloat16,
+    /// 8-bit signed integer.
+    Int8,
+    /// 16-bit signed integer.
+    Int16,
+    /// 32-bit signed integer.
+    Int32,
+    /// 64-bit signed integer.
+    Int64,
+    /// 8-bit unsigned integer.
+    Uint8,
+    /// 16-bit unsigned integer.
+    Uint16,
+    /// 32-bit unsigned integer.
+    Uint32,
+    /// 64-bit unsigned integer.
+    Uint64,
+    /// Boolean (1 byte per element).
+    Bool,
+}
+
+impl DataType {
+    /// Size in bytes of a single element of this type.
+    pub fn byte_size(self) -> usize {
+        use DataType::*;
+        match self {
+            Bool | Int8 | Uint8 => 1,
+            Float16 | Bfloat16 | Int16 | Uint16 => 2,
+            Float32 | Int32 | Uint32 => 4,
+            Float64 | Int64 | Uint64 => 8,
+        }
+    }
+
+    /// The DLPack `(code, bits)` pair for this type (`lanes` is always 1).
+    fn to_dl(self) -> (u8, u8) {
+        use onnxsim_sys::DLDataTypeCode::*;
+        use DataType::*;
+        let (code, bits) = match self {
+            Float16 => (kDLFloat, 16),
+            Float32 => (kDLFloat, 32),
+            Float64 => (kDLFloat, 64),
+            Bfloat16 => (kDLBfloat, 16),
+            Int8 => (kDLInt, 8),
+            Int16 => (kDLInt, 16),
+            Int32 => (kDLInt, 32),
+            Int64 => (kDLInt, 64),
+            Uint8 => (kDLUInt, 8),
+            Uint16 => (kDLUInt, 16),
+            Uint32 => (kDLUInt, 32),
+            Uint64 => (kDLUInt, 64),
+            Bool => (kDLBool, 8),
+        };
+        (code as u8, bits)
+    }
+
+    /// Recover a [`DataType`] from a DLPack `DLDataType`, or `None` if it is not
+    /// one onnxsim's boundary supports (vectors, unknown code/width, etc.).
+    fn from_dl(dt: onnxsim_sys::DLDataType) -> Option<DataType> {
+        use onnxsim_sys::DLDataTypeCode;
+        use DataType::*;
+        if dt.lanes != 1 {
+            return None;
+        }
+        // `dt.code` is a raw u8 from C; compare against the enum's discriminants.
+        let code = dt.code;
+        let float = DLDataTypeCode::kDLFloat as u8;
+        let bfloat = DLDataTypeCode::kDLBfloat as u8;
+        let int = DLDataTypeCode::kDLInt as u8;
+        let uint = DLDataTypeCode::kDLUInt as u8;
+        let boolean = DLDataTypeCode::kDLBool as u8;
+        match (code, dt.bits) {
+            (c, 16) if c == float => Some(Float16),
+            (c, 32) if c == float => Some(Float32),
+            (c, 64) if c == float => Some(Float64),
+            (c, 16) if c == bfloat => Some(Bfloat16),
+            (c, 8) if c == int => Some(Int8),
+            (c, 16) if c == int => Some(Int16),
+            (c, 32) if c == int => Some(Int32),
+            (c, 64) if c == int => Some(Int64),
+            (c, 8) if c == uint => Some(Uint8),
+            (c, 16) if c == uint => Some(Uint16),
+            (c, 32) if c == uint => Some(Uint32),
+            (c, 64) if c == uint => Some(Uint64),
+            (c, 8) if c == boolean => Some(Bool),
+            _ => None,
+        }
+    }
+}
+
+/// An owned CPU tensor your executor returns for a graph output: raw
+/// little-endian element bytes plus dtype and shape.
+///
+/// `data.len()` must equal `shape.iter().product::<i64>() as usize *
+/// dtype.byte_size()`; [`simplify_with_executor`] aborts the run with an error
+/// if it does not.
+#[derive(Debug, Clone)]
+pub struct Tensor {
+    dtype: DataType,
+    shape: Vec<i64>,
+    data: Vec<u8>,
+}
+
+impl Tensor {
+    /// Build an output tensor from its dtype, shape, and raw little-endian bytes.
+    pub fn new(dtype: DataType, shape: Vec<i64>, data: Vec<u8>) -> Self {
+        Tensor { dtype, shape, data }
+    }
+
+    /// Element type.
+    pub fn dtype(&self) -> DataType {
+        self.dtype
+    }
+
+    /// Shape (dimension sizes).
+    pub fn shape(&self) -> &[i64] {
+        &self.shape
+    }
+
+    /// Raw little-endian element bytes.
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// Number of elements (product of the shape; 1 for a scalar).
+    fn num_elements(&self) -> i64 {
+        self.shape.iter().product()
+    }
+
+    /// Move into a heap-allocated DLManagedTensor owned by the C side. The
+    /// returned pointer is released by [`output_deleter`] (invoked by onnxsim
+    /// through the tensor's DLPack `deleter`).
+    fn into_managed(self) -> *mut onnxsim_sys::DLManagedTensor {
+        use onnxsim_sys::{DLDataType, DLDevice, DLDeviceType, DLManagedTensor, DLTensor};
+        let (code, bits) = self.dtype.to_dl();
+        // Keep shape and data alive in a context box; the DLTensor points into
+        // the Vecs' heap buffers, which stay put when the box is leaked.
+        let mut ctx = Box::new(OutputCtx {
+            shape: self.shape,
+            data: self.data,
+        });
+        let ndim = ctx.shape.len() as c_int;
+        let shape_ptr = ctx.shape.as_mut_ptr();
+        let data_ptr = ctx.data.as_mut_ptr() as *mut c_void;
+        let managed = Box::new(DLManagedTensor {
+            dl_tensor: DLTensor {
+                data: data_ptr,
+                device: DLDevice {
+                    device_type: DLDeviceType::kDLCPU,
+                    device_id: 0,
+                },
+                ndim,
+                dtype: DLDataType {
+                    code,
+                    bits,
+                    lanes: 1,
+                },
+                shape: shape_ptr,
+                strides: ptr::null_mut(),
+                byte_offset: 0,
+            },
+            manager_ctx: Box::into_raw(ctx) as *mut c_void,
+            deleter: Some(output_deleter),
+        });
+        Box::into_raw(managed)
+    }
+}
+
+/// Backing store for a [`Tensor`] handed to the C side as a DLManagedTensor.
+struct OutputCtx {
+    shape: Vec<i64>,
+    data: Vec<u8>,
+}
+
+/// DLPack `deleter` for tensors produced by [`Tensor::into_managed`]. Reclaims
+/// both the context box (shape + data) and the DLManagedTensor box.
+unsafe extern "C" fn output_deleter(this: *mut onnxsim_sys::DLManagedTensor) {
+    if this.is_null() {
+        return;
+    }
+    let managed = Box::from_raw(this);
+    if !managed.manager_ctx.is_null() {
+        drop(Box::from_raw(managed.manager_ctx as *mut OutputCtx));
+    }
+    // `managed` (the DLManagedTensor box) is dropped here.
+}
+
+/// A borrowed view of an input tensor onnxsim feeds to the executor. Valid only
+/// for the duration of the executor call; copy out anything you need to keep.
+pub struct TensorRef<'a> {
+    dtype: DataType,
+    shape: &'a [i64],
+    data: &'a [u8],
+}
+
+impl<'a> TensorRef<'a> {
+    /// Element type.
+    pub fn dtype(&self) -> DataType {
+        self.dtype
+    }
+
+    /// Shape (dimension sizes).
+    pub fn shape(&self) -> &'a [i64] {
+        self.shape
+    }
+
+    /// Raw little-endian element bytes.
+    pub fn data(&self) -> &'a [u8] {
+        self.data
+    }
+
+    /// Borrow the fields of a DLManagedTensor onnxsim passed in. Rejects tensors
+    /// that are not CPU, not contiguous, or of an unsupported dtype.
+    ///
+    /// # Safety
+    /// `mt` must be a valid DLManagedTensor whose buffers outlive `'a`.
+    unsafe fn from_managed(mt: &'a onnxsim_sys::DLManagedTensor) -> Result<TensorRef<'a>, Error> {
+        use onnxsim_sys::DLDeviceType;
+        let t = &mt.dl_tensor;
+        if t.device.device_type != DLDeviceType::kDLCPU {
+            return Err(Error::Simplify(
+                "executor input tensor is not on the CPU device".to_string(),
+            ));
+        }
+        if !t.strides.is_null() {
+            return Err(Error::Simplify(
+                "executor input tensor is not contiguous (non-null strides)".to_string(),
+            ));
+        }
+        let dtype = DataType::from_dl(t.dtype).ok_or_else(|| {
+            Error::Simplify(format!(
+                "executor input tensor has an unsupported dtype (code={}, bits={})",
+                t.dtype.code, t.dtype.bits
+            ))
+        })?;
+        let ndim = t.ndim.max(0) as usize;
+        let shape = std::slice::from_raw_parts(t.shape, ndim);
+        let count: i64 = shape.iter().product();
+        let nbytes = count.max(0) as usize * dtype.byte_size();
+        let base = (t.data as *const u8).add(t.byte_offset as usize);
+        let data = std::slice::from_raw_parts(base, nbytes);
+        Ok(TensorRef { dtype, shape, data })
+    }
+}
+
+/// Type-erased executor closure: `(sub-model bytes, input tensors) -> outputs`.
+type ExecuteCallback<'a> =
+    dyn for<'b> FnMut(&'b [u8], &'b [TensorRef<'b>]) -> Result<Vec<Tensor>, RewriterError> + 'a;
+
+/// Holds the user closure and captures failures that cannot cross the FFI as a
+/// return value (a closure error, a panic, or an invalid input tensor).
+struct ExecutorState<'a> {
+    callback: &'a mut ExecuteCallback<'a>,
+    error: Option<RewriterError>,
+    panicked: bool,
+}
+
+/// `extern "C"` shim matching [`onnxsim_sys::OnnxsimExecuteFn`]. Recovers the
+/// `ExecutorState`, borrows the input tensors, runs the closure under
+/// `catch_unwind`, and hands the outputs back as an owned DLManagedTensor array.
+unsafe extern "C" fn execute_trampoline(
+    user_data: *mut c_void,
+    model_data: *const c_void,
+    model_size: usize,
+    inputs: *const *const onnxsim_sys::DLManagedTensor,
+    num_inputs: usize,
+    out_outputs: *mut *mut *mut onnxsim_sys::DLManagedTensor,
+    out_num_outputs: *mut usize,
+) -> c_int {
+    let state = &mut *(user_data as *mut ExecutorState);
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let model: &[u8] = if model_size == 0 {
+            &[]
+        } else {
+            std::slice::from_raw_parts(model_data as *const u8, model_size)
+        };
+        let mut refs: Vec<TensorRef> = Vec::with_capacity(num_inputs);
+        for i in 0..num_inputs {
+            let mt = *inputs.add(i);
+            if mt.is_null() {
+                return Err(RewriterError::from(Box::new(Error::Simplify(
+                    "executor received a null input tensor".to_string(),
+                ))));
+            }
+            refs.push(TensorRef::from_managed(&*mt)?);
+        }
+        (state.callback)(model, &refs)
+    }));
+    match outcome {
+        Ok(Ok(outputs)) => {
+            // Validate each output's byte length before building DLManagedTensors,
+            // so a malformed tensor is a clean error rather than an out-of-bounds
+            // read on the C side.
+            for (i, t) in outputs.iter().enumerate() {
+                let expected = t.num_elements().max(0) as usize * t.dtype.byte_size();
+                if t.data.len() != expected {
+                    state.error = Some(RewriterError::from(Box::new(Error::Simplify(format!(
+                        "executor output {i} has {} bytes but dtype {:?} and shape {:?} \
+                         imply {expected}",
+                        t.data.len(),
+                        t.dtype,
+                        t.shape
+                    )))));
+                    return -1;
+                }
+            }
+            let mut boxed: Box<[*mut onnxsim_sys::DLManagedTensor]> = outputs
+                .into_iter()
+                .map(Tensor::into_managed)
+                .collect::<Vec<_>>()
+                .into_boxed_slice();
+            let len = boxed.len();
+            let ptr = boxed.as_mut_ptr();
+            std::mem::forget(boxed); // ownership passes to execute_free_trampoline
+            *out_outputs = ptr;
+            *out_num_outputs = len;
+            0
+        }
+        Ok(Err(e)) => {
+            state.error = Some(e);
+            -1
+        }
+        Err(_) => {
+            state.panicked = true;
+            -1
+        }
+    }
+}
+
+/// `extern "C"` shim matching [`onnxsim_sys::OnnxsimExecuteFreeFn`]. Reclaims the
+/// output-array container allocated in [`execute_trampoline`]. The tensors
+/// themselves are released by onnxsim through their own deleters, so this must
+/// not touch them.
+unsafe extern "C" fn execute_free_trampoline(
+    _user_data: *mut c_void,
+    outputs: *mut *mut onnxsim_sys::DLManagedTensor,
+    num_outputs: usize,
+) {
+    if outputs.is_null() {
+        return;
+    }
+    drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+        outputs,
+        num_outputs,
+    )));
+}
+
+/// Map an FFI failure, preferring an error captured from the executor closure.
+fn executor_error(state: &mut ExecutorState, out_error: *mut c_char) -> Error {
+    let c_message = if out_error.is_null() {
+        None
+    } else {
+        match take_error(out_error) {
+            Error::Simplify(msg) => Some(msg),
+            other => Some(other.to_string()),
+        }
+    };
+    if state.panicked {
+        return Error::Simplify("the custom executor panicked".to_string());
+    }
+    if let Some(e) = state.error.take() {
+        return Error::Simplify(format!("custom executor failed: {e}"));
+    }
+    Error::Simplify(c_message.unwrap_or_else(|| "unknown error (no message provided)".to_string()))
+}
+
+/// Simplify a serialized ONNX `ModelProto`, driving constant folding through a
+/// custom executor instead of the built-in ONNX Runtime.
+///
+/// This is the Rust counterpart of the C API's executor callback — the seam for
+/// running onnxsim on top of another ONNX runtime. `executor` is called once per
+/// fold group with the sub-model as serialized `ModelProto` bytes and its input
+/// tensors (borrowed [`TensorRef`]s, positional to `graph.input`); it must
+/// evaluate the sub-model and return one owned [`Tensor`] per graph output, in
+/// order.
+///
+/// `function_rewrite_rules` on the options are not supported here (this entry
+/// point takes an executor, not a rule set) and cause an error if set.
+///
+/// ```no_run
+/// # fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+/// let model = std::fs::read("model.onnx")?;
+/// let simplified = onnxsim::simplify_with_executor(
+///     &model,
+///     &onnxsim::Options::new(),
+///     |_submodel: &[u8], _inputs: &[onnxsim::TensorRef]| {
+///         // Run `_submodel` in your runtime with `_inputs`, then return the
+///         // output tensors. (A real executor must actually evaluate it.)
+///         Ok::<_, onnxsim::Error>(Vec::<onnxsim::Tensor>::new())
+///     },
+/// )?;
+/// # let _ = simplified;
+/// # Ok(())
+/// # }
+/// ```
+pub fn simplify_with_executor<F, E>(
+    model_bytes: &[u8],
+    options: &Options,
+    mut executor: F,
+) -> Result<Vec<u8>, Error>
+where
+    F: for<'b> FnMut(&'b [u8], &'b [TensorRef<'b>]) -> Result<Vec<Tensor>, E>,
+    E: Into<RewriterError>,
+{
+    if !options.function_rewrite_rules.is_empty() {
+        return Err(Error::InvalidArgument(
+            "function_rewrite_rules are only supported by simplify/simplify_with, \
+             not simplify_with_executor"
+                .to_string(),
+        ));
+    }
+
+    let mut wrapped =
+        move |model: &[u8], inputs: &[TensorRef]| executor(model, inputs).map_err(Into::into);
+    let mut state = ExecutorState {
+        callback: &mut wrapped,
+        error: None,
+        panicked: false,
+    };
+    let ffi = FfiSkipOptimizers::new(options)?;
+
+    let mut out_data: *mut c_void = ptr::null_mut();
+    let mut out_size: usize = 0;
+    let mut out_error: *mut c_char = ptr::null_mut();
+
+    let status = unsafe {
+        onnxsim_sys::onnxsim_simplify_with_executor(
+            model_bytes.as_ptr() as *const c_void,
+            model_bytes.len(),
+            ffi.ptr(),
+            ffi.len(),
+            ffi.is_null_flag(),
+            bool_to_c(options.constant_folding),
+            bool_to_c(options.shape_inference),
+            options.tensor_size_threshold,
+            target_opset_to_c(options.target_opset_version),
+            None,
+            None,
+            ptr::null_mut(),
+            Some(execute_trampoline),
+            Some(execute_free_trampoline),
+            &mut state as *mut ExecutorState as *mut c_void,
+            &mut out_data,
+            &mut out_size,
+            &mut out_error,
+        )
+    };
+
+    if status == onnxsim_sys::ONNXSIM_OK {
+        let result =
+            unsafe { std::slice::from_raw_parts(out_data as *const u8, out_size) }.to_vec();
+        unsafe { onnxsim_sys::onnxsim_free_buffer(out_data) };
+        Ok(result)
+    } else {
+        Err(executor_error(&mut state, out_error))
+    }
+}
+
 fn bool_to_c(value: bool) -> c_int {
     if value {
         1
@@ -914,6 +1420,193 @@ mod tests {
         assert_eq!(rc, -1);
         assert!(state.panicked);
         let err = rewriter_error(&mut state, ptr::null_mut());
+        assert!(matches!(&err, Error::Simplify(m) if m.contains("panicked")));
+    }
+
+    // --- Executor boundary -------------------------------------------------
+    //
+    // Like the rewriter trampolines, the executor trampolines and the
+    // DLManagedTensor conversions are pure Rust, so the whole input-view ->
+    // closure -> output-tensor -> free round trip can be driven directly without
+    // the native library.
+
+    #[test]
+    fn datatype_byte_size_and_dl_roundtrip() {
+        use DataType::*;
+        let all = [
+            Float16, Float32, Float64, Bfloat16, Int8, Int16, Int32, Int64, Uint8, Uint16, Uint32,
+            Uint64, Bool,
+        ];
+        for dt in all {
+            let (code, bits) = dt.to_dl();
+            assert_eq!(bits as usize, dt.byte_size() * 8);
+            let recovered = DataType::from_dl(onnxsim_sys::DLDataType {
+                code,
+                bits,
+                lanes: 1,
+            });
+            assert_eq!(recovered, Some(dt));
+        }
+        // Vectors and unknown widths are rejected.
+        assert_eq!(
+            DataType::from_dl(onnxsim_sys::DLDataType {
+                code: onnxsim_sys::DLDataTypeCode::kDLFloat as u8,
+                bits: 32,
+                lanes: 4,
+            }),
+            None
+        );
+    }
+
+    /// Build a borrowed input DLManagedTensor (as onnxsim would) over caller-owned
+    /// shape/data buffers, feed it through the executor trampoline, and return the
+    /// closure's outcome plus the reconstructed outputs.
+    #[test]
+    fn execute_trampoline_roundtrips_tensors() {
+        // Input: int32 tensor shape [2] = [1, 2]; the closure echoes it back as
+        // an output, exercising both TensorRef::from_managed and into_managed.
+        let mut in_shape: [i64; 1] = [2];
+        let mut in_data: Vec<u8> = vec![1, 0, 0, 0, 2, 0, 0, 0];
+        let mut in_tensor = onnxsim_sys::DLManagedTensor {
+            dl_tensor: onnxsim_sys::DLTensor {
+                data: in_data.as_mut_ptr() as *mut c_void,
+                device: onnxsim_sys::DLDevice {
+                    device_type: onnxsim_sys::DLDeviceType::kDLCPU,
+                    device_id: 0,
+                },
+                ndim: 1,
+                dtype: onnxsim_sys::DLDataType {
+                    code: onnxsim_sys::DLDataTypeCode::kDLInt as u8,
+                    bits: 32,
+                    lanes: 1,
+                },
+                shape: in_shape.as_mut_ptr(),
+                strides: ptr::null_mut(),
+                byte_offset: 0,
+            },
+            manager_ctx: ptr::null_mut(),
+            deleter: None,
+        };
+        let input_ptrs: [*const onnxsim_sys::DLManagedTensor; 1] = [&in_tensor];
+
+        let mut seen_shape: Vec<i64> = Vec::new();
+        let mut seen_bytes: Vec<u8> = Vec::new();
+        let mut cb = |model: &[u8], inputs: &[TensorRef]| {
+            assert_eq!(model, b"model-bytes");
+            assert_eq!(inputs.len(), 1);
+            seen_shape = inputs[0].shape().to_vec();
+            seen_bytes = inputs[0].data().to_vec();
+            assert_eq!(inputs[0].dtype(), DataType::Int32);
+            Ok::<_, RewriterError>(vec![Tensor::new(
+                DataType::Int32,
+                inputs[0].shape().to_vec(),
+                inputs[0].data().to_vec(),
+            )])
+        };
+        let mut state = ExecutorState {
+            callback: &mut cb,
+            error: None,
+            panicked: false,
+        };
+
+        let model = b"model-bytes";
+        let mut out_outputs: *mut *mut onnxsim_sys::DLManagedTensor = ptr::null_mut();
+        let mut out_num: usize = 0;
+        let rc = unsafe {
+            execute_trampoline(
+                &mut state as *mut ExecutorState as *mut c_void,
+                model.as_ptr() as *const c_void,
+                model.len(),
+                input_ptrs.as_ptr(),
+                input_ptrs.len(),
+                &mut out_outputs,
+                &mut out_num,
+            )
+        };
+        assert_eq!(rc, 0);
+        assert_eq!(seen_shape, vec![2]);
+        assert_eq!(seen_bytes, vec![1, 0, 0, 0, 2, 0, 0, 0]);
+        assert_eq!(out_num, 1);
+
+        // Inspect the produced output tensor, then release it exactly as onnxsim
+        // would: each element via its deleter, then the array via the free shim.
+        unsafe {
+            let out0 = *out_outputs;
+            assert!(!out0.is_null());
+            let t = &(*out0).dl_tensor;
+            assert_eq!(t.ndim, 1);
+            assert_eq!(std::slice::from_raw_parts(t.shape, 1), &[2]);
+            let bytes = std::slice::from_raw_parts(t.data as *const u8, 8);
+            assert_eq!(bytes, &[1, 0, 0, 0, 2, 0, 0, 0]);
+            let deleter = (*out0).deleter.expect("output tensor must carry a deleter");
+            deleter(out0);
+            execute_free_trampoline(ptr::null_mut(), out_outputs, out_num);
+        }
+        // Keep the borrowed input buffers alive until here.
+        let _ = (&in_shape, &in_data, &mut in_tensor);
+    }
+
+    #[test]
+    fn execute_trampoline_rejects_wrong_output_length() {
+        let mut cb = |_: &[u8], _: &[TensorRef]| {
+            // Claims shape [4] int32 (16 bytes) but supplies only 4 bytes.
+            Ok::<_, RewriterError>(vec![Tensor::new(
+                DataType::Int32,
+                vec![4],
+                vec![0, 0, 0, 0],
+            )])
+        };
+        let mut state = ExecutorState {
+            callback: &mut cb,
+            error: None,
+            panicked: false,
+        };
+        let mut out_outputs: *mut *mut onnxsim_sys::DLManagedTensor = ptr::null_mut();
+        let mut out_num: usize = 0;
+        let rc = unsafe {
+            execute_trampoline(
+                &mut state as *mut ExecutorState as *mut c_void,
+                ptr::null(),
+                0,
+                ptr::null(),
+                0,
+                &mut out_outputs,
+                &mut out_num,
+            )
+        };
+        assert_eq!(rc, -1);
+        let err = executor_error(&mut state, ptr::null_mut());
+        assert!(matches!(&err, Error::Simplify(m) if m.contains("bytes")));
+    }
+
+    #[test]
+    fn execute_trampoline_captures_panic() {
+        let mut cb =
+            |_: &[u8], _: &[TensorRef]| -> Result<Vec<Tensor>, RewriterError> { panic!("kaboom") };
+        let mut state = ExecutorState {
+            callback: &mut cb,
+            error: None,
+            panicked: false,
+        };
+        let mut out_outputs: *mut *mut onnxsim_sys::DLManagedTensor = ptr::null_mut();
+        let mut out_num: usize = 0;
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let rc = unsafe {
+            execute_trampoline(
+                &mut state as *mut ExecutorState as *mut c_void,
+                ptr::null(),
+                0,
+                ptr::null(),
+                0,
+                &mut out_outputs,
+                &mut out_num,
+            )
+        };
+        std::panic::set_hook(prev);
+        assert_eq!(rc, -1);
+        assert!(state.panicked);
+        let err = executor_error(&mut state, ptr::null_mut());
         assert!(matches!(&err, Error::Simplify(m) if m.contains("panicked")));
     }
 }

--- a/scripts/convertmodel/interface.cpp
+++ b/scripts/convertmodel/interface.cpp
@@ -84,7 +84,7 @@ em::val onnxsimplify_export(const std::string& data, em::val skip_optimizers, bo
     try {
         optimized = Simplify(
 #ifdef ONNXSIM_WASM_ORT_WEB
-            // Runs each fold group through the page's onnxruntime-web. _Run
+            // Runs each fold group through the page's onnxruntime-web. Its Run
             // blocks on a JS Promise, so this whole function is Asyncified and
             // returns a Promise to JS (the worker awaits it).
             *GetJsModelExecutor(),

--- a/scripts/convertmodel/js_model_executor.cpp
+++ b/scripts/convertmodel/js_model_executor.cpp
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include "dlpack_bridge.h"
+
 // wasm is always little-endian; the (de)serialization below memcpy's typed data
 // to/from raw little-endian bytes, so bail loudly if that ever stops holding.
 static_assert(std::endian::native == std::endian::little,
@@ -28,15 +30,18 @@ using emscripten::val;
 // content as raw little-endian bytes of the element type.
 constexpr const char* kRunnerProp = "onnxsimOrtWebRun";
 
-// Copy `s` into a fresh JS-owned Uint8Array. Constructing `new Uint8Array(view)`
-// from a view over the wasm heap copies the bytes into a new ArrayBuffer, so
-// the result stays valid across the Asyncify suspend in _Run -- while suspended
-// the wasm heap can grow (ALLOW_MEMORY_GROWTH=1) and any view still pointing at
-// the old heap would be detached.
-val StringToJsU8Copy(const std::string& s) {
-  val view = val(emscripten::typed_memory_view(
-      s.size(), reinterpret_cast<const uint8_t*>(s.data())));
+// Copy `len` bytes at `data` into a fresh JS-owned Uint8Array. Constructing
+// `new Uint8Array(view)` from a view over the wasm heap copies the bytes into a
+// new ArrayBuffer, so the result stays valid across the Asyncify suspend in
+// Run() -- while suspended the wasm heap can grow (ALLOW_MEMORY_GROWTH=1) and
+// any view still pointing at the old heap would be detached.
+val RawToJsU8Copy(const uint8_t* data, size_t len) {
+  val view = val(emscripten::typed_memory_view(len, data));
   return val::global("Uint8Array").new_(view);
+}
+
+val StringToJsU8Copy(const std::string& s) {
+  return RawToJsU8Copy(reinterpret_cast<const uint8_t*>(s.data()), s.size());
 }
 
 // Copy a JS Uint8Array back into a std::string. Called after the await, so the
@@ -51,50 +56,18 @@ std::string JsU8ToString(const val& u8) {
   return out;
 }
 
-// Serialize a TensorProto's element data to raw little-endian bytes. Mirrors the
-// dtype coverage of the built-in CppModelExecutor's TensorProtoToTensor so the
-// two executors accept the same models. onnx packs the sub-32-bit integer and
-// bool types into int32_data, so narrow each element to its true width.
-std::string TensorProtoRawBytes(const onnx::TensorProto& t) {
-  if (t.has_raw_data()) {
-    return t.raw_data();
-  }
-  std::string raw;
-#define CASE_DTYPE(onnx_dtype, storage_dtype, cpp_type)                  \
-  case onnx::TensorProto::onnx_dtype: {                                  \
-    std::vector<cpp_type> vec;                                           \
-    vec.reserve(t.storage_dtype##_data_size());                         \
-    for (const auto& x : t.storage_dtype##_data()) {                    \
-      vec.push_back(static_cast<cpp_type>(x));                           \
-    }                                                                    \
-    raw.assign(reinterpret_cast<const char*>(vec.data()),               \
-               vec.size() * sizeof(cpp_type));                          \
-    break;                                                              \
-  }
-  switch (t.data_type()) {
-    CASE_DTYPE(FLOAT, float, float)
-    CASE_DTYPE(DOUBLE, double, double)
-    CASE_DTYPE(INT64, int64, int64_t)
-    CASE_DTYPE(UINT64, uint64, uint64_t)
-    CASE_DTYPE(INT32, int32, int32_t)
-    CASE_DTYPE(UINT8, int32, uint8_t)
-    CASE_DTYPE(INT8, int32, int8_t)
-    CASE_DTYPE(UINT16, int32, uint16_t)
-    CASE_DTYPE(INT16, int32, int16_t)
-    CASE_DTYPE(BOOL, int32, int8_t)
-    default:
-      throw std::invalid_argument("onnxruntime-web executor: unsupported input "
-                                  "dtype " +
-                                  std::to_string(t.data_type()));
-  }
-#undef CASE_DTYPE
-  return raw;
-}
-
+// A ModelExecutor that evaluates each constant-folding sub-model with
+// onnxruntime-web. Tensors cross the executor boundary as DLPack
+// DLManagedTensors (see onnxsim.h / dlpack_bridge.h): inputs are borrowed for
+// the call, and outputs are returned as freshly owned managed tensors. Across
+// the wasm<->JS boundary the payload still has to be copied into JS-owned
+// buffers (onnxsim's wasm heap and onnxruntime-web's are separate memories), but
+// nothing is serialized to TensorProto -- the contract is ONNX dtype enums plus
+// raw little-endian bytes, matching the built-in CppModelExecutor's dtype set.
 struct JsModelExecutor : public ModelExecutor {
-  std::vector<onnx::TensorProto> _Run(
+  std::vector<DLManagedTensorPtr> Run(
       const onnx::ModelProto& model,
-      const std::vector<onnx::TensorProto>& inputs) const override {
+      const std::vector<const DLManagedTensor*>& inputs) const override {
     // Reach the runner the page registered on the Module.
     val runner = val::module_property(kRunnerProp);
     if (runner.isUndefined() || runner.isNull()) {
@@ -109,18 +82,34 @@ struct JsModelExecutor : public ModelExecutor {
     const std::string model_str = model.SerializeAsString();
     val js_model = StringToJsU8Copy(model_str);
 
+    // Inputs are positional w.r.t. model.graph().input(); recover each feed's
+    // name from there (DLPack tensors carry no name), matching how the built-in
+    // executor maps feeds to graph inputs.
     val js_inputs = val::array();
-    for (const auto& inp : inputs) {
-      const std::string raw = TensorProtoRawBytes(inp);
+    for (size_t i = 0; i < inputs.size(); i++) {
+      const DLTensor& t = inputs[i]->dl_tensor;
+      int32_t onnx_dtype;
+      if (!onnxsim::dlpack::TryDLToOnnx(t.dtype, &onnx_dtype)) {
+        throw std::invalid_argument(
+            "onnxruntime-web executor: unsupported input dtype (DLPack code=" +
+            std::to_string(t.dtype.code) +
+            ", bits=" + std::to_string(t.dtype.bits) + ")");
+      }
       val obj = val::object();
-      obj.set("name", inp.name());
-      obj.set("dataType", static_cast<int>(inp.data_type()));
+      obj.set("name", i < static_cast<size_t>(model.graph().input_size())
+                          ? model.graph().input(static_cast<int>(i)).name()
+                          : std::string());
+      obj.set("dataType", onnx_dtype);
       val dims = val::array();
-      for (int i = 0; i < inp.dims_size(); i++) {
-        dims.call<void>("push", static_cast<double>(inp.dims(i)));
+      for (int32_t d = 0; d < t.ndim; d++) {
+        dims.call<void>("push", static_cast<double>(t.shape[d]));
       }
       obj.set("dims", dims);
-      obj.set("data", StringToJsU8Copy(raw));
+      const size_t nbytes =
+          static_cast<size_t>(onnxsim::dlpack::NumElements(t.shape, t.ndim)) *
+          onnxsim::dlpack::SizeOf(t.dtype);
+      const uint8_t* base = static_cast<const uint8_t*>(t.data) + t.byte_offset;
+      obj.set("data", RawToJsU8Copy(base, nbytes));
       js_inputs.call<void>("push", obj);
     }
 
@@ -130,8 +119,10 @@ struct JsModelExecutor : public ModelExecutor {
     val result = runner(js_model, js_inputs).await();
 
     // RunOps names the returned tensors positionally, in graph-output order, so
-    // return them in exactly that order (their own names are overwritten).
-    std::vector<onnx::TensorProto> outputs;
+    // return them in exactly that order. Each output is rebuilt as a TensorProto
+    // (dtype + dims + raw bytes) and handed to the DLPack boundary as an owning
+    // managed tensor.
+    std::vector<DLManagedTensorPtr> outputs;
     outputs.reserve(model.graph().output_size());
     for (const auto& out_vi : model.graph().output()) {
       val t = result[out_vi.name()];
@@ -145,11 +136,12 @@ struct JsModelExecutor : public ModelExecutor {
           static_cast<onnx::TensorProto::DataType>(t["dataType"].as<int>()));
       val dims = t["dims"];
       const size_t ndim = dims["length"].as<size_t>();
-      for (size_t i = 0; i < ndim; i++) {
-        tp.add_dims(static_cast<int64_t>(dims[i].as<double>()));
+      for (size_t d = 0; d < ndim; d++) {
+        tp.add_dims(static_cast<int64_t>(dims[d].as<double>()));
       }
       tp.set_raw_data(JsU8ToString(t["data"]));
-      outputs.push_back(std::move(tp));
+      outputs.emplace_back(
+          onnxsim::dlpack::FromTensorProtoOwning(std::move(tp)));
     }
     return outputs;
   }

--- a/scripts/convertmodel/js_model_executor.cpp
+++ b/scripts/convertmodel/js_model_executor.cpp
@@ -22,12 +22,15 @@ namespace {
 using emscripten::val;
 
 // The page registers its onnxruntime-web runner on the Emscripten Module under
-// this name (see ort_executor.mjs / worker.js). Signature, in JS:
-//   async (modelBytes: Uint8Array, inputs: InTensor[]) => { [name]: OutTensor }
-// where InTensor  = { name, dataType, dims: number[], data: Uint8Array }
-//   and OutTensor = { dataType, dims: number[], data: Uint8Array }.
-// `dataType` is the ONNX TensorProto.DataType enum value; `data` is the tensor
-// content as raw little-endian bytes of the element type.
+// this name (see ort_executor.mjs / worker.js). The crossing is batched: all of
+// a fold group's tensors travel in one concatenated byte blob plus one flat
+// [dtype, ndim, dims...] metadata array, in both directions. Signature, in JS:
+//   async (modelBytes: Uint8Array,
+//          inputsData: Uint8Array,      // all feed bytes concatenated
+//          inputsMeta: Float64Array)    // [dtype, ndim, dims...] per feed
+//     => Promise<{ data: Uint8Array, meta: Float64Array }>  // same layout
+// `dtype` is the ONNX TensorProto.DataType enum value; tensor bytes are raw
+// little-endian element data. Tensors are positional (no names cross).
 constexpr const char* kRunnerProp = "onnxsimOrtWebRun";
 
 // Copy `len` bytes at `data` into a fresh JS-owned Uint8Array. Constructing
@@ -56,14 +59,34 @@ std::string JsU8ToString(const val& u8) {
   return out;
 }
 
+// Copy a std::vector<double> into a fresh JS-owned Float64Array (the batched
+// input metadata). Like the byte copies, this survives the Asyncify suspend.
+val DoublesToJsF64Copy(const std::vector<double>& v) {
+  val view = val(emscripten::typed_memory_view(v.size(), v.data()));
+  return val::global("Float64Array").new_(view);
+}
+
+// Copy a JS Float64Array (the batched output metadata) into a vector. Called
+// after the await, against the current heap.
+std::vector<double> JsF64ToVector(const val& arr) {
+  const size_t len = arr["length"].as<size_t>();
+  std::vector<double> out(len);
+  if (len != 0) {
+    val dest = val(emscripten::typed_memory_view(len, out.data()));
+    dest.call<void>("set", arr);
+  }
+  return out;
+}
+
 // A ModelExecutor that evaluates each constant-folding sub-model with
 // onnxruntime-web. Tensors cross the executor boundary as DLPack
 // DLManagedTensors (see onnxsim.h / dlpack_bridge.h): inputs are borrowed for
 // the call, and outputs are returned as freshly owned managed tensors. Across
 // the wasm<->JS boundary the payload still has to be copied into JS-owned
-// buffers (onnxsim's wasm heap and onnxruntime-web's are separate memories), but
-// nothing is serialized to TensorProto -- the contract is ONNX dtype enums plus
-// raw little-endian bytes, matching the built-in CppModelExecutor's dtype set.
+// buffers (onnxsim's wasm heap and onnxruntime-web's are separate memories),
+// but nothing is serialized to TensorProto -- the contract is ONNX dtype enums
+// plus raw little-endian bytes, matching the built-in CppModelExecutor's dtype
+// set.
 struct JsModelExecutor : public ModelExecutor {
   std::vector<DLManagedTensorPtr> Run(
       const onnx::ModelProto& model,
@@ -82,12 +105,16 @@ struct JsModelExecutor : public ModelExecutor {
     const std::string model_str = model.SerializeAsString();
     val js_model = StringToJsU8Copy(model_str);
 
-    // Inputs are positional w.r.t. model.graph().input(); recover each feed's
-    // name from there (DLPack tensors carry no name), matching how the built-in
-    // executor maps feeds to graph inputs.
-    val js_inputs = val::array();
-    for (size_t i = 0; i < inputs.size(); i++) {
-      const DLTensor& t = inputs[i]->dl_tensor;
+    // Batch the feeds into two buffers that cross the boundary once each: all
+    // input bytes concatenated, plus a flat [dtype, ndim, dims...] metadata
+    // array (mirrored by ort_executor.mjs). This avoids the per-tensor,
+    // per-field embind round trips of building a JS object array. Inputs are
+    // positional w.r.t. model.graph().input(); the JS side rebinds them to the
+    // session's input names in the same order (DLPack tensors carry no name).
+    std::string in_blob;
+    std::vector<double> in_meta;
+    for (const DLManagedTensor* in : inputs) {
+      const DLTensor& t = in->dl_tensor;
       int32_t onnx_dtype;
       if (!onnxsim::dlpack::TryDLToOnnx(t.dtype, &onnx_dtype)) {
         throw std::invalid_argument(
@@ -95,51 +122,63 @@ struct JsModelExecutor : public ModelExecutor {
             std::to_string(t.dtype.code) +
             ", bits=" + std::to_string(t.dtype.bits) + ")");
       }
-      val obj = val::object();
-      obj.set("name", i < static_cast<size_t>(model.graph().input_size())
-                          ? model.graph().input(static_cast<int>(i)).name()
-                          : std::string());
-      obj.set("dataType", onnx_dtype);
-      val dims = val::array();
+      in_meta.push_back(onnx_dtype);
+      in_meta.push_back(t.ndim);
       for (int32_t d = 0; d < t.ndim; d++) {
-        dims.call<void>("push", static_cast<double>(t.shape[d]));
+        in_meta.push_back(static_cast<double>(t.shape[d]));
       }
-      obj.set("dims", dims);
       const size_t nbytes =
           static_cast<size_t>(onnxsim::dlpack::NumElements(t.shape, t.ndim)) *
           onnxsim::dlpack::SizeOf(t.dtype);
-      const uint8_t* base = static_cast<const uint8_t*>(t.data) + t.byte_offset;
-      obj.set("data", RawToJsU8Copy(base, nbytes));
-      js_inputs.call<void>("push", obj);
+      const char* base = static_cast<const char*>(t.data) + t.byte_offset;
+      in_blob.append(base, nbytes);
     }
+    val js_data = StringToJsU8Copy(in_blob);
+    val js_meta = DoublesToJsF64Copy(in_meta);
 
     // Run onnxruntime-web and block on its Promise. val::await() unwinds the
     // wasm stack via Asyncify and resumes here once the Promise settles; a
     // rejected Promise surfaces as a C++ exception.
-    val result = runner(js_model, js_inputs).await();
+    val result = runner(js_model, js_data, js_meta).await();
 
-    // RunOps names the returned tensors positionally, in graph-output order, so
-    // return them in exactly that order. Each output is rebuilt as a TensorProto
-    // (dtype + dims + raw bytes) and handed to the DLPack boundary as an owning
-    // managed tensor.
+    // The runner returns { data, meta } in the same batched layout, with
+    // outputs in graph-output order (which is how RunOps names them
+    // positionally). Walk the metadata, slicing each output's bytes out of the
+    // blob and rebuilding it as a TensorProto handed to the DLPack boundary as
+    // an owning tensor.
+    const std::string out_blob = JsU8ToString(result["data"]);
+    const std::vector<double> out_meta = JsF64ToVector(result["meta"]);
+
     std::vector<DLManagedTensorPtr> outputs;
     outputs.reserve(model.graph().output_size());
-    for (const auto& out_vi : model.graph().output()) {
-      val t = result[out_vi.name()];
-      if (t.isUndefined() || t.isNull()) {
-        throw std::runtime_error(
-            "onnxruntime-web executor: runner did not return output '" +
-            out_vi.name() + "'");
-      }
+    size_t m = 0;    // index into out_meta
+    size_t off = 0;  // byte offset into out_blob
+    while (m < out_meta.size()) {
+      const int32_t onnx_dtype = static_cast<int32_t>(out_meta[m++]);
+      const int32_t ndim = static_cast<int32_t>(out_meta[m++]);
       onnx::TensorProto tp;
-      tp.set_data_type(
-          static_cast<onnx::TensorProto::DataType>(t["dataType"].as<int>()));
-      val dims = t["dims"];
-      const size_t ndim = dims["length"].as<size_t>();
-      for (size_t d = 0; d < ndim; d++) {
-        tp.add_dims(static_cast<int64_t>(dims[d].as<double>()));
+      tp.set_data_type(static_cast<onnx::TensorProto::DataType>(onnx_dtype));
+      int64_t numel = 1;
+      for (int32_t d = 0; d < ndim; d++) {
+        const int64_t dim = static_cast<int64_t>(out_meta[m++]);
+        tp.add_dims(dim);
+        numel *= dim;
       }
-      tp.set_raw_data(JsU8ToString(t["data"]));
+      DLDataType dl;
+      if (!onnxsim::dlpack::TryOnnxToDL(onnx_dtype, &dl)) {
+        throw std::invalid_argument(
+            "onnxruntime-web executor: unsupported output dtype " +
+            std::to_string(onnx_dtype));
+      }
+      const size_t nbytes =
+          static_cast<size_t>(numel) * onnxsim::dlpack::SizeOf(dl);
+      if (off + nbytes > out_blob.size()) {
+        throw std::runtime_error(
+            "onnxruntime-web executor: output blob shorter than its metadata "
+            "implies");
+      }
+      tp.set_raw_data(out_blob.data() + off, nbytes);
+      off += nbytes;
       outputs.emplace_back(
           onnxsim::dlpack::FromTensorProtoOwning(std::move(tp)));
     }

--- a/scripts/convertmodel/js_model_executor.h
+++ b/scripts/convertmodel/js_model_executor.h
@@ -4,9 +4,11 @@
 //
 // This is the WebAssembly analogue of the Python "trampoline" executor
 // (PyModelExecutor in onnxsim/cpp2py_export.cc): the C++ constant folder keeps
-// calling ModelExecutor::_Run, but the actual op execution is delegated across
+// calling ModelExecutor::Run, but the actual op execution is delegated across
 // the language boundary -- to the pip `onnxruntime` package in Python, and to
-// the page's `onnxruntime-web` module here.
+// the page's `onnxruntime-web` module here. Tensors cross the executor boundary
+// as DLPack DLManagedTensors (see onnxsim.h); this executor converts them
+// to/from onnxruntime-web's dtype+dims+raw-bytes contract.
 //
 // Why: the default WASM build compiles ONNX Runtime from source and links it
 // into onnxsim's own .wasm (ONNXSIM_BUILTIN_ORT=ON). That from-source ORT
@@ -31,7 +33,7 @@
 
 #include "onnxsim.h"  // ModelExecutor
 
-// Returns the singleton onnxruntime-web-backed executor. Its _Run reaches into
+// Returns the singleton onnxruntime-web-backed executor. Its Run reaches into
 // JavaScript for the actual session run, so it must be called from a context
 // linked with Asyncify (as onnxsimplify_export is in the ORT-web build).
 std::shared_ptr<const ModelExecutor> GetJsModelExecutor();

--- a/scripts/convertmodel/ort_executor.mjs
+++ b/scripts/convertmodel/ort_executor.mjs
@@ -1,21 +1,31 @@
 // The JavaScript half of the onnxruntime-web constant-folding executor.
 //
 // When onnxsim's WASM module is built with ONNXSIM_WASM_ORT_WEB, its C++
-// constant folder does not link ONNX Runtime; instead JsModelExecutor::_Run
+// constant folder does not link ONNX Runtime; instead JsModelExecutor::Run
 // (js_model_executor.cpp) calls a runner registered on the Emscripten Module as
 // `Module.onnxsimOrtWebRun`. This file builds that runner on top of an
 // already-loaded `onnxruntime-web` module.
 //
-// Contract (must match js_model_executor.cpp):
-//   runner(modelBytes: Uint8Array, inputs: InTensor[]) => Promise<OutMap>
-//     InTensor = { name: string, dataType: number, dims: number[], data: Uint8Array }
-//     OutMap   = { [outputName: string]: { dataType, dims: number[], data: Uint8Array } }
-// `dataType` is the ONNX TensorProto.DataType enum value; `data` is the tensor
-// content as raw little-endian bytes of the element type.
+// Contract (must match js_model_executor.cpp) -- a *batched* crossing: rather
+// than one JS object + Uint8Array per tensor (which costs an embind round trip
+// per field, per tensor), all of a fold group's tensors cross in a single
+// concatenated byte blob plus one flat metadata array, in both directions:
+//
+//   runner(modelBytes: Uint8Array,
+//          inputsData: Uint8Array,     // all input tensors' bytes, concatenated
+//          inputsMeta: Float64Array)   // [dtype, ndim, dims...] per input
+//     => Promise<{ data: Uint8Array,   // all output tensors' bytes, concatenated
+//                  meta: Float64Array }>// [dtype, ndim, dims...] per output
+//
+// `dtype` is the ONNX TensorProto.DataType enum value; tensor bytes are raw
+// little-endian element data. Tensors are positional: input i binds to
+// session.inputNames[i] and outputs are emitted in session.outputNames order
+// (both equal the sub-model's graph input/output order, which is how the C++
+// side maps them). No tensor names cross the boundary.
 
 // ONNX TensorProto.DataType enum value -> [onnxruntime-web tensor type string,
 // TypedArray constructor for that type]. Kept in lock-step with the dtype set
-// TensorProtoRawBytes() in js_model_executor.cpp emits/accepts.
+// js_model_executor.cpp emits/accepts (onnxsim::dlpack's supported types).
 const ONNX_DTYPE_TO_ORT = {
   1: ["float32", Float32Array], // FLOAT
   2: ["uint8", Uint8Array], // UINT8
@@ -43,9 +53,10 @@ const ORT_TYPE_TO_ONNX = {
   uint64: 13,
 };
 
-// Reinterpret a Uint8Array's bytes as `Ctor` elements. The C++ side hands us
-// freshly-allocated (0-offset) buffers, but fall back to a copy if an offset is
-// ever unaligned for the element size.
+// Reinterpret a Uint8Array's bytes as `Ctor` elements. The bytes come from a
+// slice of the concatenated input blob, so the byte offset may not be aligned
+// to the element size; fall back to a copy (onto a fresh 0-offset buffer) when
+// it isn't.
 function typedFromBytes(Ctor, u8) {
   const bpe = Ctor.BYTES_PER_ELEMENT;
   if (u8.byteOffset % bpe === 0 && u8.byteLength % bpe === 0) {
@@ -60,6 +71,13 @@ function bytesFromTyped(ta) {
   return new Uint8Array(ta.buffer, ta.byteOffset, ta.byteLength);
 }
 
+// Elements in a tensor of shape `dims` (1 for a scalar / empty dims).
+function elementCount(dims) {
+  let n = 1;
+  for (const d of dims) n *= d;
+  return n;
+}
+
 // Build the runner that JsModelExecutor calls. `ort` is a loaded onnxruntime-web
 // module. Sessions are created per fold group with graph optimization disabled,
 // mirroring the built-in CppModelExecutor (ORT_DISABLE_ALL): we want ORT to
@@ -68,28 +86,46 @@ function bytesFromTyped(ta) {
 // `providers` lets a browser prefer e.g. WebGPU and fall back to wasm; folding
 // correctness does not depend on the provider.
 export function makeOrtRunner(ort, { providers = ["wasm"] } = {}) {
-  return async function onnxsimOrtWebRun(modelBytes, inputs) {
+  return async function onnxsimOrtWebRun(modelBytes, inputsData, inputsMeta) {
     const session = await ort.InferenceSession.create(modelBytes, {
       executionProviders: providers,
       graphOptimizationLevel: "disabled",
     });
 
+    // Unpack the input blob: walk inputsMeta, slicing the next tensor's bytes
+    // out of inputsData, and bind each positionally to session.inputNames.
+    const inputNames = session.inputNames;
     const feeds = {};
-    for (const inp of inputs) {
-      const entry = ONNX_DTYPE_TO_ORT[inp.dataType];
+    let m = 0; // index into inputsMeta
+    let off = 0; // byte offset into inputsData
+    let i = 0; // input index
+    while (m < inputsMeta.length) {
+      const dataType = inputsMeta[m++];
+      const ndim = inputsMeta[m++];
+      const dims = [];
+      for (let d = 0; d < ndim; d++) dims.push(inputsMeta[m++]);
+      const entry = ONNX_DTYPE_TO_ORT[dataType];
       if (!entry) {
         throw new Error(
-          `onnxruntime-web executor: unsupported input dtype ${inp.dataType} for '${inp.name}'`,
+          `onnxruntime-web executor: unsupported input dtype ${dataType} for '${inputNames[i]}'`,
         );
       }
       const [type, Ctor] = entry;
-      feeds[inp.name] = new ort.Tensor(type, typedFromBytes(Ctor, inp.data), inp.dims);
+      const byteLen = elementCount(dims) * Ctor.BYTES_PER_ELEMENT;
+      const sub = inputsData.subarray(off, off + byteLen);
+      off += byteLen;
+      feeds[inputNames[i]] = new ort.Tensor(type, typedFromBytes(Ctor, sub), dims);
+      i++;
     }
 
     const results = await session.run(feeds);
 
-    const out = {};
-    for (const name of Object.keys(results)) {
+    // Pack outputs in session.outputNames order (== graph.output() order, which
+    // is what the C++ side reads positionally) into one blob + one meta array.
+    const parts = [];
+    const meta = [];
+    let totalBytes = 0;
+    for (const name of session.outputNames) {
       const t = results[name];
       const onnxType = ORT_TYPE_TO_ONNX[t.type];
       if (onnxType === undefined) {
@@ -97,17 +133,22 @@ export function makeOrtRunner(ort, { providers = ["wasm"] } = {}) {
           `onnxruntime-web executor: unsupported output dtype '${t.type}' for '${name}'`,
         );
       }
-      out[name] = {
-        dataType: onnxType,
-        dims: Array.from(t.dims),
-        data: bytesFromTyped(t.data),
-      };
+      const bytes = bytesFromTyped(t.data);
+      parts.push(bytes);
+      totalBytes += bytes.byteLength;
+      meta.push(onnxType, t.dims.length, ...t.dims);
+    }
+    const data = new Uint8Array(totalBytes);
+    let o = 0;
+    for (const p of parts) {
+      data.set(p, o);
+      o += p.byteLength;
     }
 
     // Free the session's native resources; folding creates one per group.
     if (typeof session.release === "function") {
       await session.release();
     }
-    return out;
+    return { data, meta: new Float64Array(meta) };
   };
 }

--- a/scripts/convertmodel/worker.js
+++ b/scripts/convertmodel/worker.js
@@ -21,7 +21,7 @@ async function setupOrtWebIfNeeded(runtime) {
     const ort = ortMod.default ?? ortMod;
     // Pull the matching wasm binaries from the same CDN directory.
     ort.env.wasm.wasmPaths = ORT_BASE;
-    // JsModelExecutor::_Run reaches this via val::module_property("onnxsimOrtWebRun").
+    // JsModelExecutor::Run reaches this via val::module_property("onnxsimOrtWebRun").
     runtime.onnxsimOrtWebRun = makeOrtRunner(ort);
 }
 

--- a/third_party/dlpack/dlpack.h
+++ b/third_party/dlpack/dlpack.h
@@ -1,0 +1,324 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file dlpack.h
+ * \brief The common header of DLPack.
+ *
+ * Vendored from https://github.com/dmlc/dlpack (Apache-2.0). This is a
+ * verbatim-in-spirit copy of the stable DLPack ABI header; onnxsim uses it as
+ * the tensor exchange type at the ModelExecutor / C-ABI executor boundary so
+ * that constant folding can pass tensors to (and receive them from) an
+ * arbitrary runtime without serializing them to onnx::TensorProto. See
+ * docs/dlpack-executor.md for how the boundary is used.
+ */
+#ifndef DLPACK_DLPACK_H_
+#define DLPACK_DLPACK_H_
+
+/**
+ * \brief Compatibility with C++
+ */
+#ifdef __cplusplus
+#define DLPACK_EXTERN_C extern "C"
+#else
+#define DLPACK_EXTERN_C
+#endif
+
+/*! \brief The current major version of dlpack */
+#define DLPACK_MAJOR_VERSION 1
+
+/*! \brief The current minor version of dlpack */
+#define DLPACK_MINOR_VERSION 0
+
+/*! \brief DLPACK_DLL prefix for windows */
+#ifdef _WIN32
+#ifdef DLPACK_EXPORTS
+#define DLPACK_DLL __declspec(dllexport)
+#else
+#define DLPACK_DLL __declspec(dllimport)
+#endif
+#else
+#define DLPACK_DLL
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * \brief The DLPack version.
+ *
+ * A change in major version indicates that we have changed the
+ * data layout of the ABI - DLManagedTensorVersioned.
+ *
+ * A change in minor version indicates that we have added new
+ * code, such as a new device type, but the ABI is kept the same.
+ *
+ * If an obtained DLPack tensor has a major version that disagrees
+ * with the version number specified in this header file
+ * (i.e. major != DLPACK_MAJOR_VERSION), the consumer must call the deleter
+ * (and it is safe to do so). It is not safe to access any other fields
+ * as the memory layout will have changed.
+ *
+ * In the case of a minor version mismatch, the tensor can be safely used as
+ * long as the consumer knows how to interpret all fields. Minor version
+ * updates indicate the addition of enumeration values.
+ */
+typedef struct {
+  /*! \brief DLPack major version. */
+  uint32_t major;
+  /*! \brief DLPack minor version. */
+  uint32_t minor;
+} DLPackVersion;
+
+/*!
+ * \brief The device type in DLDevice.
+ */
+#ifdef __cplusplus
+typedef enum : int32_t {
+#else
+typedef enum {
+#endif
+  /*! \brief CPU device */
+  kDLCPU = 1,
+  /*! \brief CUDA GPU device */
+  kDLCUDA = 2,
+  /*!
+   * \brief Pinned CUDA CPU memory by cudaMallocHost
+   */
+  kDLCUDAHost = 3,
+  /*! \brief OpenCL devices. */
+  kDLOpenCL = 4,
+  /*! \brief Vulkan buffer for next generation graphics. */
+  kDLVulkan = 7,
+  /*! \brief Metal for Apple GPU. */
+  kDLMetal = 8,
+  /*! \brief Verilog simulator buffer */
+  kDLVPI = 9,
+  /*! \brief ROCm GPUs for AMD GPUs */
+  kDLROCM = 10,
+  /*!
+   * \brief Pinned ROCm CPU memory allocated by hipMallocHost
+   */
+  kDLROCMHost = 11,
+  /*!
+   * \brief Reserved extension device type,
+   * used for quickly test extension device
+   * The semantics can differ depending on the implementation.
+   */
+  kDLExtDev = 12,
+  /*!
+   * \brief CUDA managed/unified memory allocated by cudaMallocManaged
+   */
+  kDLCUDAManaged = 13,
+  /*!
+   * \brief Unified shared memory allocated on a oneAPI non-partitioned
+   * device. Call to oneAPI runtime is required to determine the device
+   * type, the USM allocation type and the sycl context it is bound to.
+   */
+  kDLOneAPI = 14,
+  /*! \brief GPU support for next generation WebGPU standard. */
+  kDLWebGPU = 15,
+  /*! \brief Qualcomm Hexagon DSP */
+  kDLHexagon = 16,
+  /*! \brief Microsoft MAIA devices */
+  kDLMAIA = 17,
+} DLDeviceType;
+
+/*!
+ * \brief A Device for Tensor and operator.
+ */
+typedef struct {
+  /*! \brief The device type used in the device. */
+  DLDeviceType device_type;
+  /*!
+   * \brief The device index.
+   * For vanilla CPU memory, pinned memory, or managed memory, this is set to 0.
+   */
+  int32_t device_id;
+} DLDevice;
+
+/*!
+ * \brief The type code options DLDataType.
+ */
+typedef enum {
+  /*! \brief signed integer */
+  kDLInt = 0U,
+  /*! \brief unsigned integer */
+  kDLUInt = 1U,
+  /*! \brief IEEE floating point */
+  kDLFloat = 2U,
+  /*!
+   * \brief Opaque handle type, reserved for testing purposes.
+   * Frameworks need to agree on the handle data type for the exchange to be
+   * well-defined.
+   */
+  kDLOpaqueHandle = 3U,
+  /*! \brief bfloat16 */
+  kDLBfloat = 4U,
+  /*!
+   * \brief complex number
+   * (C/C++/Python layout: compact struct per complex number)
+   */
+  kDLComplex = 5U,
+  /*! \brief boolean */
+  kDLBool = 6U,
+} DLDataTypeCode;
+
+/*!
+ * \brief The data type the tensor can hold. The data type is assumed to follow
+ * the native endian-ness. An explicit error message should be raised when
+ * attempting to export an array with non-native endianness.
+ *
+ *  Examples
+ *   - float: type_code = 2, bits = 32, lanes = 1
+ *   - float4(vectorized 4 float): type_code = 2, bits = 32, lanes = 4
+ *   - int8: type_code = 0, bits = 8, lanes = 1
+ *   - std::complex<float>: type_code = 5, bits = 64, lanes = 1
+ *   - bool: type_code = 6, bits = 8, lanes = 1 (as per common array library
+ *     convention, the underlying storage size of bool is 8 bits)
+ */
+typedef struct {
+  /*!
+   * \brief Type code of base types.
+   * We keep it uint8_t instead of DLDataTypeCode for minimal memory
+   * footprint, but the value should be one of DLDataTypeCode enum values.
+   * */
+  uint8_t code;
+  /*!
+   * \brief Number of bits, common choices are 8, 16, 32.
+   */
+  uint8_t bits;
+  /*! \brief Number of lanes in the type, used for vector types. */
+  uint16_t lanes;
+} DLDataType;
+
+/*!
+ * \brief Plain C Tensor object, does not manage memory.
+ */
+typedef struct {
+  /*!
+   * \brief The data pointer points to the allocated data. This will be CUDA
+   * device pointer or cl_mem handle in OpenCL. It may be opaque on some device
+   * types. This pointer is always aligned to 256 bytes as in CUDA. The
+   * `byte_offset` field should be used to point to the beginning of the data.
+   *
+   * Note that as of Nov 2021, multiply libraries (CuPy, PyTorch, TensorFlow,
+   * TVM, perhaps others) do not adhere to this 256 byte alignment requirement
+   * on CPU/CUDA/ROCm, and always use `byte_offset=0`. This must be fixed
+   * (after which this note will be updated); at the moment it is recommended
+   * to not rely on the data pointer being correctly aligned.
+   */
+  void* data;
+  /*! \brief The device of the tensor */
+  DLDevice device;
+  /*! \brief Number of dimensions */
+  int32_t ndim;
+  /*! \brief The data type of the pointer*/
+  DLDataType dtype;
+  /*! \brief The shape of the tensor */
+  int64_t* shape;
+  /*!
+   * \brief strides of the tensor (in number of elements, not bytes)
+   *  can be NULL, indicating tensor is compact and row-majored.
+   */
+  int64_t* strides;
+  /*! \brief The offset in bytes to the beginning pointer to data */
+  uint64_t byte_offset;
+} DLTensor;
+
+/*!
+ * \brief C Tensor object, manage memory of DLTensor. This data structure is
+ *  intended to facilitate the borrowing of DLTensor by another framework. It is
+ *  not meant to transfer the tensor. When the borrowing framework doesn't need
+ *  the tensor, it should call the deleter to notify the host that the resource
+ *  is no longer needed.
+ *
+ * \note This data structure is used as Legacy DLManagedTensor
+ *       in DLPack exchange and is deprecated after DLPack v0.8
+ *       Use DLManagedTensorVersioned instead.
+ *       This data structure may get renamed or deleted in future versions.
+ *
+ * \sa DLManagedTensorVersioned
+ */
+typedef struct DLManagedTensor {
+  /*! \brief DLTensor which is being memory managed */
+  DLTensor dl_tensor;
+  /*! \brief the context of the original host framework of DLManagedTensor in
+   *   which DLManagedTensor is used in the framework. It can also be NULL.
+   */
+  void* manager_ctx;
+  /*!
+   * \brief Destructor - this should be called
+   * to destruct the manager_ctx which backs the DLManagedTensor. It can be
+   * NULL if there is no way for the caller to provide a reasonable destructor.
+   * The destructor deletes the argument self as well.
+   */
+  void (*deleter)(struct DLManagedTensor* self);
+} DLManagedTensor;
+
+// bit masks used in the DLManagedTensorVersioned
+
+/*! \brief bit mask to indicate that the tensor is read only. */
+#define DLPACK_FLAG_BITMASK_READ_ONLY (1UL << 0UL)
+
+/*!
+ * \brief bit mask to indicate that the tensor is a copy made by the producer.
+ *
+ * If set, the tensor is considered solely owned throughout its lifetime by the
+ * consumer, until the producer-provided deleter is invoked.
+ */
+#define DLPACK_FLAG_BITMASK_IS_COPIED (1UL << 1UL)
+
+/*!
+ * \brief A versioned and managed C Tensor object, manage memory of DLTensor.
+ *
+ * This data structure is intended to facilitate the borrowing of DLTensor by
+ * another framework. It is not meant to transfer the tensor. When the borrowing
+ * framework doesn't need the tensor, it should call the deleter to notify the
+ * host that the resource is no longer needed.
+ *
+ * \note This is the current standard DLPack exchange data structure.
+ */
+struct DLManagedTensorVersioned {
+  /*!
+   * \brief The API and ABI version of the current managed Tensor
+   */
+  DLPackVersion version;
+  /*!
+   * \brief the context of the original host framework.
+   *
+   * Stores DLManagedTensorVersioned is used in the
+   * framework. It can also be NULL.
+   */
+  void* manager_ctx;
+  /*!
+   * \brief Destructor.
+   *
+   * This should be called to destruct manager_ctx which holds the
+   * DLManagedTensorVersioned. It can be NULL if there is no way for the caller
+   * to provide a reasonable destructor. The destructor deletes the argument
+   * self as well.
+   */
+  void (*deleter)(struct DLManagedTensorVersioned* self);
+  /*!
+   * \brief Additional bitmask flags information about the tensor.
+   *
+   * By default the flags should be set to 0.
+   *
+   * \note Future ABI changes should keep everything until this field
+   *       stable, to ensure that deleter can be correctly called.
+   *
+   * \sa DLPACK_FLAG_BITMASK_READ_ONLY
+   * \sa DLPACK_FLAG_BITMASK_IS_COPIED
+   */
+  uint64_t flags;
+  /*! \brief DLTensor which is being memory managed */
+  DLTensor dl_tensor;
+};
+
+#ifdef __cplusplus
+}  // DLPACK_EXTERN_C
+#endif
+#endif  // DLPACK_DLPACK_H_


### PR DESCRIPTION
Redefine ModelExecutor to exchange tensors as DLPack DLManagedTensor
instead of onnx::TensorProto, so constant folding can borrow buffers in
and move ORT's own output buffers out with no protobuf round trip, and so
onnxsim can be embedded in another ONNX stack via a single executor
callback that speaks a standard tensor ABI.

- Vendor third_party/dlpack/dlpack.h (include root third_party/).
- dlpack_dtype.h: pure ONNX<->DLDataType mapping (no onnx/ORT deps) with a
  standalone, runnable test wired into ONNXSIM_TESTS.
- dlpack_bridge.h: TensorProto<->DLManagedTensor (borrow in, single
  set_raw_data out) and Ort::Value<->DLManagedTensor (borrowing CreateTensor
  in, move ORT output out) converters. Replaces the old element-by-element
  add_*_data output path.
- ModelExecutor::Run(model, inputs) now takes borrowed DLManagedTensor*
  inputs and returns owned DLManagedTensorPtr outputs (RAII over the DLPack
  deleter). CppModelExecutor and the Python trampoline adapt to it; RunOps
  bridges initializer TensorProtos to the boundary and bakes results back.
- C ABI: OnnxsimExecuteFn + onnxsim_simplify_with_executor, the embeddability
  seam (NULL callback falls back to the built-in executor).
- docs/dlpack-executor.md: boundary design, dtype table, ownership contract,
  the three adapters, and the separate-heap analysis for a future
  onnxruntime-web JsModelExecutor.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013PncJ982YkJ918XR8k9VP2