### PR TITLE
Show model download size before fetching in converter UI

### DIFF
--- a/scripts/convertmodel/hf_load.mjs
+++ b/scripts/convertmodel/hf_load.mjs
@@ -10,6 +10,7 @@ import {
   loadModelList,
   fetchModelBytes,
   fetchModelBytesXet,
+  probeModelSize,
   humanBytes,
 } from "./hf_models.mjs";
 import { openXetCache, makeCachingFetch } from "./xet_cache.mjs";
@@ -55,12 +56,54 @@ loadModelList().then((ids) => {
   }
 });
 
+// Show the download size for the currently-referenced model *before* fetching,
+// so a user can see how big it is before committing to the download. The size
+// comes from the Hub API listing (for a repo id) or a HEAD request (for an exact
+// file / direct URL). A monotonic token guards against a slow probe overwriting
+// the status line for a reference the user has since changed.
+let probeToken = 0;
+let loading = false; // a download is in flight; don't let a probe touch the status
+async function showSizeFor(ref) {
+  if (loading) return;
+  ref = (ref || "").trim();
+  const token = ++probeToken;
+  if (!ref) {
+    if (statusEl) statusEl.textContent = "";
+    return;
+  }
+  if (statusEl) statusEl.textContent = "checking size…";
+  try {
+    const { size, name } = await probeModelSize(ref);
+    if (token !== probeToken) return; // a newer reference superseded this probe
+    if (statusEl) {
+      const label = name ? `${name} — ` : "";
+      statusEl.textContent = size
+        ? `${label}≈ ${humanBytes(size)} to download`
+        : `${label}size unavailable`;
+    }
+  } catch (e) {
+    if (token !== probeToken) return;
+    if (statusEl) statusEl.textContent = "size unavailable — see console output";
+    log(`could not determine model size for "${ref}": ${e && e.message ? e.message : e}`);
+  }
+}
+
 // Picking from the dropdown mirrors into the text box so the two never disagree
 // about what "Load" will fetch, and the user can tweak the id before loading.
+// Both a dropdown pick and a committed edit of the text box preview the size.
 if (select && refInput) {
   select.addEventListener("change", () => {
-    if (select.value) refInput.value = select.value;
+    if (select.value) {
+      refInput.value = select.value;
+      showSizeFor(select.value);
+    }
   });
+}
+// `change` fires on commit (blur / Enter), so partial keystrokes don't each
+// trigger a network probe; the text box is mirrored from the dropdown
+// programmatically, which does not fire `change`, so there's no double probe.
+if (refInput) {
+  refInput.addEventListener("change", () => showSizeFor(refInput.value));
 }
 
 async function doLoad() {
@@ -74,6 +117,11 @@ async function doLoad() {
     return;
   }
 
+  // Take over the status line from any size preview: mark a load in flight and
+  // invalidate outstanding probes so a late size result can't overwrite the
+  // download progress below.
+  loading = true;
+  probeToken += 1;
   loadBtn.disabled = true;
   if (fileInput) fileInput.disabled = true;
   if (statusEl) statusEl.textContent = "loading…";
@@ -177,6 +225,7 @@ async function doLoad() {
     // the worker's convert-done message does that).
     if (fileInput) fileInput.disabled = false;
   } finally {
+    loading = false;
     loadBtn.disabled = false;
   }
 }

--- a/scripts/convertmodel/hf_models.mjs
+++ b/scripts/convertmodel/hf_models.mjs
@@ -89,17 +89,25 @@ async function repoSiblings(repo) {
   return info.siblings || [];
 }
 
+// From a repo's sibling listing, pick the main .onnx file (largest, matching the
+// regression workers). Returns { sibling, count } where `sibling` carries both
+// `rfilename` and `size`; throws when the repo has no .onnx file.
+function pickOnnxSibling(siblings, repo) {
+  const onnx = siblings.filter((s) => s.rfilename && s.rfilename.endsWith(".onnx"));
+  if (!onnx.length) throw new Error(`no .onnx file found in ${repo}`);
+  onnx.sort((a, b) => (b.size || 0) - (a.size || 0));
+  return { sibling: onnx[0], count: onnx.length };
+}
+
 // Pick the main .onnx file in a repo (largest, matching the regression workers)
 // and warn when the graph relies on external-data blobs the in-browser,
 // single-file converter can't load.
 async function findOnnxFile(repo, onLog) {
   const siblings = await repoSiblings(repo);
-  const onnx = siblings.filter((s) => s.rfilename && s.rfilename.endsWith(".onnx"));
-  if (!onnx.length) throw new Error(`no .onnx file found in ${repo}`);
-  onnx.sort((a, b) => (b.size || 0) - (a.size || 0));
-  const chosen = onnx[0].rfilename;
-  if (onnx.length > 1) {
-    onLog(`repo has ${onnx.length} .onnx files; using the largest: ${chosen}`);
+  const { sibling, count } = pickOnnxSibling(siblings, repo);
+  const chosen = sibling.rfilename;
+  if (count > 1) {
+    onLog(`repo has ${count} .onnx files; using the largest: ${chosen}`);
   }
   const external = siblings.some(
     (s) => s.rfilename && /\.(onnx_data|onnx\.data|data|weight|weights)$/.test(s.rfilename),
@@ -112,6 +120,54 @@ async function findOnnxFile(repo, onLog) {
     );
   }
   return chosen;
+}
+
+// Read a URL's byte size from its Content-Length via a HEAD request, without
+// downloading the body. Returns a positive integer, or null when the size can't
+// be determined (request failed, header absent, or CORS hid it).
+async function headContentLength(url) {
+  try {
+    const r = await fetch(url, { method: "HEAD" });
+    if (!r.ok) return null;
+    const n = Number(r.headers && r.headers.get("content-length"));
+    return Number.isFinite(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+// Resolve a reference to the size of the model that would be downloaded, WITHOUT
+// fetching the model bytes — so the page can show how big a model is before
+// committing to the download. For a Hub repo id this reuses the Hub API listing
+// (which carries per-file sizes); for an exact file or a direct URL it issues a
+// HEAD request and reads Content-Length. Returns { size, name, repo?, file?,
+// url? }, where `size` is a byte count or null when it can't be determined.
+// Throws only when the reference itself can't be resolved (empty ref, or a repo
+// with no .onnx file).
+export async function probeModelSize(ref) {
+  const parsed = parseRef(ref);
+  if (parsed.url) {
+    return { size: await headContentLength(parsed.url), name: parsed.name, url: parsed.url };
+  }
+  const revision = parsed.revision || "main";
+  if (parsed.file) {
+    const url = fileUrl(parsed.repo, parsed.file, revision);
+    return {
+      size: await headContentLength(url),
+      name: parsed.file.split("/").pop(),
+      repo: parsed.repo,
+      file: parsed.file,
+    };
+  }
+  const siblings = await repoSiblings(parsed.repo);
+  const { sibling } = pickOnnxSibling(siblings, parsed.repo);
+  const size = Number.isFinite(sibling.size) && sibling.size > 0 ? sibling.size : null;
+  return {
+    size,
+    name: sibling.rfilename.split("/").pop(),
+    repo: parsed.repo,
+    file: sibling.rfilename,
+  };
 }
 
 // Human-readable byte size, e.g. 4.7 MB. Used in progress messages.

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -307,7 +307,9 @@
                 browser (nothing is uploaded), then runs it through the same
                 Simplify / Optimize path as an uploaded file. Bare names default
                 to the <code>onnxmodelzoo</code> org; any <code>owner/repo</code>
-                or direct <code>.onnx</code> URL works too.
+                or direct <code>.onnx</code> URL works too. Picking a model (or
+                entering a repo id / URL) shows its download size first, so you
+                can see how big it is before fetching.
             </div>
             <div style="margin-top: 0.25em;">
                 <input type="checkbox" id="hf-use-xet">

--- a/scripts/convertmodel/test/hf_models.test.mjs
+++ b/scripts/convertmodel/test/hf_models.test.mjs
@@ -10,6 +10,7 @@ import {
   fileUrl,
   loadModelList,
   fetchModelBytes,
+  probeModelSize,
   humanBytes,
 } from "../hf_models.mjs";
 
@@ -240,6 +241,57 @@ await acheck("fetchModelBytes falls back to arrayBuffer without a body", async (
       assert.deepEqual(Array.from(bytes), [7, 8]);
       // One final progress tick; total defaults to the byte count.
       assert.deepEqual(progress, [{ loaded: 2, total: 2 }]);
+    },
+  );
+});
+
+await acheck("probeModelSize reports the largest .onnx size from the Hub API", async () => {
+  const api = "https://huggingface.co/api/models/onnxmodelzoo/foo?blobs=true";
+  await withFetch(
+    {
+      [api]: {
+        json: {
+          siblings: [
+            { rfilename: "small.onnx", size: 10 },
+            { rfilename: "big.onnx", size: 999 },
+            { rfilename: "readme.md", size: 1 },
+          ],
+        },
+      },
+    },
+    async () => {
+      const info = await probeModelSize("foo");
+      assert.equal(info.size, 999);
+      assert.equal(info.name, "big.onnx");
+      assert.equal(info.repo, "onnxmodelzoo/foo");
+    },
+  );
+});
+
+await acheck("probeModelSize HEADs an exact resolve URL for its size", async () => {
+  const url = "https://huggingface.co/o/r/resolve/main/m.onnx";
+  await withFetch({ [url]: { contentLength: 4096 } }, async () => {
+    const info = await probeModelSize(url);
+    assert.equal(info.size, 4096);
+    assert.equal(info.name, "m.onnx");
+  });
+});
+
+await acheck("probeModelSize returns a null size when Content-Length is absent", async () => {
+  const url = "https://example.com/models/net.onnx";
+  await withFetch({ [url]: {} }, async () => {
+    const info = await probeModelSize(url);
+    assert.equal(info.size, null);
+    assert.equal(info.name, "net.onnx");
+  });
+});
+
+await acheck("probeModelSize surfaces a repo with no .onnx", async () => {
+  const api = "https://huggingface.co/api/models/onnxmodelzoo/empty?blobs=true";
+  await withFetch(
+    { [api]: { json: { siblings: [{ rfilename: "readme.md", size: 1 }] } } },
+    async () => {
+      await assert.rejects(probeModelSize("empty"), /no \.onnx file found/);
     },
   );
 });


### PR DESCRIPTION
## Summary
Add the ability to preview a model's download size in the converter UI before the user commits to downloading it. This helps users understand the bandwidth/storage requirements upfront.

## Key Changes

- **New `probeModelSize()` export in `hf_models.mjs`**: Resolves a model reference (Hub repo ID, exact file path, or direct URL) to its download size without fetching the full model bytes. For Hub repos, it reuses the existing API listing; for direct URLs or exact files, it issues a HEAD request to read the `Content-Length` header.

- **New `headContentLength()` helper**: Performs a HEAD request to a URL and safely extracts the `Content-Length` header, returning null if the size cannot be determined (request fails, header absent, or CORS blocks it).

- **Refactored `.onnx` file selection**: Extracted the logic for picking the largest `.onnx` file from a repo's sibling listing into a new `pickOnnxSibling()` function, which is now reused by both `findOnnxFile()` and `probeModelSize()`.

- **UI integration in `hf_load.mjs`**: Added `showSizeFor()` function that displays the model size in the status line. It's triggered when the user:
  - Selects a model from the dropdown
  - Commits a change to the reference text input (via blur or Enter)
  
  A monotonic token prevents stale size probes from overwriting the status line if the user changes the reference while a probe is in flight. The `loading` flag prevents size probes from interfering with active downloads.

- **Updated help text in `index.html`**: Clarified that the converter now shows download size before fetching.

## Implementation Details

- The `probeModelSize()` function returns an object with `{ size, name, repo?, file?, url? }`, where `size` is a byte count or null if unavailable.
- Size probes are non-blocking and gracefully degrade: if a size cannot be determined, the UI shows "size unavailable" rather than failing.
- The probe respects user intent: it only runs on explicit model selection or text input commit, not on every keystroke.
- Test coverage added for Hub API listing, HEAD requests, missing Content-Length headers, and repos with no `.onnx` files.

https://claude.ai/code/session_01BNN5ogZdrF9XLMxpp6ng4U