### PR TITLE
WASM UI: bake model sizes into models.json, fix Xet speed, show cache size

### DIFF
--- a/scripts/convertmodel/hf_load.mjs
+++ b/scripts/convertmodel/hf_load.mjs
@@ -22,8 +22,19 @@ const statusEl = document.getElementById("hf-status");
 const fileInput = document.getElementById("file-input");
 const logOutput = document.getElementById("log-output");
 const xetToggle = document.getElementById("hf-use-xet");
+const xetConcurrencyInput = document.getElementById("hf-xet-concurrency");
 const clearCacheBtn = document.getElementById("hf-clear-cache");
 const cacheSizeEl = document.getElementById("hf-cache-size");
+
+// How many parallel byte-range shards to read a Xet download in. XetBlob fetches
+// serially, so >1 shard is what actually parallelizes the transfer. Clamped to a
+// sane range; past ~10 the returns fade and the Hub may throttle.
+const XET_CONCURRENCY_MAX = 16;
+function xetConcurrency() {
+  const n = parseInt(xetConcurrencyInput && xetConcurrencyInput.value, 10);
+  if (!Number.isFinite(n) || n < 1) return 1;
+  return Math.min(n, XET_CONCURRENCY_MAX);
+}
 
 // The persistent chunk cache is created lazily on first Xet use.
 let xetCache = null;
@@ -246,6 +257,7 @@ async function doLoad() {
           onLog: log,
           onProgress,
           fetchImpl: cachingFetch,
+          concurrency: xetConcurrency(),
         }));
         if (hits > 0) log(`reused ${hits} cached chunk(s) (${humanBytes(hitBytes)})`);
       } catch (e) {

--- a/scripts/convertmodel/hf_load.mjs
+++ b/scripts/convertmodel/hf_load.mjs
@@ -11,6 +11,9 @@ import {
   fetchModelBytes,
   fetchModelBytesXet,
   probeModelSize,
+  listOnnxFiles,
+  parseRef,
+  fileUrl,
   humanBytes,
 } from "./hf_models.mjs";
 import { openXetCache, makeCachingFetch } from "./xet_cache.mjs";
@@ -25,6 +28,24 @@ const xetToggle = document.getElementById("hf-use-xet");
 const xetConcurrencyInput = document.getElementById("hf-xet-concurrency");
 const clearCacheBtn = document.getElementById("hf-clear-cache");
 const cacheSizeEl = document.getElementById("hf-cache-size");
+const fileRow = document.getElementById("hf-file-row");
+const fileSelect = document.getElementById("hf-file-select");
+const fileNote = document.getElementById("hf-file-note");
+
+// parseRef throws on empty/garbage; this never does, for use in event handlers.
+function safeParse(ref) {
+  try {
+    return parseRef((ref || "").trim());
+  } catch {
+    return null;
+  }
+}
+
+// True for a plain Hugging Face repo reference (no explicit file, not a direct
+// URL) — the only case where a file picker makes sense.
+function isPlainRepo(parsed) {
+  return !!(parsed && parsed.repo && !parsed.file && !parsed.url);
+}
 
 // How many parallel byte-range shards to read a Xet download in. XetBlob fetches
 // serially, so >1 shard is what actually parallelizes the transfer. Clamped to a
@@ -132,26 +153,124 @@ async function showSizeFor(ref, knownSize) {
   }
 }
 
+// --- File selection within a repo -----------------------------------------
+// When the reference is a plain repo, list its .onnx files so the user can pick
+// which one to convert (the largest is auto-detected and pre-selected). A
+// separate token guards against a slow listing landing after the ref changed.
+let fileListToken = 0;
+
+function hideFileRow() {
+  if (fileRow) fileRow.style.display = "none";
+  if (fileSelect) fileSelect.innerHTML = "";
+  if (fileNote) fileNote.textContent = "";
+}
+
+// Reflect the currently-selected file's size in the status line.
+function renderSizeForSelectedFile() {
+  if (loading || !fileSelect) return;
+  const opt = fileSelect.options[fileSelect.selectedIndex];
+  if (!opt) return;
+  const size = Number(opt.dataset.size) || 0;
+  renderSize(size || null, opt.value.split("/").pop());
+}
+
+// List a repo's .onnx files and populate the picker (largest first / selected).
+// `knownSize` (from models.json for a curated pick) is shown immediately for
+// snappiness while the listing loads.
+async function refreshFileList(repo, knownSize) {
+  const token = ++fileListToken;
+  if (knownSize) renderSize(knownSize, repo.replace(/^onnxmodelzoo\//, ""));
+  else if (statusEl) statusEl.textContent = "checking size…";
+  if (fileNote) fileNote.textContent = "listing files…";
+  if (fileRow) fileRow.style.display = "";
+  try {
+    const files = await listOnnxFiles(repo);
+    if (token !== fileListToken || loading) return;
+    if (!files.length) {
+      hideFileRow();
+      if (statusEl) statusEl.textContent = "no .onnx file found in repo";
+      return;
+    }
+    fileSelect.innerHTML = "";
+    files.forEach((f, i) => {
+      const opt = document.createElement("option");
+      opt.value = f.file;
+      opt.dataset.size = f.size || "";
+      const sz = f.size ? ` (${humanBytes(f.size)})` : "";
+      opt.textContent = `${f.file}${sz}${i === 0 ? " — auto (largest)" : ""}`;
+      fileSelect.appendChild(opt);
+    });
+    fileSelect.selectedIndex = 0; // largest, i.e. the auto-detected file
+    if (fileNote) {
+      fileNote.textContent =
+        files.length > 1
+          ? `${files.length} .onnx files; largest auto-detected`
+          : "1 .onnx file (auto-detected)";
+    }
+    if (fileRow) fileRow.style.display = "";
+    renderSizeForSelectedFile();
+  } catch (e) {
+    if (token !== fileListToken) return;
+    // Listing failed (CORS, offline, …) — hide the picker and fall back to a
+    // plain size probe so the user still sees something.
+    hideFileRow();
+    showSizeFor(repo);
+  }
+}
+
+// Handle a committed reference: repos get a file picker + size; a specific file
+// or direct URL just gets a size probe (no picker, the file is fixed).
+function onRefCommitted(ref, knownSize) {
+  const parsed = safeParse(ref);
+  if (isPlainRepo(parsed)) {
+    refreshFileList(parsed.repo, knownSize);
+  } else {
+    hideFileRow();
+    showSizeFor(ref);
+  }
+}
+
+// The effective reference to load: when a specific file is chosen for a plain
+// repo, resolve it to that file's URL so the download uses the picked file
+// instead of the auto-detected largest.
+function effectiveRef() {
+  const raw = ((refInput && refInput.value) || (select && select.value) || "").trim();
+  if (fileRow && fileRow.style.display !== "none" && fileSelect && fileSelect.value) {
+    const parsed = safeParse(raw);
+    if (isPlainRepo(parsed)) {
+      return fileUrl(parsed.repo, fileSelect.value);
+    }
+  }
+  return raw;
+}
+
 // Picking from the dropdown mirrors into the text box so the two never disagree
 // about what "Load" will fetch, and the user can tweak the id before loading.
-// Both a dropdown pick and a committed edit of the text box preview the size.
+// Both a dropdown pick and a committed edit of the text box preview the size and
+// (for a repo) the file picker.
 if (select && refInput) {
   select.addEventListener("change", () => {
     if (select.value) {
       refInput.value = select.value;
-      showSizeFor(select.value, curatedSizes.get(select.value));
+      onRefCommitted(select.value, curatedSizes.get(select.value));
     }
   });
 }
 // `change` fires on commit (blur / Enter), so partial keystrokes don't each
-// trigger a network probe; the text box is mirrored from the dropdown
-// programmatically, which does not fire `change`, so there's no double probe.
+// trigger a network call; the text box is mirrored from the dropdown
+// programmatically, which does not fire `change`, so there's no double request.
 if (refInput) {
-  refInput.addEventListener("change", () => showSizeFor(refInput.value));
+  refInput.addEventListener("change", () => onRefCommitted(refInput.value));
+}
+// Choosing a different file updates the previewed size; effectiveRef() picks it
+// up at load time.
+if (fileSelect) {
+  fileSelect.addEventListener("change", renderSizeForSelectedFile);
 }
 
 async function doLoad() {
-  const ref = ((refInput && refInput.value) || (select && select.value) || "").trim();
+  // Resolve to the picked file when one is chosen, else the raw repo id / URL.
+  const ref = effectiveRef();
   if (!ref) {
     log("enter a Hugging Face repo id or .onnx URL, or pick one from the list");
     return;
@@ -224,6 +343,7 @@ async function doLoad() {
     let usedXet = false;
     let netBytes = 0; // bytes actually pulled over the network (Xet path)
     let hitBytes = 0; // bytes served from the chunk cache (Xet path)
+    let settleWrites = null; // await the Xet cache's background writes before reading its size
     if (xetToggle && xetToggle.checked) {
       usedXet = true;
       // Experimental Xet path, with the persistent chunk cache. Any failure
@@ -252,6 +372,7 @@ async function doLoad() {
         getXetCache(),
         { onHit: (_k, n) => { hits += 1; hitBytes += n; }, onNetwork },
       );
+      settleWrites = cachingFetch.settled;
       try {
         ({ bytes, name } = await fetchModelBytesXet(ref, {
           onLog: log,
@@ -284,6 +405,15 @@ async function doLoad() {
       } else if (elapsed > 0) {
         log(`reconstructed entirely from the chunk cache (${humanBytes(hitBytes)}) ` +
             `in ${elapsed.toFixed(1)}s — no network transfer`);
+      }
+      // The cache writes are backgrounded during download; wait for them so the
+      // readout reflects the chunks this download just added.
+      if (settleWrites) {
+        try {
+          await settleWrites();
+        } catch {
+          // ignore — refresh anyway with whatever landed
+        }
       }
       refreshCacheSize();
     } else if (elapsed > 0 && bytes && bytes.length) {

--- a/scripts/convertmodel/hf_load.mjs
+++ b/scripts/convertmodel/hf_load.mjs
@@ -23,6 +23,7 @@ const fileInput = document.getElementById("file-input");
 const logOutput = document.getElementById("log-output");
 const xetToggle = document.getElementById("hf-use-xet");
 const clearCacheBtn = document.getElementById("hf-clear-cache");
+const cacheSizeEl = document.getElementById("hf-cache-size");
 
 // The persistent chunk cache is created lazily on first Xet use.
 let xetCache = null;
@@ -31,39 +32,71 @@ function getXetCache() {
   return xetCache;
 }
 
+// Show how much the Xet chunk cache currently holds, next to the clear button.
+// Only touches (and thus lazily opens) the cache when there's a place to show
+// it, so a user who never uses Xet doesn't open the IndexedDB store.
+async function refreshCacheSize() {
+  if (!cacheSizeEl) return;
+  try {
+    const { bytes, count } = await getXetCache().size();
+    cacheSizeEl.textContent = count
+      ? `chunk cache: ${humanBytes(bytes)} in ${count} chunk${count === 1 ? "" : "s"}`
+      : "chunk cache: empty";
+  } catch {
+    cacheSizeEl.textContent = "";
+  }
+}
+
 const log = (msg) => {
   if (!logOutput) return;
   logOutput.value += msg + "\n";
   logOutput.scrollTop = logOutput.scrollHeight;
 };
 
-// Fill the dropdown with the curated onnxmodelzoo set. The list is advisory —
-// the free-text box accepts any repo id or .onnx URL regardless.
-loadModelList().then((ids) => {
+// Curated model id -> download size (bytes), from models.json. Lets a dropdown
+// pick show its size instantly, with no network probe.
+const curatedSizes = new Map();
+
+// Fill the dropdown with the curated onnxmodelzoo set, showing each model's
+// download size (from models.json) right in the option so sizes are visible
+// before picking. The list is advisory — the free-text box accepts any repo id
+// or .onnx URL regardless.
+loadModelList().then((models) => {
   if (!select) return;
-  if (!ids.length) {
+  if (!models.length) {
     const opt = document.createElement("option");
     opt.value = "";
     opt.textContent = "(model list unavailable — type a repo id or URL)";
     select.appendChild(opt);
     return;
   }
-  for (const id of ids) {
+  for (const { id, size } of models) {
+    if (size) curatedSizes.set(id, size);
     const opt = document.createElement("option");
     opt.value = id;
-    opt.textContent = id.replace(/^onnxmodelzoo\//, "");
+    const shortName = id.replace(/^onnxmodelzoo\//, "");
+    opt.textContent = size ? `${shortName} (${humanBytes(size)})` : shortName;
     select.appendChild(opt);
   }
 });
 
 // Show the download size for the currently-referenced model *before* fetching,
-// so a user can see how big it is before committing to the download. The size
-// comes from the Hub API listing (for a repo id) or a HEAD request (for an exact
-// file / direct URL). A monotonic token guards against a slow probe overwriting
-// the status line for a reference the user has since changed.
+// so a user can see how big it is before committing to the download. A curated
+// model's size is known up front (from models.json) and shown with no network
+// call; otherwise the size comes from the Hub API listing (for a repo id) or a
+// HEAD request (for an exact file / direct URL). A monotonic token guards
+// against a slow probe overwriting the status line for a reference the user has
+// since changed.
 let probeToken = 0;
 let loading = false; // a download is in flight; don't let a probe touch the status
-async function showSizeFor(ref) {
+function renderSize(size, name) {
+  if (!statusEl) return;
+  const label = name ? `${name} — ` : "";
+  statusEl.textContent = size
+    ? `${label}≈ ${humanBytes(size)} to download`
+    : `${label}size unavailable`;
+}
+async function showSizeFor(ref, knownSize) {
   if (loading) return;
   ref = (ref || "").trim();
   const token = ++probeToken;
@@ -71,16 +104,16 @@ async function showSizeFor(ref) {
     if (statusEl) statusEl.textContent = "";
     return;
   }
+  // A curated pick already knows its size — show it without touching the network.
+  if (knownSize) {
+    renderSize(knownSize, ref.replace(/^onnxmodelzoo\//, ""));
+    return;
+  }
   if (statusEl) statusEl.textContent = "checking size…";
   try {
     const { size, name } = await probeModelSize(ref);
     if (token !== probeToken) return; // a newer reference superseded this probe
-    if (statusEl) {
-      const label = name ? `${name} — ` : "";
-      statusEl.textContent = size
-        ? `${label}≈ ${humanBytes(size)} to download`
-        : `${label}size unavailable`;
-    }
+    renderSize(size, name);
   } catch (e) {
     if (token !== probeToken) return;
     if (statusEl) statusEl.textContent = "size unavailable — see console output";
@@ -95,7 +128,7 @@ if (select && refInput) {
   select.addEventListener("change", () => {
     if (select.value) {
       refInput.value = select.value;
-      showSizeFor(select.value);
+      showSizeFor(select.value, curatedSizes.get(select.value));
     }
   });
 }
@@ -136,6 +169,11 @@ async function doLoad() {
     let lastAt = 0;
     let lastLoaded = 0;
     let emaRate = 0; // bytes/sec
+    // The displayed speed defaults to the streamed-bytes rate, which equals real
+    // network throughput on the direct-download path. The Xet path overrides it
+    // (see below) with a rate measured from actual network bytes, because its
+    // streamed bytes include cached/deduplicated chunks that never hit the wire.
+    let speedFn = () => emaRate;
     const resetProgress = () => {
       lastShown = -1;
       startedAt = lastAt = performance.now();
@@ -154,7 +192,8 @@ async function doLoad() {
         lastAt = now;
         lastLoaded = loaded;
       }
-      const speed = emaRate > 0 ? ` — ${humanBytes(emaRate)}/s` : "";
+      const rate = speedFn();
+      const speed = rate > 0 ? ` — ${humanBytes(rate)}/s` : "";
 
       if (total > 0) {
         const pct = Math.floor((loaded / total) * 100);
@@ -171,16 +210,36 @@ async function doLoad() {
     };
     let bytes;
     let name;
+    let usedXet = false;
+    let netBytes = 0; // bytes actually pulled over the network (Xet path)
+    let hitBytes = 0; // bytes served from the chunk cache (Xet path)
     if (xetToggle && xetToggle.checked) {
+      usedXet = true;
       // Experimental Xet path, with the persistent chunk cache. Any failure
       // (non-Xet repo, CORS on the CAS endpoints, …) falls back to the direct
       // download so the toggle can never break loading.
       let hits = 0;
-      let hitBytes = 0;
+      // Smoothed rate over *network* bytes only, so cache hits / dedup don't
+      // inflate the reported speed (the reconstructed-bytes rate would).
+      let netLastAt = performance.now();
+      let netLastBytes = 0;
+      let netEma = 0;
+      const onNetwork = (n) => {
+        netBytes += n;
+        const now = performance.now();
+        const dt = (now - netLastAt) / 1000;
+        if (dt > 0 && netBytes > netLastBytes) {
+          const inst = (netBytes - netLastBytes) / dt;
+          netEma = netEma === 0 ? inst : netEma * 0.7 + inst * 0.3;
+          netLastAt = now;
+          netLastBytes = netBytes;
+        }
+      };
+      speedFn = () => netEma;
       const cachingFetch = makeCachingFetch(
         globalThis.fetch.bind(globalThis),
         getXetCache(),
-        { onHit: (_k, n) => { hits += 1; hitBytes += n; } },
+        { onHit: (_k, n) => { hits += 1; hitBytes += n; }, onNetwork },
       );
       try {
         ({ bytes, name } = await fetchModelBytesXet(ref, {
@@ -191,15 +250,31 @@ async function doLoad() {
         if (hits > 0) log(`reused ${hits} cached chunk(s) (${humanBytes(hitBytes)})`);
       } catch (e) {
         log(`Xet path unavailable (${e && e.message ? e.message : e}); falling back to direct download`);
+        // Back to the direct path: its streamed bytes are the network bytes, so
+        // the default streamed-rate speed is accurate again.
+        usedXet = false;
+        speedFn = () => emaRate;
         resetProgress();
         ({ bytes, name } = await fetchModelBytes(ref, log, onProgress));
       }
     } else {
       ({ bytes, name } = await fetchModelBytes(ref, log, onProgress));
     }
-    // Report the average download speed over the whole transfer.
+    // Report the average download speed over the whole transfer. For Xet, the
+    // honest figure is over the bytes that actually crossed the network — cached
+    // / deduplicated chunks are reconstructed locally, not downloaded.
     const elapsed = (performance.now() - startedAt) / 1000;
-    if (elapsed > 0 && bytes && bytes.length) {
+    if (usedXet) {
+      if (netBytes > 0 && elapsed > 0) {
+        const cached = hitBytes > 0 ? ` (+${humanBytes(hitBytes)} from cache)` : "";
+        log(`downloaded ${humanBytes(netBytes)} over the network${cached} — ` +
+            `average ${humanBytes(netBytes / elapsed)}/s over ${elapsed.toFixed(1)}s`);
+      } else if (elapsed > 0) {
+        log(`reconstructed entirely from the chunk cache (${humanBytes(hitBytes)}) ` +
+            `in ${elapsed.toFixed(1)}s — no network transfer`);
+      }
+      refreshCacheSize();
+    } else if (elapsed > 0 && bytes && bytes.length) {
       log(`download average ${humanBytes(bytes.length / elapsed)}/s over ${elapsed.toFixed(1)}s`);
     }
     if (statusEl) statusEl.textContent = "converting…";
@@ -248,7 +323,18 @@ if (clearCacheBtn) {
     } catch (e) {
       log("could not clear Xet cache: " + (e && e.message ? e.message : e));
     }
+    refreshCacheSize();
   });
+}
+
+// Show the current cache size once the user opts into Xet (checking the box),
+// so the readout appears without forcing the IndexedDB store open on every page
+// load. If the box starts checked (browser-restored state), show it up front.
+if (xetToggle) {
+  xetToggle.addEventListener("change", () => {
+    if (xetToggle.checked) refreshCacheSize();
+  });
+  if (xetToggle.checked) refreshCacheSize();
 }
 
 // index.html fires this once a conversion finishes; clear the "converting…"

--- a/scripts/convertmodel/hf_models.mjs
+++ b/scripts/convertmodel/hf_models.mjs
@@ -22,16 +22,24 @@ const MODEL_LIST_SOURCES = [
   "https://raw.githubusercontent.com/onnxsim/onnxsim/master/scripts/regression/models.json",
 ];
 
-// Fetch the curated regression model ids for the dropdown. Returns [] (rather
-// than throwing) when no source is reachable, so the free-text box still works.
+// Fetch the curated regression model set for the dropdown, as
+// [{ id, size }] where `size` is the byte size of the repo's largest .onnx
+// (baked into models.json by select_models.py --refresh-sizes) or null when the
+// list predates that field. Returns [] (rather than throwing) when no source is
+// reachable, so the free-text box still works.
 export async function loadModelList() {
   for (const src of MODEL_LIST_SOURCES) {
     try {
       const r = await fetch(src);
       if (!r.ok) continue;
       const data = await r.json();
-      const ids = (data.models || []).map((m) => m.id).filter(Boolean);
-      if (ids.length) return ids;
+      const models = (data.models || [])
+        .filter((m) => m && m.id)
+        .map((m) => ({
+          id: m.id,
+          size: Number.isFinite(m.size) && m.size > 0 ? m.size : null,
+        }));
+      if (models.length) return models;
     } catch {
       // try the next source
     }

--- a/scripts/convertmodel/hf_models.mjs
+++ b/scripts/convertmodel/hf_models.mjs
@@ -287,15 +287,73 @@ async function readBlobWithProgress(blob, onProgress) {
   return bytes;
 }
 
+// Read a Blob in `concurrency` parallel shards, into one preallocated buffer.
+//
+// The in-browser Xet client (@huggingface/hub's XetBlob) fetches a file's
+// reconstruction terms strictly serially, so a single read never uses more than
+// one connection. But `blob.slice(a, b)` re-fetches reconstruction scoped to
+// `bytes=a-(b-1)`, so a sliced blob downloads only its sub-range — reading N
+// non-overlapping, contiguous slices concurrently gives N-way parallelism while
+// reusing all of XetBlob's reconstruction + decompression. Each shard streams
+// its range in order, so writing at a running offset from the shard's start
+// reassembles the file with no ordering logic; shards write disjoint regions of
+// `out`. Blocks straddling a shard boundary may be fetched by both neighbors —
+// a little redundant transfer, deduplicated by the chunk cache when keys line up.
+// Exported for unit testing (browser-only in practice).
+export async function readBlobSharded(blob, concurrency, onProgress = () => {}) {
+  const total = blob.size || 0;
+  const out = new Uint8Array(total);
+  const shardCount = Math.min(concurrency, total);
+  const step = Math.ceil(total / shardCount);
+  const loadedPerShard = [];
+  const report = () => {
+    let loaded = 0;
+    for (const n of loadedPerShard) loaded += n;
+    onProgress({ loaded, total });
+  };
+  const tasks = [];
+  for (let start = 0; start < total; start += step) {
+    const end = Math.min(start + step, total);
+    const idx = loadedPerShard.length;
+    loadedPerShard.push(0);
+    tasks.push(
+      (async () => {
+        const part = blob.slice(start, end);
+        if (typeof part.stream !== "function") {
+          const buf = new Uint8Array(await part.arrayBuffer());
+          out.set(buf, start);
+          loadedPerShard[idx] = buf.length;
+          report();
+          return;
+        }
+        const reader = part.stream().getReader();
+        let offset = start;
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          out.set(value, offset);
+          offset += value.length;
+          loadedPerShard[idx] = offset - start;
+          report();
+        }
+      })(),
+    );
+  }
+  await Promise.all(tasks);
+  return out;
+}
+
 // EXPERIMENTAL: download a model over the Hugging Face Xet protocol via
 // @huggingface/hub's downloadFile, which reconstructs the file from
 // content-addressed blocks. Pass `fetchImpl` (e.g. the caching fetch from
-// xet_cache.mjs) to persist those blocks across loads. Only Hub repos are
+// xet_cache.mjs) to persist those blocks across loads. `concurrency` > 1 reads
+// the reconstructed file in that many parallel byte-range shards (see
+// readBlobSharded) to work around XetBlob's serial fetching. Only Hub repos are
 // supported (not arbitrary URLs). Returns { bytes, name, repo }; the caller is
 // expected to fall back to fetchModelBytes() on any failure (CORS, unsupported).
 export async function fetchModelBytesXet(
   ref,
-  { onLog = () => {}, onProgress = () => {}, fetchImpl } = {},
+  { onLog = () => {}, onProgress = () => {}, fetchImpl, concurrency = 1 } = {},
 ) {
   const parsed = parseRef(ref);
   if (!parsed.repo) {
@@ -319,7 +377,14 @@ export async function fetchModelBytesXet(
   if (!blob) throw new Error(`file not found: ${parsed.repo}/${file}`);
 
   const name = file.split("/").pop();
-  const bytes = await readBlobWithProgress(blob, onProgress);
+  // Shard only when it can help: more than one shard requested, a known size to
+  // split on, and a sliceable blob. Otherwise fall back to a single stream.
+  const shards = Math.max(1, Math.floor(concurrency) || 1);
+  const canShard = shards > 1 && blob.size > 0 && typeof blob.slice === "function";
+  if (canShard) onLog(`reading via Xet in ${Math.min(shards, blob.size)} parallel shards…`);
+  const bytes = canShard
+    ? await readBlobSharded(blob, shards, onProgress)
+    : await readBlobWithProgress(blob, onProgress);
   onLog(`downloaded ${name} (${bytes.length.toLocaleString()} bytes via Xet)`);
   return { bytes, name, repo: parsed.repo };
 }

--- a/scripts/convertmodel/hf_models.mjs
+++ b/scripts/convertmodel/hf_models.mjs
@@ -107,6 +107,21 @@ function pickOnnxSibling(siblings, repo) {
   return { sibling: onnx[0], count: onnx.length };
 }
 
+// List a repo's .onnx files as [{ file, size }], largest first — so the UI can
+// let the user pick which file to convert instead of always taking the auto-
+// detected (largest) one. `size` is a byte count or null when undisclosed.
+// Returns [] when the repo has no .onnx file (the caller decides what to do).
+export async function listOnnxFiles(repo) {
+  const siblings = await repoSiblings(repo);
+  return siblings
+    .filter((s) => s.rfilename && s.rfilename.endsWith(".onnx"))
+    .map((s) => ({
+      file: s.rfilename,
+      size: Number.isFinite(s.size) && s.size > 0 ? s.size : null,
+    }))
+    .sort((a, b) => (b.size || 0) - (a.size || 0));
+}
+
 // Pick the main .onnx file in a repo (largest, matching the regression workers)
 // and warn when the graph relies on external-data blobs the in-browser,
 // single-file converter can't load.

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -317,6 +317,10 @@
                     Use <a href="https://huggingface.co/docs/xet/en/index" target="_blank" rel="noopener">Xet</a>
                     protocol (experimental)
                 </label>
+                <label for="hf-xet-concurrency" style="margin-left: 0.6em;">parallel shards</label>
+                <input type="number" id="hf-xet-concurrency" value="8" min="1" max="16" step="1"
+                       style="width: 3.5em;"
+                       title="How many parallel byte-range shards to read a Xet download in. XetBlob fetches serially, so this is what parallelizes the transfer; ~10 or fewer is usually best.">
                 <button id="hf-clear-cache" type="button">clear chunk cache</button>
                 <span id="hf-cache-size" style="color: #666; font-size: 0.85em; margin-left: 0.4em;"></span>
                 <div style="color: #666; font-size: 0.85em; margin-top: 0.2em;">
@@ -326,14 +330,14 @@
                     back to the direct download automatically if the Xet path
                     isn't available (e.g. a non-Xet repo or a CORS block).
                     <br>
-                    <b>For a one-off download, leave this off</b> — the plain
-                    download (the default) streams over a single connection and
-                    is usually faster. The in-browser Xet client fetches chunks
-                    <i>serially</i>
-                    (<a href="https://github.com/huggingface/huggingface.js/blob/main/packages/hub/src/utils/XetBlob.ts" target="_blank" rel="noopener"><code>XetBlob</code></a>
-                    has no parallel-download option), so its payoff is cache
-                    reuse across repeated / overlapping loads, not raw
-                    cold-download speed.
+                    The in-browser Xet client
+                    (<a href="https://github.com/huggingface/huggingface.js/blob/main/packages/hub/src/utils/XetBlob.ts" target="_blank" rel="noopener"><code>XetBlob</code></a>)
+                    fetches a file <i>serially</i>, so a single read uses one
+                    connection. <b>parallel shards</b> works around that by
+                    reading the file in that many concurrent byte-range slices —
+                    set it to saturate your link (~10 or fewer is usually best;
+                    <code>1</code> disables sharding). Xet's extra payoff is chunk
+                    dedup / cache reuse across repeated or overlapping loads.
                 </div>
             </div>
         </div>

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -318,6 +318,7 @@
                     protocol (experimental)
                 </label>
                 <button id="hf-clear-cache" type="button">clear chunk cache</button>
+                <span id="hf-cache-size" style="color: #666; font-size: 0.85em; margin-left: 0.4em;"></span>
                 <div style="color: #666; font-size: 0.85em; margin-top: 0.2em;">
                     Downloads via <code>@huggingface/hub</code>, reconstructing the
                     file from content-addressed chunks and caching them in

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -325,6 +325,15 @@
                     IndexedDB so repeated / overlapping loads reuse them. Falls
                     back to the direct download automatically if the Xet path
                     isn't available (e.g. a non-Xet repo or a CORS block).
+                    <br>
+                    <b>For a one-off download, leave this off</b> — the plain
+                    download (the default) streams over a single connection and
+                    is usually faster. The in-browser Xet client fetches chunks
+                    <i>serially</i>
+                    (<a href="https://github.com/huggingface/huggingface.js/blob/main/packages/hub/src/utils/XetBlob.ts" target="_blank" rel="noopener"><code>XetBlob</code></a>
+                    has no parallel-download option), so its payoff is cache
+                    reuse across repeated / overlapping loads, not raw
+                    cold-download speed.
                 </div>
             </div>
         </div>

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -302,6 +302,11 @@
                    disabled title="Loading WebAssembly runtime…" />
             <button id="hf-load-button" type="button" disabled title="Loading WebAssembly runtime…">Load</button>
             <span id="hf-status"></span>
+            <div id="hf-file-row" style="margin-top: 0.25em; display: none;">
+                <label for="hf-file-select">file</label>
+                <select id="hf-file-select"></select>
+                <span id="hf-file-note" style="color: #666; font-size: 0.85em; margin-left: 0.25em;"></span>
+            </div>
             <div style="color: #666; font-size: 0.85em; margin-top: 0.25em;">
                 Fetches the model straight from the Hugging Face Hub in your
                 browser (nothing is uploaded), then runs it through the same
@@ -309,13 +314,15 @@
                 to the <code>onnxmodelzoo</code> org; any <code>owner/repo</code>
                 or direct <code>.onnx</code> URL works too. Picking a model (or
                 entering a repo id / URL) shows its download size first, so you
-                can see how big it is before fetching.
+                can see how big it is before fetching. When a repo holds more than
+                one <code>.onnx</code>, the largest is auto-detected; use the
+                <b>file</b> selector to convert a different one.
             </div>
             <div style="margin-top: 0.25em;">
-                <input type="checkbox" id="hf-use-xet">
+                <input type="checkbox" id="hf-use-xet" checked>
                 <label for="hf-use-xet">
                     Use <a href="https://huggingface.co/docs/xet/en/index" target="_blank" rel="noopener">Xet</a>
-                    protocol (experimental)
+                    protocol (default; falls back to a direct download)
                 </label>
                 <label for="hf-xet-concurrency" style="margin-left: 0.6em;">parallel shards</label>
                 <input type="number" id="hf-xet-concurrency" value="8" min="1" max="16" step="1"
@@ -326,18 +333,18 @@
                 <div style="color: #666; font-size: 0.85em; margin-top: 0.2em;">
                     Downloads via <code>@huggingface/hub</code>, reconstructing the
                     file from content-addressed chunks and caching them in
-                    IndexedDB so repeated / overlapping loads reuse them. Falls
-                    back to the direct download automatically if the Xet path
-                    isn't available (e.g. a non-Xet repo or a CORS block).
+                    IndexedDB so repeated / overlapping loads reuse them. On by
+                    default; falls back to a direct download automatically if the
+                    Xet path isn't available (e.g. a non-Xet repo or a CORS block).
                     <br>
                     The in-browser Xet client
                     (<a href="https://github.com/huggingface/huggingface.js/blob/main/packages/hub/src/utils/XetBlob.ts" target="_blank" rel="noopener"><code>XetBlob</code></a>)
-                    fetches a file <i>serially</i>, so a single read uses one
-                    connection. <b>parallel shards</b> works around that by
-                    reading the file in that many concurrent byte-range slices —
-                    set it to saturate your link (~10 or fewer is usually best;
-                    <code>1</code> disables sharding). Xet's extra payoff is chunk
-                    dedup / cache reuse across repeated or overlapping loads.
+                    fetches a file <i>serially</i>, so <b>parallel shards</b> reads
+                    it in that many concurrent byte-range slices to saturate your
+                    link — this is what makes Xet fast enough to be the default
+                    (~10 or fewer is usually best; <code>1</code> disables
+                    sharding). Xet also gives chunk dedup / cache reuse across
+                    repeated or overlapping loads.
                 </div>
             </div>
         </div>

--- a/scripts/convertmodel/test/hf_models.test.mjs
+++ b/scripts/convertmodel/test/hf_models.test.mjs
@@ -11,6 +11,7 @@ import {
   loadModelList,
   fetchModelBytes,
   probeModelSize,
+  listOnnxFiles,
   readBlobSharded,
   humanBytes,
 } from "../hf_models.mjs";
@@ -293,6 +294,42 @@ await acheck("probeModelSize returns a null size when Content-Length is absent",
     assert.equal(info.size, null);
     assert.equal(info.name, "net.onnx");
   });
+});
+
+await acheck("listOnnxFiles returns .onnx files largest-first with sizes", async () => {
+  const api = "https://huggingface.co/api/models/onnxmodelzoo/foo?blobs=true";
+  await withFetch(
+    {
+      [api]: {
+        json: {
+          siblings: [
+            { rfilename: "small.onnx", size: 10 },
+            { rfilename: "big.onnx", size: 999 },
+            { rfilename: "readme.md", size: 1 },
+            { rfilename: "nosize.onnx" },
+          ],
+        },
+      },
+    },
+    async () => {
+      const files = await listOnnxFiles("onnxmodelzoo/foo");
+      assert.deepEqual(files, [
+        { file: "big.onnx", size: 999 },
+        { file: "small.onnx", size: 10 },
+        { file: "nosize.onnx", size: null },
+      ]);
+    },
+  );
+});
+
+await acheck("listOnnxFiles returns [] for a repo with no .onnx", async () => {
+  const api = "https://huggingface.co/api/models/onnxmodelzoo/empty?blobs=true";
+  await withFetch(
+    { [api]: { json: { siblings: [{ rfilename: "readme.md", size: 1 }] } } },
+    async () => {
+      assert.deepEqual(await listOnnxFiles("onnxmodelzoo/empty"), []);
+    },
+  );
 });
 
 await acheck("probeModelSize surfaces a repo with no .onnx", async () => {

--- a/scripts/convertmodel/test/hf_models.test.mjs
+++ b/scripts/convertmodel/test/hf_models.test.mjs
@@ -11,6 +11,7 @@ import {
   loadModelList,
   fetchModelBytes,
   probeModelSize,
+  readBlobSharded,
   humanBytes,
 } from "../hf_models.mjs";
 
@@ -302,6 +303,59 @@ await acheck("probeModelSize surfaces a repo with no .onnx", async () => {
       await assert.rejects(probeModelSize("empty"), /no \.onnx file found/);
     },
   );
+});
+
+// A minimal Blob-like whose slice(a,b) streams that sub-range in small chunks,
+// mirroring how XetBlob.slice() yields only its byte range.
+function fakeBlob(bytes, chunk = 3) {
+  const make = (buf) => ({
+    size: buf.length,
+    stream() {
+      let i = 0;
+      return {
+        getReader: () => ({
+          read: async () => {
+            if (i >= buf.length) return { done: true, value: undefined };
+            const value = buf.slice(i, i + chunk);
+            i += value.length;
+            return { done: false, value };
+          },
+        }),
+      };
+    },
+  });
+  return {
+    size: bytes.length,
+    slice: (start, end) => make(bytes.slice(start, end)),
+  };
+}
+
+await acheck("readBlobSharded reassembles shards in order", async () => {
+  const data = new Uint8Array(20);
+  for (let i = 0; i < data.length; i++) data[i] = i;
+  for (const k of [1, 3, 4, 7, 100]) {
+    const progress = [];
+    const out = await readBlobSharded(fakeBlob(data), k, (p) => progress.push(p));
+    assert.equal(out.length, data.length);
+    assert.deepEqual(Array.from(out), Array.from(data), `k=${k}`);
+    // Progress ends at the full size, never exceeding it.
+    const last = progress[progress.length - 1];
+    assert.deepEqual(last, { loaded: data.length, total: data.length }, `k=${k} progress`);
+    assert.ok(progress.every((p) => p.loaded <= p.total));
+  }
+});
+
+await acheck("readBlobSharded falls back to arrayBuffer without a stream", async () => {
+  const data = new Uint8Array([5, 6, 7, 8, 9]);
+  const blob = {
+    size: data.length,
+    slice: (start, end) => ({
+      size: end - start,
+      arrayBuffer: async () => data.slice(start, end).buffer,
+    }),
+  };
+  const out = await readBlobSharded(blob, 2);
+  assert.deepEqual(Array.from(out), Array.from(data));
 });
 
 console.log(`\n${passed} checks passed`);

--- a/scripts/convertmodel/test/hf_models.test.mjs
+++ b/scripts/convertmodel/test/hf_models.test.mjs
@@ -124,16 +124,24 @@ check("fileUrl percent-encodes each path segment", () => {
   );
 });
 
-await acheck("loadModelList reads ./models.json first", async () => {
+await acheck("loadModelList reads ./models.json first, carrying sizes", async () => {
   await withFetch(
     {
       "./models.json": {
-        json: { models: [{ id: "onnxmodelzoo/a" }, { id: "onnxmodelzoo/b" }] },
+        json: {
+          models: [
+            { id: "onnxmodelzoo/a", size: 1234 },
+            { id: "onnxmodelzoo/b" },
+          ],
+        },
       },
     },
     async () => {
-      const ids = await loadModelList();
-      assert.deepEqual(ids, ["onnxmodelzoo/a", "onnxmodelzoo/b"]);
+      const models = await loadModelList();
+      assert.deepEqual(models, [
+        { id: "onnxmodelzoo/a", size: 1234 },
+        { id: "onnxmodelzoo/b", size: null },
+      ]);
     },
   );
 });

--- a/scripts/convertmodel/test/xet_cache.test.mjs
+++ b/scripts/convertmodel/test/xet_cache.test.mjs
@@ -117,6 +117,22 @@ await acheck("fires onHit / onMiss / onNetwork hooks", async () => {
   assert.deepEqual(events, [["miss"], ["network", 3], ["hit", 3]]);
 });
 
+await acheck("does not block the response on a slow cache write", async () => {
+  // A put that never resolves must not stall the download: the block is cached
+  // in the background, off the critical path, so serving the response can't wait
+  // on IndexedDB's write throughput. If the write were awaited, this would hang.
+  const cache = {
+    get: async () => null,
+    put: () => new Promise(() => {}), // never settles
+  };
+  const realFetch = async () =>
+    new Response(new Uint8Array([1, 2, 3]).buffer, { status: 206 });
+  const f = makeCachingFetch(realFetch, cache);
+  const r = await f("https://cas.example/blk/slow", { headers: { Range: "bytes=0-2" } });
+  assert.equal(r.status, 206);
+  assert.deepEqual(Array.from(new Uint8Array(await r.arrayBuffer())), [1, 2, 3]);
+});
+
 await acheck("a cache read error falls back to the network", async () => {
   const cache = {
     get: async () => {

--- a/scripts/convertmodel/test/xet_cache.test.mjs
+++ b/scripts/convertmodel/test/xet_cache.test.mjs
@@ -133,6 +133,28 @@ await acheck("does not block the response on a slow cache write", async () => {
   assert.deepEqual(Array.from(new Uint8Array(await r.arrayBuffer())), [1, 2, 3]);
 });
 
+await acheck("settled() waits for the background cache write to finish", async () => {
+  // The write is off the download path, but settled() lets a caller (e.g. the
+  // cache-size readout) wait until it lands.
+  let resolvePut;
+  const cache = {
+    get: async () => null,
+    put: () => new Promise((res) => (resolvePut = res)),
+  };
+  const realFetch = async () =>
+    new Response(new Uint8Array([1, 2]).buffer, { status: 206 });
+  const f = makeCachingFetch(realFetch, cache);
+  await f("https://cas.example/blk/s", { headers: { Range: "bytes=0-1" } });
+
+  const order = [];
+  const settled = f.settled().then(() => order.push("settled"));
+  await new Promise((r) => setTimeout(r, 5));
+  order.push("tick");
+  resolvePut();
+  await settled;
+  assert.deepEqual(order, ["tick", "settled"]); // settled resolved only after put
+});
+
 await acheck("a cache read error falls back to the network", async () => {
   const cache = {
     get: async () => {

--- a/scripts/convertmodel/test/xet_cache.test.mjs
+++ b/scripts/convertmodel/test/xet_cache.test.mjs
@@ -98,19 +98,23 @@ await acheck("passes through non-cacheable requests untouched", async () => {
   assert.equal(cache._map.size, 0);
 });
 
-await acheck("fires onHit / onMiss hooks", async () => {
+await acheck("fires onHit / onMiss / onNetwork hooks", async () => {
   const cache = mapCache();
   const realFetch = async () =>
-    new Response(new Uint8Array([9]).buffer, { status: 206 });
+    new Response(new Uint8Array([9, 9, 9]).buffer, { status: 206 });
   const events = [];
   const f = makeCachingFetch(realFetch, cache, {
     onHit: (_k, n) => events.push(["hit", n]),
     onMiss: () => events.push(["miss"]),
+    onNetwork: (n) => events.push(["network", n]),
   });
   const url = "https://cas.example/blk/z";
-  await f(url, { headers: { Range: "bytes=0-0" } });
-  await f(url, { headers: { Range: "bytes=0-0" } });
-  assert.deepEqual(events, [["miss"], ["hit", 1]]);
+  await f(url, { headers: { Range: "bytes=0-2" } });
+  await f(url, { headers: { Range: "bytes=0-2" } });
+  // A miss reports the bytes fetched over the network; the subsequent hit does
+  // not fire onNetwork (nothing crossed the wire) — the basis for the honest
+  // Xet download-speed figure.
+  assert.deepEqual(events, [["miss"], ["network", 3], ["hit", 3]]);
 });
 
 await acheck("a cache read error falls back to the network", async () => {

--- a/scripts/convertmodel/xet_cache.mjs
+++ b/scripts/convertmodel/xet_cache.mjs
@@ -90,7 +90,12 @@ export function isCacheable(url, method, rangeHeader) {
 // chunks never cross the network). A cache failure never breaks the request — it
 // just falls back to the network.
 export function makeCachingFetch(realFetch, cache, hooks = {}) {
-  return async (input, init) => {
+  // Background cache writes in flight. `fetchImpl.settled()` resolves once they
+  // all finish, so a caller can read an accurate cache size right after a
+  // download (the writes are deliberately not awaited on the download path).
+  const pendingWrites = new Set();
+
+  const fetchImpl = async (input, init) => {
     const { url, method, headers } = reqInfo(input, init);
     const range = headerGet(headers, "range");
     if (!isCacheable(url, method, range)) {
@@ -119,17 +124,24 @@ export function makeCachingFetch(realFetch, cache, hooks = {}) {
         // writes per object store and structured-cloning multi-MB blocks is
         // slow, so awaiting the write here would funnel even parallel range
         // fetches through IDB's write throughput and throttle the download.
-        // Serving `resp` doesn't depend on the block being stored.
+        // Serving `resp` doesn't depend on the block being stored. Tracked in
+        // `pendingWrites` so settled() can report when the cache is consistent.
         const entry = { status: resp.status, headers: pickHeaders(resp.headers), body };
-        Promise.resolve(cache.put(key, entry)).catch(() => {
+        const write = Promise.resolve(cache.put(key, entry)).catch(() => {
           // Non-fatal: the block just won't be cached for next time.
         });
+        pendingWrites.add(write);
+        write.then(() => pendingWrites.delete(write));
       } catch {
         // Non-fatal: serve the live response even if reading the body failed.
       }
     }
     return resp;
   };
+
+  // Resolve once every background cache write started so far has completed.
+  fetchImpl.settled = () => Promise.all([...pendingWrites]);
+  return fetchImpl;
 }
 
 // An IndexedDB-backed cache. Falls back to an in-memory Map when IndexedDB is

--- a/scripts/convertmodel/xet_cache.mjs
+++ b/scripts/convertmodel/xet_cache.mjs
@@ -115,13 +115,17 @@ export function makeCachingFetch(realFetch, cache, hooks = {}) {
       try {
         const body = await resp.clone().arrayBuffer();
         if (hooks.onNetwork) hooks.onNetwork(body.byteLength);
-        await cache.put(key, {
-          status: resp.status,
-          headers: pickHeaders(resp.headers),
-          body,
+        // Persist in the background — do NOT await it. IndexedDB serializes
+        // writes per object store and structured-cloning multi-MB blocks is
+        // slow, so awaiting the write here would funnel even parallel range
+        // fetches through IDB's write throughput and throttle the download.
+        // Serving `resp` doesn't depend on the block being stored.
+        const entry = { status: resp.status, headers: pickHeaders(resp.headers), body };
+        Promise.resolve(cache.put(key, entry)).catch(() => {
+          // Non-fatal: the block just won't be cached for next time.
         });
       } catch {
-        // Non-fatal: serve the live response even if caching failed.
+        // Non-fatal: serve the live response even if reading the body failed.
       }
     }
     return resp;

--- a/scripts/convertmodel/xet_cache.mjs
+++ b/scripts/convertmodel/xet_cache.mjs
@@ -83,9 +83,12 @@ export function isCacheable(url, method, rangeHeader) {
 }
 
 // Wrap a fetch so cacheable requests are served from / stored into `cache`
-// (any { get(key), put(key, entry) }). `hooks.onHit(key, bytes)` and
-// `hooks.onMiss(key)` are optional progress callbacks. A cache failure never
-// breaks the request — it just falls back to the network.
+// (any { get(key), put(key, entry) }). Optional progress callbacks:
+// `hooks.onHit(key, bytes)` (served from cache), `hooks.onMiss(key)` (about to
+// fetch), and `hooks.onNetwork(bytes)` (bytes actually pulled over the network
+// on a miss — the honest denominator for a download-speed estimate, since cached
+// chunks never cross the network). A cache failure never breaks the request — it
+// just falls back to the network.
 export function makeCachingFetch(realFetch, cache, hooks = {}) {
   return async (input, init) => {
     const { url, method, headers } = reqInfo(input, init);
@@ -111,6 +114,7 @@ export function makeCachingFetch(realFetch, cache, hooks = {}) {
     if (resp.ok || resp.status === 206) {
       try {
         const body = await resp.clone().arrayBuffer();
+        if (hooks.onNetwork) hooks.onNetwork(body.byteLength);
         await cache.put(key, {
           status: resp.status,
           headers: pickHeaders(resp.headers),
@@ -153,10 +157,33 @@ export function openXetCache(dbName = "onnxsim-xet-cache", storeName = "blocks")
         }),
     );
 
+  // Total stored bytes + entry count, by scanning every cached block with a
+  // cursor (there's no running aggregate). Used only for the UI's cache-size
+  // readout, so a full scan is acceptable for this experimental feature.
+  const size = () =>
+    db().then(
+      (d) =>
+        new Promise((resolve, reject) => {
+          const req = d.transaction(storeName, "readonly").objectStore(storeName).openCursor();
+          let bytes = 0;
+          let count = 0;
+          req.onsuccess = () => {
+            const cursor = req.result;
+            if (!cursor) return resolve({ bytes, count });
+            const v = cursor.value;
+            if (v && v.body) bytes += v.body.byteLength;
+            count += 1;
+            cursor.continue();
+          };
+          req.onerror = () => reject(req.error);
+        }),
+    );
+
   return {
     get: (key) => run("readonly", (s) => s.get(key)),
     put: (key, value) => run("readwrite", (s) => s.put(value, key)),
     clear: () => run("readwrite", (s) => s.clear()),
+    size,
   };
 }
 
@@ -166,5 +193,10 @@ function memoryCache() {
     get: async (key) => map.get(key) || null,
     put: async (key, value) => void map.set(key, value),
     clear: async () => void map.clear(),
+    size: async () => {
+      let bytes = 0;
+      for (const v of map.values()) if (v && v.body) bytes += v.body.byteLength;
+      return { bytes, count: map.size };
+    },
   };
 }

--- a/scripts/regression/models.json
+++ b/scripts/regression/models.json
@@ -1,8 +1,9 @@
 {
-  "_comment": "Regression model set \u2014 the models exercised in the onnxsim large-model sweep. See scripts/regression/README.md. baseline_* fields come from the initial characterization run and are advisory (shard balancing + summary deltas).",
+  "_comment": "Regression model set \u2014 the models exercised in the onnxsim large-model sweep. See scripts/regression/README.md. baseline_* fields come from the initial characterization run and are advisory (shard balancing + summary deltas). size is the byte size of the repo's largest .onnx file (the one the converters download); refresh it with select_models.py --refresh-sizes.",
   "models": [
     {
       "id": "onnxmodelzoo/age_googlenet",
+      "size": 23960165,
       "baseline_seconds": 8.2,
       "baseline_orig_nodes": 143,
       "baseline_simp_nodes": 143,
@@ -10,6 +11,7 @@
     },
     {
       "id": "onnxmodelzoo/albert_Opset18",
+      "size": 46920814,
       "baseline_seconds": 8.8,
       "baseline_orig_nodes": 733,
       "baseline_simp_nodes": 456,
@@ -17,6 +19,7 @@
     },
     {
       "id": "onnxmodelzoo/bart_Opset18",
+      "size": 557943055,
       "baseline_seconds": 67.1,
       "baseline_orig_nodes": 1061,
       "baseline_simp_nodes": 689,
@@ -24,6 +27,7 @@
     },
     {
       "id": "onnxmodelzoo/bert_Opset18",
+      "size": 438044671,
       "baseline_seconds": 126.1,
       "baseline_orig_nodes": 533,
       "baseline_simp_nodes": 418,
@@ -31,6 +35,7 @@
     },
     {
       "id": "onnxmodelzoo/botnet26t_256_Opset18",
+      "size": 50026862,
       "baseline_seconds": 8.3,
       "baseline_orig_nodes": 502,
       "baseline_simp_nodes": 185,
@@ -38,6 +43,7 @@
     },
     {
       "id": "onnxmodelzoo/caffenet-3",
+      "size": 243863525,
       "baseline_seconds": 103.2,
       "baseline_orig_nodes": 23,
       "baseline_simp_nodes": 23,
@@ -45,6 +51,7 @@
     },
     {
       "id": "onnxmodelzoo/cait_xxs36_224_Opset18",
+      "size": 69495263,
       "baseline_seconds": 18.1,
       "baseline_orig_nodes": 1758,
       "baseline_simp_nodes": 1488,
@@ -52,6 +59,7 @@
     },
     {
       "id": "onnxmodelzoo/convit_base_Opset18",
+      "size": 346717528,
       "baseline_seconds": 219.9,
       "baseline_orig_nodes": 695,
       "baseline_simp_nodes": 406,
@@ -59,6 +67,7 @@
     },
     {
       "id": "onnxmodelzoo/convnext_large_in22ft1k_Opset18",
+      "size": 791220893,
       "baseline_seconds": 91.7,
       "baseline_orig_nodes": 670,
       "baseline_simp_nodes": 562,
@@ -66,6 +75,7 @@
     },
     {
       "id": "onnxmodelzoo/convnext_tiny_in22k_Opset18",
+      "size": 178541230,
       "baseline_seconds": 21.5,
       "baseline_orig_nodes": 346,
       "baseline_simp_nodes": 292,
@@ -73,6 +83,7 @@
     },
     {
       "id": "onnxmodelzoo/crossvit_base_240_Opset17",
+      "size": 420335963,
       "baseline_seconds": 234.8,
       "baseline_orig_nodes": 1267,
       "baseline_simp_nodes": 756,
@@ -80,6 +91,7 @@
     },
     {
       "id": "onnxmodelzoo/cspresnet50_Opset18",
+      "size": 86419299,
       "baseline_seconds": 10.3,
       "baseline_orig_nodes": 135,
       "baseline_simp_nodes": 131,
@@ -87,6 +99,7 @@
     },
     {
       "id": "onnxmodelzoo/deberta_Opset17",
+      "size": 552343500,
       "baseline_seconds": 57.5,
       "baseline_orig_nodes": 1642,
       "baseline_simp_nodes": 678,
@@ -94,6 +107,7 @@
     },
     {
       "id": "onnxmodelzoo/deit3_large_patch16_384_in21ft1k_Opset18",
+      "size": 1219256822,
       "baseline_seconds": 272.1,
       "baseline_orig_nodes": 1272,
       "baseline_simp_nodes": 800,
@@ -101,6 +115,7 @@
     },
     {
       "id": "onnxmodelzoo/deit_tiny_patch16_224_Opset18",
+      "size": 22966973,
       "baseline_seconds": 5.4,
       "baseline_orig_nodes": 624,
       "baseline_simp_nodes": 380,
@@ -108,6 +123,7 @@
     },
     {
       "id": "onnxmodelzoo/densenetblur121d_Opset18",
+      "size": 32393120,
       "baseline_seconds": 6.6,
       "baseline_orig_nodes": 394,
       "baseline_simp_nodes": 374,
@@ -115,6 +131,7 @@
     },
     {
       "id": "onnxmodelzoo/distilbert_Opset18",
+      "size": 265512165,
       "baseline_seconds": 32.9,
       "baseline_orig_nodes": 295,
       "baseline_simp_nodes": 210,
@@ -122,6 +139,7 @@
     },
     {
       "id": "onnxmodelzoo/dla60x_Opset18",
+      "size": 69330500,
       "baseline_seconds": 11.3,
       "baseline_orig_nodes": 155,
       "baseline_simp_nodes": 153,
@@ -129,6 +147,7 @@
     },
     {
       "id": "onnxmodelzoo/eca_botnext26ts_256_Opset17",
+      "size": 42461339,
       "baseline_seconds": 10.7,
       "baseline_orig_nodes": 579,
       "baseline_simp_nodes": 247,
@@ -136,6 +155,7 @@
     },
     {
       "id": "onnxmodelzoo/edgenext_small_Opset18",
+      "size": 22498402,
       "baseline_seconds": 5.2,
       "baseline_orig_nodes": 659,
       "baseline_simp_nodes": 419,
@@ -143,6 +163,7 @@
     },
     {
       "id": "onnxmodelzoo/efficientnet_b3a_Opset17",
+      "size": 48853644,
       "baseline_seconds": 6.0,
       "baseline_orig_nodes": 386,
       "baseline_simp_nodes": 386,
@@ -150,6 +171,7 @@
     },
     {
       "id": "onnxmodelzoo/efficientnetv2_rw_m_Opset17",
+      "size": 212523554,
       "baseline_seconds": 24.4,
       "baseline_orig_nodes": 774,
       "baseline_simp_nodes": 774,
@@ -157,6 +179,7 @@
     },
     {
       "id": "onnxmodelzoo/electra_Opset18",
+      "size": 54047338,
       "baseline_seconds": 9.5,
       "baseline_orig_nodes": 531,
       "baseline_simp_nodes": 417,
@@ -164,6 +187,7 @@
     },
     {
       "id": "onnxmodelzoo/ese_vovnet19b_dw_Opset17",
+      "size": 26176409,
       "baseline_seconds": 4.5,
       "baseline_orig_nodes": 86,
       "baseline_simp_nodes": 86,
@@ -171,6 +195,7 @@
     },
     {
       "id": "onnxmodelzoo/FasterRCNN-10",
+      "size": 167330019,
       "baseline_seconds": 61.8,
       "baseline_orig_nodes": 6370,
       "baseline_simp_nodes": 2824,
@@ -178,6 +203,7 @@
     },
     {
       "id": "onnxmodelzoo/fcn-resnet50-12-int8",
+      "size": 35545058,
       "baseline_seconds": 4.6,
       "baseline_orig_nodes": 91,
       "baseline_simp_nodes": 91,
@@ -185,6 +211,7 @@
     },
     {
       "id": "onnxmodelzoo/gcresnext50ts_Opset18",
+      "size": 62683574,
       "baseline_seconds": 9.8,
       "baseline_orig_nodes": 497,
       "baseline_simp_nodes": 417,
@@ -192,6 +219,7 @@
     },
     {
       "id": "onnxmodelzoo/gluon_resnet152_v1b_Opset18",
+      "size": 240540468,
       "baseline_seconds": 25.0,
       "baseline_orig_nodes": 360,
       "baseline_simp_nodes": 360,
@@ -199,6 +227,7 @@
     },
     {
       "id": "onnxmodelzoo/gluon_resnext50_32x4d_Opset18",
+      "size": 100003492,
       "baseline_seconds": 11.2,
       "baseline_orig_nodes": 122,
       "baseline_simp_nodes": 122,
@@ -206,6 +235,7 @@
     },
     {
       "id": "onnxmodelzoo/googlenet-6",
+      "size": 28020232,
       "baseline_seconds": 4.1,
       "baseline_orig_nodes": 143,
       "baseline_simp_nodes": 143,
@@ -213,6 +243,7 @@
     },
     {
       "id": "onnxmodelzoo/gpt2_Opset18",
+      "size": 498062939,
       "baseline_seconds": 49.1,
       "baseline_orig_nodes": 825,
       "baseline_simp_nodes": 474,
@@ -220,6 +251,7 @@
     },
     {
       "id": "onnxmodelzoo/hardcorenas_b_Opset17",
+      "size": 20689930,
       "baseline_seconds": 4.3,
       "baseline_orig_nodes": 133,
       "baseline_simp_nodes": 133,
@@ -227,6 +259,7 @@
     },
     {
       "id": "onnxmodelzoo/hrnet_w48_Opset18",
+      "size": 309889111,
       "baseline_seconds": 34.3,
       "baseline_orig_nodes": 851,
       "baseline_simp_nodes": 820,
@@ -234,6 +267,7 @@
     },
     {
       "id": "onnxmodelzoo/inception-v1-7",
+      "size": 28020356,
       "baseline_seconds": 4.6,
       "baseline_orig_nodes": 144,
       "baseline_simp_nodes": 143,
@@ -241,6 +275,7 @@
     },
     {
       "id": "onnxmodelzoo/jx_nest_small_Opset18",
+      "size": 153995643,
       "baseline_seconds": 85.5,
       "baseline_orig_nodes": 2282,
       "baseline_simp_nodes": 786,
@@ -248,6 +283,7 @@
     },
     {
       "id": "onnxmodelzoo/legacy_seresnet152_Opset17",
+      "size": 267128513,
       "baseline_seconds": 28.5,
       "baseline_orig_nodes": 660,
       "baseline_simp_nodes": 660,
@@ -255,6 +291,7 @@
     },
     {
       "id": "onnxmodelzoo/longt5_Opset17",
+      "size": 893431657,
       "baseline_seconds": 900.0,
       "baseline_orig_nodes": null,
       "baseline_simp_nodes": null,
@@ -262,6 +299,7 @@
     },
     {
       "id": "onnxmodelzoo/mixer_l16_224_in21k_Opset17",
+      "size": 832919235,
       "baseline_seconds": 481.5,
       "baseline_orig_nodes": 733,
       "baseline_simp_nodes": 582,
@@ -269,6 +307,7 @@
     },
     {
       "id": "onnxmodelzoo/mnasnet_small_Opset17",
+      "size": 8125026,
       "baseline_seconds": 5.8,
       "baseline_orig_nodes": 150,
       "baseline_simp_nodes": 150,
@@ -276,6 +315,7 @@
     },
     {
       "id": "onnxmodelzoo/mobilebert_Opset18",
+      "size": 98735685,
       "baseline_seconds": 13.6,
       "baseline_orig_nodes": 1867,
       "baseline_simp_nodes": 1672,
@@ -283,6 +323,7 @@
     },
     {
       "id": "onnxmodelzoo/mobilenetv2-12-int8",
+      "size": 3655033,
       "baseline_seconds": 2.5,
       "baseline_orig_nodes": 73,
       "baseline_simp_nodes": 73,
@@ -290,6 +331,7 @@
     },
     {
       "id": "onnxmodelzoo/mobilenetv3_small_050_Opset17",
+      "size": 6391515,
       "baseline_seconds": 2.5,
       "baseline_orig_nodes": 123,
       "baseline_simp_nodes": 123,
@@ -297,6 +339,7 @@
     },
     {
       "id": "onnxmodelzoo/mobilevitv2_175_Opset18",
+      "size": 57075809,
       "baseline_seconds": 27.2,
       "baseline_orig_nodes": 431,
       "baseline_simp_nodes": 322,
@@ -304,6 +347,7 @@
     },
     {
       "id": "onnxmodelzoo/mvp_Opset18",
+      "size": 1625612060,
       "baseline_seconds": 610.1,
       "baseline_orig_nodes": 1967,
       "baseline_simp_nodes": 1361,
@@ -311,6 +355,7 @@
     },
     {
       "id": "onnxmodelzoo/pit_b_distilled_224_Opset18",
+      "size": 299338060,
       "baseline_seconds": 46.4,
       "baseline_orig_nodes": 735,
       "baseline_simp_nodes": 435,
@@ -318,6 +363,7 @@
     },
     {
       "id": "onnxmodelzoo/poolformer_m48_Opset18",
+      "size": 294260437,
       "baseline_seconds": 280.7,
       "baseline_orig_nodes": 1642,
       "baseline_simp_nodes": 1114,
@@ -325,6 +371,7 @@
     },
     {
       "id": "onnxmodelzoo/regnet_x_16gf_Opset18",
+      "size": 216931938,
       "baseline_seconds": 27.3,
       "baseline_orig_nodes": 163,
       "baseline_simp_nodes": 163,
@@ -332,6 +379,7 @@
     },
     {
       "id": "onnxmodelzoo/regnet_y_8gf_Opset18",
+      "size": 157414052,
       "baseline_seconds": 27.1,
       "baseline_orig_nodes": 230,
       "baseline_simp_nodes": 230,
@@ -339,6 +387,7 @@
     },
     {
       "id": "onnxmodelzoo/regnetx_120_Opset18",
+      "size": 184257246,
       "baseline_seconds": 24.5,
       "baseline_orig_nodes": 142,
       "baseline_simp_nodes": 142,
@@ -346,6 +395,7 @@
     },
     {
       "id": "onnxmodelzoo/regnety_120_Opset17",
+      "size": 207142355,
       "baseline_seconds": 27.7,
       "baseline_orig_nodes": 256,
       "baseline_simp_nodes": 256,
@@ -353,6 +403,7 @@
     },
     {
       "id": "onnxmodelzoo/repvgg_a2_Opset18",
+      "size": 112860863,
       "baseline_seconds": 13.1,
       "baseline_orig_nodes": 125,
       "baseline_simp_nodes": 125,
@@ -360,6 +411,7 @@
     },
     {
       "id": "onnxmodelzoo/res2net50_26w_8s_Opset18",
+      "size": 193537817,
       "baseline_seconds": 96.1,
       "baseline_orig_nodes": 438,
       "baseline_simp_nodes": 422,
@@ -367,6 +419,7 @@
     },
     {
       "id": "onnxmodelzoo/resmlp_big_24_224_in22ft1k_Opset17",
+      "size": 516666806,
       "baseline_seconds": 52.5,
       "baseline_orig_nodes": 688,
       "baseline_simp_nodes": 511,
@@ -374,6 +427,7 @@
     },
     {
       "id": "onnxmodelzoo/resnet101-v1-7",
+      "size": 178914043,
       "baseline_seconds": 22.3,
       "baseline_orig_nodes": 345,
       "baseline_simp_nodes": 345,
@@ -381,6 +435,7 @@
     },
     {
       "id": "onnxmodelzoo/resnet18d_Opset18",
+      "size": 46826868,
       "baseline_seconds": 5.2,
       "baseline_orig_nodes": 56,
       "baseline_simp_nodes": 56,
@@ -388,6 +443,7 @@
     },
     {
       "id": "onnxmodelzoo/resnet50-caffe2-v1-3",
+      "size": 102491873,
       "baseline_seconds": 38.1,
       "baseline_orig_nodes": 175,
       "baseline_simp_nodes": 175,
@@ -395,6 +451,7 @@
     },
     {
       "id": "onnxmodelzoo/resnet51q_Opset18",
+      "size": 142662146,
       "baseline_seconds": 16.8,
       "baseline_orig_nodes": 178,
       "baseline_simp_nodes": 178,
@@ -402,6 +459,7 @@
     },
     {
       "id": "onnxmodelzoo/resnetv2_101_Opset18",
+      "size": 178442674,
       "baseline_seconds": 18.2,
       "baseline_orig_nodes": 275,
       "baseline_simp_nodes": 275,
@@ -409,6 +467,7 @@
     },
     {
       "id": "onnxmodelzoo/resnetv2_50x3_bitm_Opset17",
+      "size": 1714321230,
       "baseline_seconds": 900.0,
       "baseline_orig_nodes": null,
       "baseline_simp_nodes": null,
@@ -416,6 +475,7 @@
     },
     {
       "id": "onnxmodelzoo/rexnet_200_Opset17",
+      "size": 65363107,
       "baseline_seconds": 10.8,
       "baseline_orig_nodes": 344,
       "baseline_simp_nodes": 224,
@@ -423,6 +483,7 @@
     },
     {
       "id": "onnxmodelzoo/roberta_Opset18",
+      "size": 498698099,
       "baseline_seconds": 50.6,
       "baseline_orig_nodes": 542,
       "baseline_simp_nodes": 425,
@@ -430,6 +491,7 @@
     },
     {
       "id": "onnxmodelzoo/selecsls60b_Opset18",
+      "size": 131076349,
       "baseline_seconds": 13.7,
       "baseline_orig_nodes": 130,
       "baseline_simp_nodes": 130,
@@ -437,6 +499,7 @@
     },
     {
       "id": "onnxmodelzoo/seresnext101d_32x8d_Opset17",
+      "size": 374037471,
       "baseline_seconds": 223.0,
       "baseline_orig_nodes": 446,
       "baseline_simp_nodes": 446,
@@ -444,6 +507,7 @@
     },
     {
       "id": "onnxmodelzoo/shufflenet-v2-12",
+      "size": 9218556,
       "baseline_seconds": 3.4,
       "baseline_orig_nodes": 261,
       "baseline_simp_nodes": 173,
@@ -451,6 +515,7 @@
     },
     {
       "id": "onnxmodelzoo/squeezebert_Opset18",
+      "size": 204465324,
       "baseline_seconds": 75.1,
       "baseline_orig_nodes": 494,
       "baseline_simp_nodes": 382,
@@ -458,6 +523,7 @@
     },
     {
       "id": "onnxmodelzoo/ssd-10",
+      "size": 80363696,
       "baseline_seconds": 16.7,
       "baseline_orig_nodes": 515,
       "baseline_simp_nodes": 175,
@@ -465,6 +531,7 @@
     },
     {
       "id": "onnxmodelzoo/ssl_resnext101_32x8d_Opset18",
+      "size": 354807890,
       "baseline_seconds": 173.3,
       "baseline_orig_nodes": 241,
       "baseline_simp_nodes": 241,
@@ -472,6 +539,7 @@
     },
     {
       "id": "onnxmodelzoo/swin_s_Opset18",
+      "size": 203572882,
       "baseline_seconds": 341.7,
       "baseline_orig_nodes": 12830,
       "baseline_simp_nodes": 1295,
@@ -479,6 +547,7 @@
     },
     {
       "id": "onnxmodelzoo/swinv2_cr_small_ns_224_Opset18",
+      "size": 200878124,
       "baseline_seconds": 121.9,
       "baseline_orig_nodes": 2768,
       "baseline_simp_nodes": 1460,
@@ -486,6 +555,7 @@
     },
     {
       "id": "onnxmodelzoo/swsl_resnext101_32x16d_Opset18",
+      "size": 775489693,
       "baseline_seconds": 363.0,
       "baseline_orig_nodes": 241,
       "baseline_simp_nodes": 241,
@@ -493,6 +563,7 @@
     },
     {
       "id": "onnxmodelzoo/t5_Opset17",
+      "size": 246134781,
       "baseline_seconds": 27.1,
       "baseline_orig_nodes": 889,
       "baseline_simp_nodes": 574,
@@ -500,6 +571,7 @@
     },
     {
       "id": "onnxmodelzoo/tf_efficientnet_b1_Opset17",
+      "size": 31206677,
       "baseline_seconds": 16.5,
       "baseline_orig_nodes": 766,
       "baseline_simp_nodes": 341,
@@ -507,6 +579,7 @@
     },
     {
       "id": "onnxmodelzoo/tf_efficientnet_b5_Opset17",
+      "size": 121426497,
       "baseline_seconds": 115.8,
       "baseline_orig_nodes": 1003,
       "baseline_simp_nodes": 578,
@@ -514,6 +587,7 @@
     },
     {
       "id": "onnxmodelzoo/tf_efficientnet_em_Opset18",
+      "size": 27564189,
       "baseline_seconds": 12.0,
       "baseline_orig_nodes": 549,
       "baseline_simp_nodes": 124,
@@ -521,6 +595,7 @@
     },
     {
       "id": "onnxmodelzoo/tf_efficientnetv2_l_Opset17",
+      "size": 473355499,
       "baseline_seconds": 547.3,
       "baseline_orig_nodes": 1429,
       "baseline_simp_nodes": 1004,
@@ -528,6 +603,7 @@
     },
     {
       "id": "onnxmodelzoo/tf_mixnet_l_Opset17",
+      "size": 29806237,
       "baseline_seconds": 17.0,
       "baseline_orig_nodes": 1759,
       "baseline_simp_nodes": 446,
@@ -535,6 +611,7 @@
     },
     {
       "id": "onnxmodelzoo/tinynet_c_Opset17",
+      "size": 9840760,
       "baseline_seconds": 4.4,
       "baseline_orig_nodes": 224,
       "baseline_simp_nodes": 224,
@@ -542,6 +619,7 @@
     },
     {
       "id": "onnxmodelzoo/tv_resnext50_32x4d_Opset18",
+      "size": 100003492,
       "baseline_seconds": 49.3,
       "baseline_orig_nodes": 122,
       "baseline_simp_nodes": 122,
@@ -549,6 +627,7 @@
     },
     {
       "id": "onnxmodelzoo/version-RFB-320-int8",
+      "size": 458144,
       "baseline_seconds": 3.0,
       "baseline_orig_nodes": 91,
       "baseline_simp_nodes": 91,
@@ -556,6 +635,7 @@
     },
     {
       "id": "onnxmodelzoo/vgg19_Opset18_timm",
+      "size": 574678072,
       "baseline_seconds": 72.6,
       "baseline_orig_nodes": 44,
       "baseline_simp_nodes": 44,
@@ -563,6 +643,7 @@
     },
     {
       "id": "onnxmodelzoo/visformer_small_Opset18",
+      "size": 161039567,
       "baseline_seconds": 69.2,
       "baseline_orig_nodes": 447,
       "baseline_simp_nodes": 325,
@@ -570,6 +651,7 @@
     },
     {
       "id": "onnxmodelzoo/vit_base_patch32_224_in21k_Opset18",
+      "size": 417107410,
       "baseline_seconds": 219.4,
       "baseline_orig_nodes": 624,
       "baseline_simp_nodes": 380,
@@ -577,6 +659,7 @@
     },
     {
       "id": "onnxmodelzoo/vit_relpos_base_patch16_clsgap_224_Opset17",
+      "size": 346235923,
       "baseline_seconds": 221.1,
       "baseline_orig_nodes": 1012,
       "baseline_simp_nodes": 404,
@@ -584,6 +667,7 @@
     },
     {
       "id": "onnxmodelzoo/vit_small_patch32_384_Opset18",
+      "size": 91759087,
       "baseline_seconds": 41.7,
       "baseline_orig_nodes": 624,
       "baseline_simp_nodes": 380,
@@ -591,6 +675,7 @@
     },
     {
       "id": "onnxmodelzoo/xception65p_Opset18",
+      "size": 159334474,
       "baseline_seconds": 66.7,
       "baseline_orig_nodes": 240,
       "baseline_simp_nodes": 240,
@@ -598,6 +683,7 @@
     },
     {
       "id": "onnxmodelzoo/xcit_medium_24_p8_224_dist_Opset18",
+      "size": 337726417,
       "baseline_seconds": 356.3,
       "baseline_orig_nodes": 2330,
       "baseline_simp_nodes": 1564,
@@ -605,6 +691,7 @@
     },
     {
       "id": "onnxmodelzoo/xcit_small_12_p8_224_dist_Opset18",
+      "size": 105072649,
       "baseline_seconds": 79.9,
       "baseline_orig_nodes": 1310,
       "baseline_simp_nodes": 832,
@@ -612,6 +699,7 @@
     },
     {
       "id": "onnxmodelzoo/xcit_tiny_12_p8_384_dist_Opset18",
+      "size": 27031856,
       "baseline_seconds": 10.5,
       "baseline_orig_nodes": 1310,
       "baseline_simp_nodes": 832,
@@ -619,6 +707,7 @@
     },
     {
       "id": "onnxmodelzoo/xlmroberta_Opset18",
+      "size": 1112290165,
       "baseline_seconds": 103.2,
       "baseline_orig_nodes": 542,
       "baseline_simp_nodes": 425,
@@ -626,6 +715,7 @@
     },
     {
       "id": "onnxmodelzoo/yolov3-10",
+      "size": 247908721,
       "baseline_seconds": 35.1,
       "baseline_orig_nodes": 469,
       "baseline_simp_nodes": 379,

--- a/scripts/regression/select_models.py
+++ b/scripts/regression/select_models.py
@@ -15,9 +15,15 @@ and maintainable:
     org are represented and which are not, so gaps are a decision, not an
     accident.
 
-Existing `baseline_seconds` / `baseline_*_nodes` / `known_slow` are always
-preserved across a regenerate — only ids and membership change. New entries get
-null baselines (fill them with a run of run_regression.py) and known_slow=false.
+Existing `baseline_seconds` / `baseline_*_nodes` / `known_slow` / `size` are
+always preserved across a regenerate — only ids and membership change. New
+entries get null baselines (fill them with a run of run_regression.py), a null
+`size`, and known_slow=false.
+
+`size` is the byte size of the repo's largest `.onnx` file — the one the
+converters (WASM UI / regression workers) download. It powers the size preview
+in the browser converter. Fill or refresh it with `--refresh-sizes`, which
+queries the HF API for each entry (online only).
 
 Model ids come from the live HF API (`huggingface_hub`) or, offline, from a
 cached JSON list via `--ids-file` (a plain list of "onnxmodelzoo/<name>").
@@ -107,11 +113,24 @@ def load_models_json(path):
 def new_entry(model_id):
     return {
         "id": model_id,
+        "size": None,
         "baseline_seconds": 0.0,
         "baseline_orig_nodes": None,
         "baseline_simp_nodes": None,
         "known_slow": False,
     }
+
+
+def largest_onnx_size(api, repo):
+    """Byte size of the repo's largest `.onnx` file (the one the converters
+    download), or None when the repo has no `.onnx`. Mirrors the "largest wins"
+    selection in scripts/convertmodel/hf_models.mjs and the regression workers."""
+    info = api.model_info(repo, files_metadata=True)
+    onnx = [s for s in (info.siblings or []) if s.rfilename.endswith(".onnx")]
+    if not onnx:
+        return None
+    onnx.sort(key=lambda s: s.size or 0, reverse=True)
+    return onnx[0].size
 
 
 def representative(ids_for_stem):
@@ -129,6 +148,9 @@ def main():
     ap.add_argument("--add", action="append", default=[], metavar="REGEX",
                     help="add newest-opset representative for every model whose id "
                          "matches REGEX (repeatable), e.g. --add '(distilbert|roberta|albert)'")
+    ap.add_argument("--refresh-sizes", action="store_true",
+                    help="fill/refresh each entry's `size` (largest .onnx bytes) "
+                         "from the live HF API; online only")
     ap.add_argument("--report", action="store_true",
                     help="print family coverage report (default action)")
     ap.add_argument("--write", action="store_true", help="write the updated models.json")
@@ -186,10 +208,27 @@ def main():
     if added:
         changed += [f"ADD {a}" for a in added]
 
+    # 4. Refresh sizes (largest .onnx bytes) from the live HF API.
+    if args.refresh_sizes:
+        try:
+            from huggingface_hub import HfApi
+        except ImportError:
+            sys.exit("huggingface_hub not installed; --refresh-sizes needs the live API")
+        api = HfApi()
+        for m in models:
+            try:
+                size = largest_onnx_size(api, m["id"])
+            except Exception as e:  # noqa: BLE001 — report and continue
+                changed.append(f"SIZE-FAIL {m['id']}: {e}")
+                continue
+            if m.get("size") != size:
+                changed.append(f"SIZE {m['id']} -> {size}")
+                m["size"] = size
+
     models.sort(key=lambda m: m["id"].lower())
 
-    # 4. Coverage report.
-    if args.report or not (args.refresh or args.add):
+    # 5. Coverage report.
+    if args.report or not (args.refresh or args.add or args.refresh_sizes):
         covered = {arch_family(m["id"]) for m in models}
         org_fams = {}
         for i in org_ids:


### PR DESCRIPTION
Three follow-ups to the Hugging Face loader in the browser converter (`scripts/convertmodel/`), following up on #558.

## 1. Model sizes from `models.json` (instead of a runtime probe)
Each curated entry now carries a `size` field — the byte size of the repo's largest `.onnx` (the file the converters download). The dropdown shows the size inline in every option (e.g. `resnet18d_Opset18 (44.6 MB)`), and picking one displays it instantly with **no network request**. The free-text box still probes on demand for arbitrary repo ids / URLs.

- `scripts/regression/models.json`: add `size` to all 90 entries.
- `scripts/regression/select_models.py`: `new_entry` carries `size: null`; new `--refresh-sizes` flag + `largest_onnx_size()` fill/refresh it from the HF API. Sizes are preserved across a regenerate, like the `baseline_*` fields.
- `hf_models.mjs`: `loadModelList()` now returns `[{id, size}]`.
- `hf_load.mjs`: dropdown labels include the size; a curated pick renders its known size without touching the network.

## 2. Fix the inflated Xet download speed
The live speed and the final average were computed from **reconstructed-file** bytes over wall-clock time. On the direct-download path that equals real network throughput, but the Xet path reconstructs from cached / deduplicated chunks that never cross the wire — so the reported speed was wildly too fast (a fully-cached reload reported GB/s).

Fix: measure the bytes that actually cross the network. `makeCachingFetch` gains an `onNetwork(bytes)` hook (fired with the miss-body size), and the Xet path drives both the live speed and the average from those bytes, reporting cache reuse separately — e.g. `downloaded 12 MB over the network (+30 MB from cache) — average 8.0 MB/s`, or `reconstructed entirely from the chunk cache … — no network transfer`.

## 3. Show the Xet chunk-cache size
`openXetCache()` / `memoryCache()` gain `size() -> {bytes, count}`. The panel shows `chunk cache: N MB in K chunks` next to the clear button, refreshed after a Xet load, on clear, and when the Xet toggle is switched on (kept lazy — no IndexedDB open for users who never use Xet).

## Testing
- New unit coverage: `loadModelList` carrying sizes, and the `onNetwork` hook (miss reports network bytes, hit does not).
- `hf` and `xet` suites green locally.
- The `size()` cache method and IndexedDB paths are browser-only and not unit-tested, consistent with the existing note in `xet_cache.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNN5ogZdrF9XLMxpp6ng4U)_