### PR TITLE
Raise WASM heap cap to 4 GiB and explain OOM in the converter UI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,13 @@ add_executable(
   ${ONNXSIM_WASM_INTERFACE})
 set_target_properties(onnxsim_bin PROPERTIES OUTPUT_NAME onnxsim)
 if (EMSCRIPTEN)
-  set_target_properties(onnxsim_bin PROPERTIES LINK_FLAGS "-s ALLOW_MEMORY_GROWTH=1 -s EXIT_RUNTIME=0 -s FORCE_FILESYSTEM=1 -s MODULARIZE=1 -s 'EXPORT_NAME=\"create_onnxsim\"' -s 
+  # ALLOW_MEMORY_GROWTH=1 lets the heap grow on demand, but without
+  # MAXIMUM_MEMORY Emscripten caps that growth at 2 GiB and aborts with
+  # "Cannot enlarge memory, requested N bytes, but the limit is 2147483648
+  # bytes!" the moment a model needs more. Raise the cap to 4 GiB, the hard
+  # addressing limit of a wasm32 module (2^32 bytes), so larger models can be
+  # converted in the browser. Going beyond 4 GiB would require MEMORY64/wasm64.
+  set_target_properties(onnxsim_bin PROPERTIES LINK_FLAGS "-s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4294967296 -s EXIT_RUNTIME=0 -s FORCE_FILESYSTEM=1 -s MODULARIZE=1 -s 'EXPORT_NAME=\"create_onnxsim\"' -s
   'EXPORTED_RUNTIME_METHODS=[ENV]' -Wl,--threads=8 -Wl,--lto-partitions=8 -Wl,--lto-O0 -Wl,--lto-CGO0 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -sASSERTIONS=2 -sINVOKE_RUN=0")
   target_link_libraries(onnxsim_bin embind "-Wl,--whole-archive" onnxsim "-Wl,--no-whole-archive")
 else()

--- a/scripts/convertmodel/worker.js
+++ b/scripts/convertmodel/worker.js
@@ -5,6 +5,41 @@ importScripts("./onnxsim.js");
 const ORT_VERSION = "1.27.0";
 const ORT_BASE = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ORT_VERSION}/dist/`;
 
+// Turn a low-level WASM out-of-memory abort into an actionable explanation.
+// When a model needs more heap than the module can address, Emscripten aborts
+// with "Cannot enlarge memory, requested N bytes, but the limit is M bytes!"
+// (surfaced via printErr) and throws a RuntimeError from the conversion call.
+// Both are accurate but say nothing about *why* or *what to do*, so translate
+// them into a message the user can act on. The module caps its heap at 4 GiB,
+// the hard addressing limit of a wasm32 build (see MAXIMUM_MEMORY in
+// CMakeLists.txt); simplification needs several times the model's size on top
+// of the model itself, so large models can exhaust it.
+function isOutOfMemory(text) {
+    return /Cannot enlarge memory|out of memory|Aborted|enlarge|allocat/i.test(
+        String(text || ""));
+}
+
+function memoryLimitMessage(text) {
+    const gib = (n) => (n / (1024 ** 3)).toFixed(2) + " GiB";
+    const m = /requested (\d+) bytes, but the limit is (\d+) bytes/.exec(
+        String(text || ""));
+    const limit = m ? gib(Number(m[2])) : "4 GiB";
+    const needed = m ? ` (it needed about ${gib(Number(m[1]))})` : "";
+    return [
+        `This model is too large to convert in the browser${needed}.`,
+        `The WebAssembly build can address at most ${limit} of memory, and`,
+        `simplification (shape inference + constant folding) needs several times`,
+        `the model's size on top of the model itself.`,
+        ``,
+        `Things to try:`,
+        `  - run onnxsim locally, where it is not limited to ${limit}:`,
+        `      pip install onnxsim && onnxsim input.onnx output.onnx`,
+        `  - turn off "constant folding" (or lower the tensor-size threshold),`,
+        `    then convert again`,
+        `  - reduce the model size first (e.g. split it or externalize weights)`,
+    ].join("\n");
+}
+
 // For the ORT-web build (onnxsim compiled with ONNXSIM_WASM_ORT_WEB): load
 // onnxruntime-web and register the runner JsModelExecutor calls. In the default
 // built-in-ORT build onnxsim_needs_ort_web() is false and this is a no-op, so
@@ -36,6 +71,10 @@ create_onnxsim({
     printErr: (str) => {
         console.error("stderr:", [str]);
         postMessage(["stderr", str]);
+        // Augment the raw Emscripten OOM abort line with a human-readable hint.
+        if (typeof str === "string" && str.includes("Cannot enlarge memory")) {
+            postMessage(["stderr", memoryLimitMessage(str)]);
+        }
     },
 }).then(async (runtime) => {
     // Wire up onnxruntime-web before announcing readiness, so the first
@@ -59,6 +98,11 @@ create_onnxsim({
         // requested, otherwise an empty string.
         let model = null;
         let trace = "";
+        // A model that outgrows the wasm heap makes Emscripten abort mid-run and
+        // throw a RuntimeError out of the conversion call. Catch it here so the
+        // user gets an explanation (see memoryLimitMessage) instead of the worker
+        // dying with an opaque, unhandled error.
+        try {
         switch (e.data[0]) {
             case "simplify": {
                 // Simplify returns { model, trace } so the profiling trace can
@@ -102,6 +146,17 @@ create_onnxsim({
             default:
                 postMessage(["stderr", "unknown conversion type: " + e.data[0]]);
                 return;
+        }
+        } catch (err) {
+            const detail = String((err && err.message) || err);
+            if (isOutOfMemory(detail)) {
+                // The raw "Cannot enlarge memory" line (if any) already went out
+                // via printErr; this adds the actionable explanation.
+                postMessage(["stderr", memoryLimitMessage(detail)]);
+            } else {
+                postMessage(["stderr", e.data[0] + " failed: " + detail]);
+            }
+            return;
         }
         if (!model) {
             postMessage(["stderr", e.data[0] + " failed!"]);


### PR DESCRIPTION
## Problem

The WASM converter UI aborts on larger models with:

```
Cannot enlarge memory, requested 2148487168 bytes, but the limit is 2147483648 bytes!
```

`2147483648` is exactly **2 GiB (2³¹)** — Emscripten's *default* ceiling for a growable heap. The Emscripten link flags in `CMakeLists.txt` set `ALLOW_MEMORY_GROWTH=1` (heap grows on demand) but never set `MAXIMUM_MEMORY`, so growth was capped at 2 GiB and any model that needed a bit more aborted.

## Changes

**`CMakeLists.txt`** — add `-s MAXIMUM_MEMORY=4294967296` (4 GiB) to the Emscripten link flags. 4 GiB (2³²) is the hard addressing limit of a wasm32 module, so this is as high as we can go without switching to MEMORY64/wasm64. `ALLOW_MEMORY_GROWTH=1` still means the heap starts small and grows on demand — this only lifts the cap it may grow *to*. The change is inside `if (EMSCRIPTEN)`, so the Python wheel is unaffected.

**`scripts/convertmodel/worker.js`** — turn the low-level OOM abort into an actionable message. An out-of-memory condition both prints `Cannot enlarge memory ...` via `printErr` **and** throws a `RuntimeError` out of the conversion call, which was previously unhandled and killed the worker. The conversion is now wrapped in a `try/catch`, and both paths post a human-readable explanation of the 4 GiB limit with suggestions (run onnxsim locally, disable constant folding / lower the tensor-size threshold, or shrink the model).

## Notes / limitations

- 4 GiB is the wall for wasm32; models needing more than that would require MEMORY64, a larger change that also depends on the rest of the pipeline (incl. onnxruntime-web in the ORT-web variant) being 64-bit-ready.
- Even under the 4 GiB cap a browser/device can still refuse the allocation; the failure is now reported cleanly instead of aborting opaquely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLhnXP5YgZA9QVtKSGp9pP

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLhnXP5YgZA9QVtKSGp9pP)_