### PR TITLE
WASM converter UI: backend tests, text-graph parsing, single-pass debug modes, versions, Netron SVG/PNG export, and URL-driven input

### DIFF
--- a/.github/workflows/convertmodel-inference.yml
+++ b/.github/workflows/convertmodel-inference.yml
@@ -41,6 +41,15 @@ jobs:
       - name: Run WebNN helper unit test
         working-directory: scripts/convertmodel
         run: npm run test:webnn
+      - name: Run library-versions unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:versions
+      - name: Run backend-test-runner unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:backend
+      - name: Run query-parameter unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:query
       - name: Run inference smoke test (wasm EP)
         working-directory: scripts/convertmodel
         run: npm run test:inference

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -143,7 +143,10 @@ jobs:
       - name: Build and embed Netron
         env:
           NETRON_REPO: https://github.com/onnxsim/netron
-          NETRON_REF: claude/wasm-netron-visualization-c4ppnv
+          # Netron 9.1.9 + the embedding protocol, now also exposing an
+          # `export` command so the page's "export SVG" buttons can save the
+          # rendered graph (see the onnxsim/netron branch / docs/embedding.md).
+          NETRON_REF: claude/wasm-netron-svg-export
         run: |
           git clone --depth 1 --branch "$NETRON_REF" "$NETRON_REPO" netron-src
           (cd netron-src && node package.js build web)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,27 @@ add_executable(
   onnxsim/bin/onnxsim_option.cpp
   ${ONNXSIM_WASM_INTERFACE})
 set_target_properties(onnxsim_bin PROPERTIES OUTPUT_NAME onnxsim)
+
+# Bake the onnxsim and onnx-optimizer version strings into the module so the
+# WASM converter's interface.cpp can report them (the "versions" panel / issue
+# report). Read from the VERSION files that ship in the tree; the onnx and
+# protobuf versions are read at runtime from the linked libraries instead.
+if (EMSCRIPTEN)
+  set(_onnxsim_ver "unknown")
+  if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/VERSION")
+    file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" _onnxsim_ver LIMIT_COUNT 1)
+    string(STRIP "${_onnxsim_ver}" _onnxsim_ver)
+  endif()
+  set(_onnxopt_ver "unknown")
+  if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/onnx-optimizer/VERSION_NUMBER")
+    file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/onnx-optimizer/VERSION_NUMBER" _onnxopt_ver LIMIT_COUNT 1)
+    string(STRIP "${_onnxopt_ver}" _onnxopt_ver)
+  endif()
+  target_compile_definitions(onnxsim_bin PRIVATE
+    "ONNXSIM_VERSION_STRING=\"${_onnxsim_ver}\""
+    "ONNX_OPTIMIZER_VERSION_STRING=\"${_onnxopt_ver}\"")
+endif()
+
 if (EMSCRIPTEN)
   # ALLOW_MEMORY_GROWTH=1 lets the heap grow on demand, but without
   # MAXIMUM_MEMORY Emscripten caps that growth at 2 GiB and aborts with

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -1920,6 +1920,52 @@ onnx::ModelProto ConvertOpsetVersion(const onnx::ModelProto& model,
   return onnx::version_conversion::ConvertVersion(model, target_version);
 }
 
+// Shared schema setup for the single-pass debug helpers below, mirroring the
+// head of ``Simplify``: teach shape inference about ONNX Runtime's quantized
+// contrib ops and register permissive placeholders for custom ops exported into
+// the default ONNX domain, so neither shape inference nor a later checker
+// rejects the model. Unlike ``Simplify`` these helpers do not ``Check`` the
+// model up front -- the point of running a step in isolation is to debug a model
+// that may not yet be fully valid.
+void PrepareSchemasForDebug(const onnx::ModelProto& model) {
+  onnxsim::RegisterContribOpSchemas();
+  FixupSchemaDeterminism();
+  RegisterCustomDefaultDomainOpSchemas(model);
+}
+
+onnx::ModelProto InferShapesOnce(const onnx::ModelProto& model) {
+  PrepareSchemasForDebug(model);
+  onnx::ModelProto out = model;
+  _InferShapes(out);
+  return out;
+}
+
+onnx::ModelProto PropagateDataOnce(const onnx::ModelProto& model) {
+  PrepareSchemasForDebug(model);
+  onnx::ModelProto out = model;
+  _EvalPartialShape(out);
+  return out;
+}
+
+onnx::ModelProto FoldConstantOnce(const ModelExecutor& executor,
+                                  const onnx::ModelProto& model,
+                                  size_t tensor_size_threshold,
+                                  bool initializers_as_constants) {
+  PrepareSchemasForDebug(model);
+  // ``_FoldConstant`` reads these globals (tensor-size cap and the
+  // initializers-as-constants policy), just as ``Simplify`` sets them.
+  config.tensor_size_threshold = tensor_size_threshold;
+  config.initializers_as_constants = initializers_as_constants;
+  config.optimizer_passes.clear();
+  onnx::ModelProto out = model;
+  // Mirror ``Simplify``'s FoldConstant step: partial shape evaluation first
+  // turns Shape/Gather-on-shape into constants that the ordinary constant
+  // folder can then propagate.
+  _EvalPartialShape(out);
+  out = _FoldConstant(executor, out);
+  return out;
+}
+
 onnx::ModelProto Simplify(
     const ModelExecutor& executor, const onnx::ModelProto& model,
     std::optional<std::vector<std::string>> skip_optimizers,

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -1925,8 +1925,8 @@ onnx::ModelProto ConvertOpsetVersion(const onnx::ModelProto& model,
 // contrib ops and register permissive placeholders for custom ops exported into
 // the default ONNX domain, so neither shape inference nor a later checker
 // rejects the model. Unlike ``Simplify`` these helpers do not ``Check`` the
-// model up front -- the point of running a step in isolation is to debug a model
-// that may not yet be fully valid.
+// model up front -- the point of running a step in isolation is to debug a
+// model that may not yet be fully valid.
 void PrepareSchemasForDebug(const onnx::ModelProto& model) {
   onnxsim::RegisterContribOpSchemas();
   FixupSchemaDeterminism();

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -94,6 +94,26 @@ onnx::ModelProto Simplify(
     const GraphRewriter* rewriter = nullptr,
     bool initializers_as_constants = true);
 
+// Debugging helpers: run a *single* one of the transforms that ``Simplify``
+// otherwise drives to a fixed point, once, on a copy of ``model``, and return
+// the result. They let a caller inspect the isolated effect of a step (e.g. the
+// WASM converter's "run a single feature" panel) instead of the whole
+// fixed-point simplification. The input model is never mutated.
+//
+// ``InferShapesOnce`` runs ONNX shape inference (populates value_info / output
+// types). ``PropagateDataOnce`` runs onnxsim's partial-shape / data-propagation
+// pass, which rewrites nodes whose output value became statically known into
+// ``Constant`` nodes. ``FoldConstantOnce`` runs the same partial-shape pass and
+// then one constant-folding round through ``executor`` (so it needs a model
+// executor, exactly like ``Simplify``); ``tensor_size_threshold`` caps the size
+// of tensors that folding may materialize, matching ``Simplify``'s parameter.
+onnx::ModelProto InferShapesOnce(const onnx::ModelProto& model);
+onnx::ModelProto PropagateDataOnce(const onnx::ModelProto& model);
+onnx::ModelProto FoldConstantOnce(const ModelExecutor& executor,
+                                  const onnx::ModelProto& model,
+                                  size_t tensor_size_threshold,
+                                  bool initializers_as_constants = true);
+
 void SimplifyPath(const ModelExecutor& executor, const std::string& in_path,
                   const std::string& out_path,
                   std::optional<std::vector<std::string>> skip_optimizers,

--- a/scripts/convertmodel/.c8rc.json
+++ b/scripts/convertmodel/.c8rc.json
@@ -13,6 +13,7 @@
     "issue_report.mjs",
     "macs.mjs",
     "netron.mjs",
+    "query_params.mjs",
     "trace_build.mjs",
     "versions.mjs",
     "xet_cache.mjs"

--- a/scripts/convertmodel/.c8rc.json
+++ b/scripts/convertmodel/.c8rc.json
@@ -7,12 +7,14 @@
   "all": true,
   "src": ["."],
   "include": [
+    "backend_test.mjs",
     "hf_models.mjs",
     "inference_core.mjs",
     "issue_report.mjs",
     "macs.mjs",
     "netron.mjs",
     "trace_build.mjs",
+    "versions.mjs",
     "xet_cache.mjs"
   ],
   "exclude": [

--- a/scripts/convertmodel/backend_test.mjs
+++ b/scripts/convertmodel/backend_test.mjs
@@ -21,6 +21,35 @@ import { syncInputUrl } from "./query_params.mjs";
 const ORT_VERSION = "1.27.0";
 const ORT_BASE = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ORT_VERSION}/dist/`;
 
+// A curated set of common ONNX backend *node* test cases for the picker, like
+// the Hugging Face model dropdown. Each entry's value is the GitHub tree URL of
+// the test-case directory; the free-text box accepts any other URL. The base is
+// onnx/onnx@main's node-test data directory.
+const BACKEND_NODE_BASE =
+  "https://github.com/onnx/onnx/tree/main/onnx/backend/test/data/node/";
+export const BACKEND_PRESETS = [
+  "test_relu",
+  "test_sigmoid",
+  "test_tanh",
+  "test_abs",
+  "test_exp",
+  "test_log",
+  "test_softmax_example",
+  "test_add",
+  "test_sub",
+  "test_mul",
+  "test_div",
+  "test_matmul_2d",
+  "test_gemm_default_zero_bias",
+  "test_transpose_default",
+  "test_concat_1d_axis_0",
+  "test_conv_with_strides_no_padding",
+  "test_basic_conv_with_padding",
+  "test_maxpool_2d_default",
+  "test_averagepool_2d_default",
+  "test_reduce_mean_default_axes_keepdims_example",
+].map((name) => ({ name, url: BACKEND_NODE_BASE + name }));
+
 // ONNX TensorProto.DataType -> onnxruntime-web tensor type + the typed-array
 // constructor over the raw little-endian bytes. STRING/COMPLEX are unbridged
 // (the module's parser rejects them before we get here).
@@ -349,6 +378,7 @@ async function runBackendTest(url, tol, epPref, convert, log) {
 
 function initBackendPanel() {
   const btn = document.getElementById("backend-run");
+  const select = document.getElementById("backend-select");
   const urlInput = document.getElementById("backend-url");
   const epSelect = document.getElementById("backend-ep");
   const atolInput = document.getElementById("backend-atol");
@@ -356,7 +386,23 @@ function initBackendPanel() {
   const out = document.getElementById("backend-output");
   const dlBtn = document.getElementById("backend-download-log");
   const convertChk = document.getElementById("backend-convert");
+  const statusEl = document.getElementById("backend-status");
   if (!btn) return;
+
+  // Populate the preset picker and mirror a pick into the free-text box, so the
+  // two never disagree about what "Run test case" will fetch (like the Hugging
+  // Face model dropdown / text box pair).
+  if (select) {
+    for (const { name, url } of BACKEND_PRESETS) {
+      const opt = document.createElement("option");
+      opt.value = url;
+      opt.textContent = name.replace(/^test_/, "");
+      select.appendChild(opt);
+    }
+    select.addEventListener("change", () => {
+      if (select.value && urlInput) urlInput.value = select.value;
+    });
+  }
 
   const log = (msg) => {
     if (!out) return;
@@ -370,6 +416,7 @@ function initBackendPanel() {
   btn.addEventListener("click", async () => {
     btn.disabled = true;
     if (out) out.value = "";
+    if (statusEl) statusEl.textContent = "running…";
     try {
       const tol = {
         atol: parseFloat(atolInput ? atolInput.value : "") || 1e-4,
@@ -377,9 +424,11 @@ function initBackendPanel() {
       };
       const epPref = epSelect ? epSelect.value : "wasm";
       const convert = convertChk ? convertChk.checked : false;
-      await runBackendTest(urlInput ? urlInput.value : "", tol, epPref, convert, log);
+      const passed = await runBackendTest(urlInput ? urlInput.value : "", tol, epPref, convert, log);
+      if (statusEl) statusEl.textContent = passed ? "PASS ✅" : "FAIL ❌";
     } catch (e) {
       log("ERROR: " + (e && e.message ? e.message : String(e)));
+      if (statusEl) statusEl.textContent = "error — see output";
     } finally {
       btn.disabled = false;
     }

--- a/scripts/convertmodel/backend_test.mjs
+++ b/scripts/convertmodel/backend_test.mjs
@@ -1,0 +1,362 @@
+// Browser glue for the "Run an ONNX backend test case" panel.
+//
+// The ONNX repo ships backend test cases under onnx/backend/test/data/... Each
+// case directory holds a `model.onnx` plus one or more `test_data_set_N/`
+// directories of serialized TensorProtos: `input_*.pb` feed the model's graph
+// inputs (positionally) and `output_*.pb` are the expected results. Given a URL
+// to such a directory, this panel fetches the model and the test data, runs the
+// model through onnxruntime-web, and checks each output against the expected
+// tensor within tolerance.
+//
+// GitHub `tree`/`blob` URLs, `raw.githubusercontent.com` URLs, and the contents
+// API URL are all accepted (see parseGithubDirUrl). Directory listing and raw
+// file bytes come from the GitHub REST contents API (CORS-enabled, but
+// unauthenticated and rate-limited — fine for a demo). TensorProtos are decoded
+// by the module's `onnxsim_parse_tensor` (this page's runtime), which needs no
+// onnxruntime-web, so decoding works even if inference can't run.
+
+import { downloadText } from "./download.mjs";
+
+const ORT_VERSION = "1.27.0";
+const ORT_BASE = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ORT_VERSION}/dist/`;
+
+// ONNX TensorProto.DataType -> onnxruntime-web tensor type + the typed-array
+// constructor over the raw little-endian bytes. STRING/COMPLEX are unbridged
+// (the module's parser rejects them before we get here).
+export const ONNX_DTYPE = {
+  1: { ort: "float32", Ctor: Float32Array },
+  2: { ort: "uint8", Ctor: Uint8Array },
+  3: { ort: "int8", Ctor: Int8Array },
+  4: { ort: "uint16", Ctor: Uint16Array },
+  5: { ort: "int16", Ctor: Int16Array },
+  6: { ort: "int32", Ctor: Int32Array },
+  7: { ort: "int64", Ctor: typeof BigInt64Array !== "undefined" ? BigInt64Array : null },
+  9: { ort: "bool", Ctor: Uint8Array },
+  10: { ort: "float16", Ctor: Uint16Array },
+  11: { ort: "float64", Ctor: Float64Array },
+  12: { ort: "uint32", Ctor: Uint32Array },
+  13: { ort: "uint64", Ctor: typeof BigUint64Array !== "undefined" ? BigUint64Array : null },
+  16: { ort: "float16", Ctor: Uint16Array }, // BFLOAT16 has no ort type; view raw.
+};
+
+// Parse a URL that points at a directory in a GitHub repo into
+// { owner, repo, ref, path }. Accepts:
+//   https://github.com/<owner>/<repo>/tree/<ref>/<path...>
+//   https://github.com/<owner>/<repo>/blob/<ref>/<path...>
+//   https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<path...>
+//   https://api.github.com/repos/<owner>/<repo>/contents/<path...>?ref=<ref>
+// Returns null if it is not a recognizable GitHub URL.
+export function parseGithubDirUrl(url) {
+  let u;
+  try {
+    u = new URL(String(url).trim());
+  } catch {
+    return null;
+  }
+  const seg = u.pathname.split("/").filter(Boolean).map(decodeURIComponent);
+  const host = u.hostname.toLowerCase();
+
+  if (host === "github.com") {
+    // <owner>/<repo>/(tree|blob)/<ref>/<path...>
+    if (seg.length >= 4 && (seg[2] === "tree" || seg[2] === "blob")) {
+      return {
+        owner: seg[0],
+        repo: seg[1],
+        ref: seg[3],
+        path: seg.slice(4).join("/"),
+      };
+    }
+    return null;
+  }
+  if (host === "raw.githubusercontent.com") {
+    // <owner>/<repo>/<ref>/<path...>
+    if (seg.length >= 3) {
+      return {
+        owner: seg[0],
+        repo: seg[1],
+        ref: seg[2],
+        path: seg.slice(3).join("/"),
+      };
+    }
+    return null;
+  }
+  if (host === "api.github.com") {
+    // repos/<owner>/<repo>/contents/<path...>?ref=<ref>
+    if (seg.length >= 4 && seg[0] === "repos" && seg[3] === "contents") {
+      return {
+        owner: seg[1],
+        repo: seg[2],
+        ref: u.searchParams.get("ref") || "main",
+        path: seg.slice(4).join("/"),
+      };
+    }
+    return null;
+  }
+  return null;
+}
+
+// The numeric suffix of an "input_12.pb" / "output_3.pb" name, for ordering the
+// tensors by graph position (so input_10 sorts after input_2, not before).
+export function tensorIndex(name) {
+  const m = /_(\d+)\.pb$/.exec(name);
+  return m ? parseInt(m[1], 10) : Number.MAX_SAFE_INTEGER;
+}
+
+// Build the GitHub contents-API URL for a repo path.
+function contentsApiUrl({ owner, repo, ref, path }) {
+  const base = `https://api.github.com/repos/${owner}/${repo}/contents/`;
+  const p = path ? path.split("/").map(encodeURIComponent).join("/") : "";
+  return `${base}${p}?ref=${encodeURIComponent(ref)}`;
+}
+
+async function listDir(loc, onLog) {
+  const url = contentsApiUrl(loc);
+  const resp = await fetch(url, { headers: { Accept: "application/vnd.github+json" } });
+  if (!resp.ok) {
+    const hint =
+      resp.status === 403
+        ? " (GitHub's unauthenticated API rate limit may be exhausted — try again later)"
+        : resp.status === 404
+          ? " (not found — check the URL points at a test-case directory)"
+          : "";
+    throw new Error(`listing ${loc.path || "/"} failed: HTTP ${resp.status}${hint}`);
+  }
+  const json = await resp.json();
+  if (!Array.isArray(json)) {
+    throw new Error(`${loc.path || "/"} is not a directory`);
+  }
+  return json; // [{ name, type: "file"|"dir", download_url, ... }]
+}
+
+async function fetchBytes(url) {
+  const resp = await fetch(url);
+  if (!resp.ok) throw new Error(`fetch ${url} failed: HTTP ${resp.status}`);
+  return new Uint8Array(await resp.arrayBuffer());
+}
+
+// Decode a serialized TensorProto via the page runtime into
+// { dtype, name, dims, bytes } (bytes copied out of the wasm heap).
+function parseTensor(runtime, pbBytes) {
+  // onnxsim_parse_tensor takes the raw bytes as a string arg (embind std::string
+  // accepts a JS string or a typed array of bytes); pass the Uint8Array.
+  const res = runtime.onnxsim_parse_tensor(pbBytes);
+  if (!res || res.error) {
+    throw new Error(res ? res.error : "failed to parse tensor");
+  }
+  return {
+    dtype: res.dtype,
+    name: res.name,
+    dims: Array.from(res.dims, (d) => Number(d)),
+    bytes: new Uint8Array(res.data), // copy out of wasm heap
+  };
+}
+
+// Build a typed array of the tensor's elements from its raw little-endian bytes.
+function typedFromTensor(t) {
+  const info = ONNX_DTYPE[t.dtype];
+  if (!info || !info.Ctor) {
+    throw new Error(`unsupported tensor dtype ${t.dtype}`);
+  }
+  const per = info.Ctor.BYTES_PER_ELEMENT;
+  if (t.bytes.byteLength % per !== 0) {
+    throw new Error(`tensor byte length ${t.bytes.byteLength} not a multiple of ${per}`);
+  }
+  return new info.Ctor(t.bytes.buffer, t.bytes.byteOffset, t.bytes.byteLength / per);
+}
+
+// Compare an actual onnxruntime output (typed array + dims) against an expected
+// parsed tensor within tolerance. Integer/bool/bigint data must match exactly;
+// floats use |a-b| <= atol + rtol*|expected|. Returns
+// { ok, maxDiff, shapeOk, n, firstBad }.
+export function compareTensors(actualData, actualDims, expected, { atol = 1e-4, rtol = 1e-3 } = {}) {
+  const exp = typedFromTensor(expected);
+  const shapeOk = arraysEqual(actualDims.map(Number), expected.dims.map(Number));
+  const n = Math.min(actualData.length, exp.length);
+  let maxDiff = 0;
+  let firstBad = -1;
+  const isBig = typeof actualData[0] === "bigint" || typeof exp[0] === "bigint";
+  for (let i = 0; i < n; i++) {
+    if (isBig) {
+      if (BigInt(actualData[i]) !== BigInt(exp[i])) {
+        if (firstBad < 0) firstBad = i;
+        maxDiff = Infinity;
+      }
+      continue;
+    }
+    const a = Number(actualData[i]);
+    const b = Number(exp[i]);
+    const diff = Math.abs(a - b);
+    if (diff > maxDiff) maxDiff = diff;
+    if (diff > atol + rtol * Math.abs(b) && firstBad < 0) firstBad = i;
+  }
+  const lenOk = actualData.length === exp.length;
+  const ok = shapeOk && lenOk && firstBad < 0;
+  return { ok, maxDiff, shapeOk: shapeOk && lenOk, n, firstBad };
+}
+
+function arraysEqual(a, b) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+let ortPromise = null;
+function loadOrt() {
+  if (!ortPromise) {
+    ortPromise = import(/* @vite-ignore */ `${ORT_BASE}ort.min.mjs`).then((m) => {
+      const ort = m.default ?? m;
+      ort.env.wasm.wasmPaths = ORT_BASE;
+      return ort;
+    });
+  }
+  return ortPromise;
+}
+
+// Group a test-case directory's entries into { modelUrl, dataSets: [{name,url}] }.
+function classifyCaseDir(entries) {
+  let modelUrl = null;
+  const dataSets = [];
+  for (const e of entries) {
+    if (e.type === "file" && e.name === "model.onnx") modelUrl = e.download_url;
+    else if (e.type === "dir" && /^test_data_set_\d+$/.test(e.name)) dataSets.push(e);
+  }
+  dataSets.sort((a, b) => tensorIndex(a.name + ".pb") - tensorIndex(b.name + ".pb"));
+  return { modelUrl, dataSets };
+}
+
+// Run one test_data_set: fetch/parse its input_*.pb and output_*.pb, run the
+// session, and compare. Returns { name, passed, lines }.
+async function runDataSet(ort, runtime, session, loc, setEntry, tol, log) {
+  const setLoc = { ...loc, path: `${loc.path}/${setEntry.name}` };
+  const entries = await listDir(setLoc, log);
+  const inputs = entries.filter((e) => e.type === "file" && /^input_\d+\.pb$/.test(e.name));
+  const outputs = entries.filter((e) => e.type === "file" && /^output_\d+\.pb$/.test(e.name));
+  inputs.sort((a, b) => tensorIndex(a.name) - tensorIndex(b.name));
+  outputs.sort((a, b) => tensorIndex(a.name) - tensorIndex(b.name));
+
+  const feeds = {};
+  for (let i = 0; i < inputs.length; i++) {
+    const t = parseTensor(runtime, await fetchBytes(inputs[i].download_url));
+    const name = session.inputNames[i] ?? t.name;
+    feeds[name] = new ort.Tensor(ONNX_DTYPE[t.dtype].ort, typedFromTensor(t), t.dims);
+  }
+  const results = await session.run(feeds);
+
+  const lines = [];
+  let passed = true;
+  for (let i = 0; i < outputs.length; i++) {
+    const expected = parseTensor(runtime, await fetchBytes(outputs[i].download_url));
+    const outName = session.outputNames[i];
+    const got = results[outName];
+    if (!got) {
+      passed = false;
+      lines.push(`  output ${i} '${outName}': MISSING from run results`);
+      continue;
+    }
+    const cmp = compareTensors(got.data, got.dims, expected, tol);
+    if (cmp.ok) {
+      lines.push(`  output ${i} '${outName}': OK (maxDiff ${cmp.maxDiff.toExponential(2)})`);
+    } else {
+      passed = false;
+      const why = !cmp.shapeOk
+        ? `shape/length mismatch (got [${Array.from(got.dims).join(",")}], expected [${expected.dims.join(",")}])`
+        : `maxDiff ${cmp.maxDiff.toExponential(2)} exceeds tol (atol ${tol.atol}, rtol ${tol.rtol}), first at index ${cmp.firstBad}`;
+      lines.push(`  output ${i} '${outName}': FAIL — ${why}`);
+    }
+  }
+  return { name: setEntry.name, passed, lines };
+}
+
+async function runBackendTest(url, tol, epPref, log) {
+  const loc = parseGithubDirUrl(url);
+  if (!loc) {
+    throw new Error(
+      "could not parse the URL — paste a GitHub directory URL like " +
+        "https://github.com/onnx/onnx/tree/main/onnx/backend/test/data/node/test_relu",
+    );
+  }
+  log(`case: ${loc.owner}/${loc.repo}@${loc.ref} :: ${loc.path}`);
+  const runtime = await window.__onnxsimRuntimePromise;
+
+  log("listing the test-case directory…");
+  const entries = await listDir(loc, log);
+  const { modelUrl, dataSets } = classifyCaseDir(entries);
+  if (!modelUrl) throw new Error("no model.onnx found in that directory");
+  if (!dataSets.length) throw new Error("no test_data_set_* directories found");
+  log(`found model.onnx and ${dataSets.length} test data set(s)`);
+
+  log(`fetching model.onnx…`);
+  const modelBytes = await fetchBytes(modelUrl);
+
+  log(`loading onnxruntime-web ${ORT_VERSION}…`);
+  const ort = await loadOrt();
+  const providers = epPref === "webgpu" ? ["webgpu", "wasm"] : ["wasm"];
+  let session = null;
+  let usedEp = null;
+  for (const ep of providers) {
+    try {
+      session = await ort.InferenceSession.create(modelBytes, {
+        executionProviders: [ep],
+        graphOptimizationLevel: "all",
+      });
+      usedEp = ep;
+      break;
+    } catch (e) {
+      log(`execution provider '${ep}' unavailable: ${e && e.message ? e.message : e}`);
+    }
+  }
+  if (!session) throw new Error("could not create an inference session on any provider");
+  log(`session ready on '${usedEp}' (inputs: ${session.inputNames.join(", ")}; outputs: ${session.outputNames.join(", ")})`);
+
+  let allPassed = true;
+  for (const setEntry of dataSets) {
+    log(`running ${setEntry.name}…`);
+    const r = await runDataSet(ort, runtime, session, loc, setEntry, tol, log);
+    for (const line of r.lines) log(line);
+    log(`${setEntry.name}: ${r.passed ? "PASS" : "FAIL"}`);
+    allPassed = allPassed && r.passed;
+  }
+  log(allPassed ? "RESULT: PASS ✅" : "RESULT: FAIL ❌");
+  return allPassed;
+}
+
+function initBackendPanel() {
+  const btn = document.getElementById("backend-run");
+  const urlInput = document.getElementById("backend-url");
+  const epSelect = document.getElementById("backend-ep");
+  const atolInput = document.getElementById("backend-atol");
+  const rtolInput = document.getElementById("backend-rtol");
+  const out = document.getElementById("backend-output");
+  const dlBtn = document.getElementById("backend-download-log");
+  if (!btn) return;
+
+  const log = (msg) => {
+    if (!out) return;
+    out.value += msg + "\n";
+    out.scrollTop = out.scrollHeight;
+  };
+  if (dlBtn) {
+    dlBtn.addEventListener("click", () => downloadText((out && out.value) || "", "onnxsim-backend-test.log"));
+  }
+
+  btn.addEventListener("click", async () => {
+    btn.disabled = true;
+    if (out) out.value = "";
+    try {
+      const tol = {
+        atol: parseFloat(atolInput ? atolInput.value : "") || 1e-4,
+        rtol: parseFloat(rtolInput ? rtolInput.value : "") || 1e-3,
+      };
+      const epPref = epSelect ? epSelect.value : "wasm";
+      await runBackendTest(urlInput ? urlInput.value : "", tol, epPref, log);
+    } catch (e) {
+      log("ERROR: " + (e && e.message ? e.message : String(e)));
+    } finally {
+      btn.disabled = false;
+    }
+  });
+}
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  initBackendPanel();
+}

--- a/scripts/convertmodel/backend_test.mjs
+++ b/scripts/convertmodel/backend_test.mjs
@@ -16,6 +16,7 @@
 // onnxruntime-web, so decoding works even if inference can't run.
 
 import { downloadText } from "./download.mjs";
+import { syncInputUrl } from "./query_params.mjs";
 
 const ORT_VERSION = "1.27.0";
 const ORT_BASE = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ORT_VERSION}/dist/`;
@@ -276,6 +277,8 @@ async function runBackendTest(url, tol, epPref, convert, log) {
     );
   }
   log(`case: ${loc.owner}/${loc.repo}@${loc.ref} :: ${loc.path}`);
+  // Reflect the test-case URL in the address bar so the link is shareable.
+  syncInputUrl("backend", url);
   const runtime = await window.__onnxsimRuntimePromise;
 
   log("listing the test-case directory…");

--- a/scripts/convertmodel/backend_test.mjs
+++ b/scripts/convertmodel/backend_test.mjs
@@ -267,7 +267,7 @@ async function runDataSet(ort, runtime, session, loc, setEntry, tol, log) {
   return { name: setEntry.name, passed, lines };
 }
 
-async function runBackendTest(url, tol, epPref, log) {
+async function runBackendTest(url, tol, epPref, convert, log) {
   const loc = parseGithubDirUrl(url);
   if (!loc) {
     throw new Error(
@@ -287,15 +287,28 @@ async function runBackendTest(url, tol, epPref, log) {
 
   log(`fetching model.onnx…`);
   const modelBytes = await fetchBytes(modelUrl);
+  const caseName = (loc.path.split("/").filter(Boolean).pop() || "model") + ".onnx";
 
-  // Preview the fetched model in the "Before" Netron pane (like the text-graph
-  // parser does), naming it after the test case so the pane is labelled.
+  // Make the fetched model a first-class converter input, like the text-graph
+  // parser: preview it in the "Before" Netron pane and publish it as the
+  // inference panel's "original" source.
   if (typeof window.netronShowBefore === "function") {
-    const caseName = (loc.path.split("/").filter(Boolean).pop() || "model") + ".onnx";
     try {
       window.netronShowBefore(modelBytes, caseName);
     } catch {
       // Best-effort preview: a Netron hiccup must not fail the test run.
+    }
+  }
+  window.__onnxsimOriginal = { bytes: modelBytes, name: caseName };
+  // Optionally run it straight through the Simplify / Optimize path (a copy,
+  // since startConversion transfers and detaches the buffer it is given, and we
+  // still need modelBytes for the inference session below).
+  if (convert && typeof window.__onnxsimStartConversion === "function") {
+    log(`sending ${caseName} through the converter…`);
+    try {
+      window.__onnxsimStartConversion(caseName, modelBytes.slice().buffer);
+    } catch (e) {
+      log(`could not start conversion: ${e && e.message ? e.message : e}`);
     }
   }
 
@@ -339,6 +352,7 @@ function initBackendPanel() {
   const rtolInput = document.getElementById("backend-rtol");
   const out = document.getElementById("backend-output");
   const dlBtn = document.getElementById("backend-download-log");
+  const convertChk = document.getElementById("backend-convert");
   if (!btn) return;
 
   const log = (msg) => {
@@ -359,7 +373,8 @@ function initBackendPanel() {
         rtol: parseFloat(rtolInput ? rtolInput.value : "") || 1e-3,
       };
       const epPref = epSelect ? epSelect.value : "wasm";
-      await runBackendTest(urlInput ? urlInput.value : "", tol, epPref, log);
+      const convert = convertChk ? convertChk.checked : false;
+      await runBackendTest(urlInput ? urlInput.value : "", tol, epPref, convert, log);
     } catch (e) {
       log("ERROR: " + (e && e.message ? e.message : String(e)));
     } finally {

--- a/scripts/convertmodel/backend_test.mjs
+++ b/scripts/convertmodel/backend_test.mjs
@@ -288,6 +288,17 @@ async function runBackendTest(url, tol, epPref, log) {
   log(`fetching model.onnx…`);
   const modelBytes = await fetchBytes(modelUrl);
 
+  // Preview the fetched model in the "Before" Netron pane (like the text-graph
+  // parser does), naming it after the test case so the pane is labelled.
+  if (typeof window.netronShowBefore === "function") {
+    const caseName = (loc.path.split("/").filter(Boolean).pop() || "model") + ".onnx";
+    try {
+      window.netronShowBefore(modelBytes, caseName);
+    } catch {
+      // Best-effort preview: a Netron hiccup must not fail the test run.
+    }
+  }
+
   log(`loading onnxruntime-web ${ORT_VERSION}…`);
   const ort = await loadOrt();
   const providers = epPref === "webgpu" ? ["webgpu", "wasm"] : ["wasm"];

--- a/scripts/convertmodel/debug_tools.mjs
+++ b/scripts/convertmodel/debug_tools.mjs
@@ -9,6 +9,7 @@
 // Parsing needs no model executor, so it runs on this page's runtime directly.
 
 import { downloadBytes } from "./download.mjs";
+import { syncInputUrl } from "./query_params.mjs";
 
 // Resolve this page's WASM runtime (published by index.html's inline loader).
 function getRuntime() {
@@ -56,6 +57,8 @@ async function initParsePanel() {
       // inference panel's "original" source.
       if (window.netronShowBefore) window.netronShowBefore(bytes, name);
       window.__onnxsimOriginal = { bytes, name };
+      // Reflect the graph text in the address bar so the link is shareable.
+      syncInputUrl("graph", text);
       // Optionally run it straight through the converter using the currently
       // selected mode (a fresh copy, since startConversion transfers and
       // detaches the buffer it is given).

--- a/scripts/convertmodel/debug_tools.mjs
+++ b/scripts/convertmodel/debug_tools.mjs
@@ -1,0 +1,249 @@
+// Browser glue for two debugging panels on the converter page:
+//
+//   1. "Parse a text graph" — parse the ONNX textual representation (the form
+//      onnx.parser.parse_graph / parse_model accept) into a model with the
+//      module's `onnxsim_parse_graph`, then drive it through the same
+//      Simplify/visualize path as an uploaded file. Also makes the parsed model
+//      the source for the single-feature passes below.
+//
+//   2. "Run a single feature" — run exactly one of the transforms Simplify
+//      otherwise drives to a fixed point (shape inference, ONNX data
+//      propagation, or constant folding) once, so its isolated effect can be
+//      inspected. The pass runs in the conversion worker (constant folding needs
+//      the same model executor Simplify uses), and the result is shown in the
+//      "After" Netron pane and offered as a download.
+//
+// Parsing needs no model executor, so it runs on this page's runtime directly;
+// the single-feature passes go through the worker.
+
+import { downloadBytes } from "./download.mjs";
+
+// Resolve this page's WASM runtime (published by index.html's inline loader).
+function getRuntime() {
+  return window.__onnxsimRuntimePromise;
+}
+
+// Resolve the conversion worker, waiting for index.html to create it if needed.
+function getWorker() {
+  return new Promise((resolve) => {
+    if (window.__onnxsimWorker) {
+      resolve(window.__onnxsimWorker);
+      return;
+    }
+    window.addEventListener(
+      "onnxsim:worker-ready",
+      () => resolve(window.__onnxsimWorker),
+      { once: true },
+    );
+  });
+}
+
+// Resolve once BOTH WASM runtimes are up (index.html dispatches "onnxsim:ready"
+// from maybeEnableInput). A pass posted before the worker's runtime has
+// registered its message listener would be silently dropped, so the pass
+// buttons wait for this first.
+function whenReady() {
+  return new Promise((resolve) => {
+    if (window.__onnxsimReady) {
+      resolve();
+      return;
+    }
+    window.addEventListener("onnxsim:ready", () => resolve(), { once: true });
+  });
+}
+
+// The model the single-feature passes operate on: an uploaded/parsed/loaded
+// model, or a previous pass's output (so passes can be chained). Kept as a copy
+// so the worker transfer of a per-run duplicate never detaches it.
+let debugSource = null; // { bytes: Uint8Array, name: string }
+
+function setDebugSource(bytes, name) {
+  debugSource = { bytes, name };
+  const label = document.getElementById("debug-source-name");
+  if (label) label.textContent = name ? `current model: ${name}` : "no model loaded yet";
+}
+
+// ---- Parse a text graph ----------------------------------------------------
+
+async function initParsePanel() {
+  const textEl = document.getElementById("parse-graph-text");
+  const btn = document.getElementById("parse-graph-button");
+  const convertChk = document.getElementById("parse-graph-convert");
+  const statusEl = document.getElementById("parse-graph-status");
+  const dlBtn = document.getElementById("parse-graph-download");
+  if (!btn) return;
+
+  let lastBytes = null;
+  const setStatus = (msg) => {
+    if (statusEl) statusEl.textContent = msg;
+  };
+
+  btn.addEventListener("click", async () => {
+    const text = (textEl && textEl.value) || "";
+    if (!text.trim()) {
+      setStatus("Enter an ONNX text graph first.");
+      return;
+    }
+    btn.disabled = true;
+    setStatus("parsing…");
+    try {
+      const runtime = await getRuntime();
+      const res = runtime.onnxsim_parse_graph(text);
+      if (!res || res.error) {
+        setStatus("parse failed: " + (res ? res.error : "unknown error"));
+        return;
+      }
+      // res.model is a view into the wasm heap — copy it out immediately.
+      const bytes = new Uint8Array(res.model);
+      lastBytes = bytes;
+      const name = "parsed_graph.onnx";
+      setStatus(`parsed OK (${bytes.length} bytes).`);
+      if (dlBtn) {
+        dlBtn.style.display = "";
+        dlBtn.onclick = () => downloadBytes(lastBytes, name);
+      }
+      // Show the parsed model in the "Before" Netron pane and make it the
+      // single-feature source.
+      if (window.netronShowBefore) window.netronShowBefore(bytes, name);
+      setDebugSource(bytes, name);
+      // Optionally run it straight through the converter (a fresh copy, since
+      // startConversion transfers and detaches the buffer it is given).
+      if ((!convertChk || convertChk.checked) && window.__onnxsimStartConversion) {
+        window.__onnxsimOriginal = { bytes, name };
+        window.__onnxsimStartConversion(name, bytes.slice().buffer);
+      }
+    } catch (err) {
+      setStatus("parse error: " + (err && err.message ? err.message : err));
+    } finally {
+      btn.disabled = false;
+    }
+  });
+}
+
+// ---- Run a single feature (debug passes) -----------------------------------
+
+async function initSinglePanel() {
+  const fileInput = document.getElementById("debug-file-input");
+  const useConvertedBtn = document.getElementById("debug-use-converted");
+  const thresholdInput = document.getElementById("debug-tensor-size-threshold");
+  const out = document.getElementById("debug-output");
+  const dlBtn = document.getElementById("debug-download");
+  const buttons = {
+    infer_shapes: document.getElementById("debug-infer-shapes"),
+    data_propagation: document.getElementById("debug-data-propagation"),
+    fold_constant: document.getElementById("debug-fold-constant"),
+  };
+  if (!buttons.infer_shapes) return;
+
+  const log = (msg) => {
+    if (!out) return;
+    out.value += msg + "\n";
+    out.scrollTop = out.scrollHeight;
+  };
+
+  // Its own file input keeps the debug source independent of the converter's
+  // transfer-and-detach upload flow.
+  if (fileInput) {
+    fileInput.addEventListener("change", async (e) => {
+      const file = e.target.files && e.target.files[0];
+      if (!file) return;
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      setDebugSource(bytes, file.name);
+      log(`loaded ${file.name} (${bytes.length} bytes) as the debug source`);
+    });
+  }
+
+  if (useConvertedBtn) {
+    useConvertedBtn.addEventListener("click", () => {
+      const c = window.__onnxsimConverted;
+      if (!c || !c.bytes) {
+        log("no converted model yet — run a conversion above first.");
+        return;
+      }
+      setDebugSource(new Uint8Array(c.bytes), c.name || "converted.onnx");
+      log(`using the converted result (${c.name || "converted.onnx"}) as the debug source`);
+    });
+  }
+
+  const setBusy = (busy) => {
+    for (const b of Object.values(buttons)) if (b) b.disabled = busy;
+  };
+
+  let lastResult = null; // { bytes, name }
+  if (dlBtn) {
+    dlBtn.onclick = () => {
+      if (lastResult) downloadBytes(lastResult.bytes, lastResult.name);
+    };
+  }
+
+  const PASS_LABELS = {
+    infer_shapes: "shape inference",
+    data_propagation: "data propagation",
+    fold_constant: "constant folding",
+  };
+
+  const runPass = async (type) => {
+    if (!debugSource) {
+      log("no model loaded — pick a file (or use the converted result / a parsed graph) first.");
+      return;
+    }
+    setBusy(true);
+    log(`running ${PASS_LABELS[type]} on ${debugSource.name}…`);
+    try {
+      // Wait until the worker's runtime is initialized so the pass message is
+      // not dropped, then grab the worker handle.
+      await whenReady();
+      const worker = await getWorker();
+      // Send a fresh copy of the source bytes; the worker transfers the buffer.
+      const buf = debugSource.bytes.slice().buffer;
+      const threshold = parseInt(thresholdInput ? thresholdInput.value : "", 10);
+      const done = new Promise((resolve) => {
+        const onMessage = (e) => {
+          if (!e.data || e.data[0] !== "debug-done" || e.data[1] !== type) return;
+          worker.removeEventListener("message", onMessage);
+          resolve({ dataUrl: e.data[2], error: e.data[3] });
+        };
+        worker.addEventListener("message", onMessage);
+      });
+      const args =
+        type === "fold_constant"
+          ? [type, buf, Number.isFinite(threshold) ? threshold : 1000000000]
+          : [type, buf];
+      worker.postMessage(args, [buf]);
+      const { dataUrl, error } = await done;
+      if (error || !dataUrl) {
+        log(`${PASS_LABELS[type]} failed: ${error || "no model produced"}`);
+        return;
+      }
+      const resultBytes = dataUrlToBytes(dataUrl);
+      const name = `${debugSource.name.replace(/\.onnx$/i, "")}.${type}.onnx`;
+      lastResult = { bytes: resultBytes, name };
+      if (dlBtn) dlBtn.style.display = "";
+      // Show the result in the shared "After" Netron pane and make it the next
+      // debug source so passes can be chained (e.g. shape-infer then fold).
+      if (window.netronShowAfter) window.netronShowAfter(dataUrl, name);
+      setDebugSource(resultBytes, name);
+      log(`${PASS_LABELS[type]} done → ${name} (${resultBytes.length} bytes). Shown in the "After" Netron pane; download available.`);
+    } catch (err) {
+      log(`${PASS_LABELS[type]} error: ${err && err.message ? err.message : err}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  for (const [type, btn] of Object.entries(buttons)) {
+    if (btn) btn.addEventListener("click", () => runPass(type));
+  }
+}
+
+// Decode a "data:...;base64,<b64>" URL into a Uint8Array.
+function dataUrlToBytes(dataUrl) {
+  const b64 = dataUrl.slice(dataUrl.indexOf(",") + 1);
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+initParsePanel();
+initSinglePanel();

--- a/scripts/convertmodel/debug_tools.mjs
+++ b/scripts/convertmodel/debug_tools.mjs
@@ -1,20 +1,12 @@
-// Browser glue for two debugging panels on the converter page:
+// Browser glue for the "Parse a text graph" panel on the converter page.
 //
-//   1. "Parse a text graph" — parse the ONNX textual representation (the form
-//      onnx.parser.parse_graph / parse_model accept) into a model with the
-//      module's `onnxsim_parse_graph`, then drive it through the same
-//      Simplify/visualize path as an uploaded file. Also makes the parsed model
-//      the source for the single-feature passes below.
+// It parses the ONNX textual representation (the form onnx.parser.parse_graph /
+// parse_model accept) into a model with the module's `onnxsim_parse_graph`, then
+// drives it through the same Simplify / visualize path as an uploaded file. The
+// single-pass debugging transforms (shape inference, data propagation, constant
+// folding) are exposed as options of the converter's mode radios, not here.
 //
-//   2. "Run a single feature" — run exactly one of the transforms Simplify
-//      otherwise drives to a fixed point (shape inference, ONNX data
-//      propagation, or constant folding) once, so its isolated effect can be
-//      inspected. The pass runs in the conversion worker (constant folding needs
-//      the same model executor Simplify uses), and the result is shown in the
-//      "After" Netron pane and offered as a download.
-//
-// Parsing needs no model executor, so it runs on this page's runtime directly;
-// the single-feature passes go through the worker.
+// Parsing needs no model executor, so it runs on this page's runtime directly.
 
 import { downloadBytes } from "./download.mjs";
 
@@ -22,48 +14,6 @@ import { downloadBytes } from "./download.mjs";
 function getRuntime() {
   return window.__onnxsimRuntimePromise;
 }
-
-// Resolve the conversion worker, waiting for index.html to create it if needed.
-function getWorker() {
-  return new Promise((resolve) => {
-    if (window.__onnxsimWorker) {
-      resolve(window.__onnxsimWorker);
-      return;
-    }
-    window.addEventListener(
-      "onnxsim:worker-ready",
-      () => resolve(window.__onnxsimWorker),
-      { once: true },
-    );
-  });
-}
-
-// Resolve once BOTH WASM runtimes are up (index.html dispatches "onnxsim:ready"
-// from maybeEnableInput). A pass posted before the worker's runtime has
-// registered its message listener would be silently dropped, so the pass
-// buttons wait for this first.
-function whenReady() {
-  return new Promise((resolve) => {
-    if (window.__onnxsimReady) {
-      resolve();
-      return;
-    }
-    window.addEventListener("onnxsim:ready", () => resolve(), { once: true });
-  });
-}
-
-// The model the single-feature passes operate on: an uploaded/parsed/loaded
-// model, or a previous pass's output (so passes can be chained). Kept as a copy
-// so the worker transfer of a per-run duplicate never detaches it.
-let debugSource = null; // { bytes: Uint8Array, name: string }
-
-function setDebugSource(bytes, name) {
-  debugSource = { bytes, name };
-  const label = document.getElementById("debug-source-name");
-  if (label) label.textContent = name ? `current model: ${name}` : "no model loaded yet";
-}
-
-// ---- Parse a text graph ----------------------------------------------------
 
 async function initParsePanel() {
   const textEl = document.getElementById("parse-graph-text");
@@ -102,14 +52,14 @@ async function initParsePanel() {
         dlBtn.style.display = "";
         dlBtn.onclick = () => downloadBytes(lastBytes, name);
       }
-      // Show the parsed model in the "Before" Netron pane and make it the
-      // single-feature source.
+      // Show the parsed model in the "Before" Netron pane and publish it as the
+      // inference panel's "original" source.
       if (window.netronShowBefore) window.netronShowBefore(bytes, name);
-      setDebugSource(bytes, name);
-      // Optionally run it straight through the converter (a fresh copy, since
-      // startConversion transfers and detaches the buffer it is given).
+      window.__onnxsimOriginal = { bytes, name };
+      // Optionally run it straight through the converter using the currently
+      // selected mode (a fresh copy, since startConversion transfers and
+      // detaches the buffer it is given).
       if ((!convertChk || convertChk.checked) && window.__onnxsimStartConversion) {
-        window.__onnxsimOriginal = { bytes, name };
         window.__onnxsimStartConversion(name, bytes.slice().buffer);
       }
     } catch (err) {
@@ -120,130 +70,4 @@ async function initParsePanel() {
   });
 }
 
-// ---- Run a single feature (debug passes) -----------------------------------
-
-async function initSinglePanel() {
-  const fileInput = document.getElementById("debug-file-input");
-  const useConvertedBtn = document.getElementById("debug-use-converted");
-  const thresholdInput = document.getElementById("debug-tensor-size-threshold");
-  const out = document.getElementById("debug-output");
-  const dlBtn = document.getElementById("debug-download");
-  const buttons = {
-    infer_shapes: document.getElementById("debug-infer-shapes"),
-    data_propagation: document.getElementById("debug-data-propagation"),
-    fold_constant: document.getElementById("debug-fold-constant"),
-  };
-  if (!buttons.infer_shapes) return;
-
-  const log = (msg) => {
-    if (!out) return;
-    out.value += msg + "\n";
-    out.scrollTop = out.scrollHeight;
-  };
-
-  // Its own file input keeps the debug source independent of the converter's
-  // transfer-and-detach upload flow.
-  if (fileInput) {
-    fileInput.addEventListener("change", async (e) => {
-      const file = e.target.files && e.target.files[0];
-      if (!file) return;
-      const bytes = new Uint8Array(await file.arrayBuffer());
-      setDebugSource(bytes, file.name);
-      log(`loaded ${file.name} (${bytes.length} bytes) as the debug source`);
-    });
-  }
-
-  if (useConvertedBtn) {
-    useConvertedBtn.addEventListener("click", () => {
-      const c = window.__onnxsimConverted;
-      if (!c || !c.bytes) {
-        log("no converted model yet — run a conversion above first.");
-        return;
-      }
-      setDebugSource(new Uint8Array(c.bytes), c.name || "converted.onnx");
-      log(`using the converted result (${c.name || "converted.onnx"}) as the debug source`);
-    });
-  }
-
-  const setBusy = (busy) => {
-    for (const b of Object.values(buttons)) if (b) b.disabled = busy;
-  };
-
-  let lastResult = null; // { bytes, name }
-  if (dlBtn) {
-    dlBtn.onclick = () => {
-      if (lastResult) downloadBytes(lastResult.bytes, lastResult.name);
-    };
-  }
-
-  const PASS_LABELS = {
-    infer_shapes: "shape inference",
-    data_propagation: "data propagation",
-    fold_constant: "constant folding",
-  };
-
-  const runPass = async (type) => {
-    if (!debugSource) {
-      log("no model loaded — pick a file (or use the converted result / a parsed graph) first.");
-      return;
-    }
-    setBusy(true);
-    log(`running ${PASS_LABELS[type]} on ${debugSource.name}…`);
-    try {
-      // Wait until the worker's runtime is initialized so the pass message is
-      // not dropped, then grab the worker handle.
-      await whenReady();
-      const worker = await getWorker();
-      // Send a fresh copy of the source bytes; the worker transfers the buffer.
-      const buf = debugSource.bytes.slice().buffer;
-      const threshold = parseInt(thresholdInput ? thresholdInput.value : "", 10);
-      const done = new Promise((resolve) => {
-        const onMessage = (e) => {
-          if (!e.data || e.data[0] !== "debug-done" || e.data[1] !== type) return;
-          worker.removeEventListener("message", onMessage);
-          resolve({ dataUrl: e.data[2], error: e.data[3] });
-        };
-        worker.addEventListener("message", onMessage);
-      });
-      const args =
-        type === "fold_constant"
-          ? [type, buf, Number.isFinite(threshold) ? threshold : 1000000000]
-          : [type, buf];
-      worker.postMessage(args, [buf]);
-      const { dataUrl, error } = await done;
-      if (error || !dataUrl) {
-        log(`${PASS_LABELS[type]} failed: ${error || "no model produced"}`);
-        return;
-      }
-      const resultBytes = dataUrlToBytes(dataUrl);
-      const name = `${debugSource.name.replace(/\.onnx$/i, "")}.${type}.onnx`;
-      lastResult = { bytes: resultBytes, name };
-      if (dlBtn) dlBtn.style.display = "";
-      // Show the result in the shared "After" Netron pane and make it the next
-      // debug source so passes can be chained (e.g. shape-infer then fold).
-      if (window.netronShowAfter) window.netronShowAfter(dataUrl, name);
-      setDebugSource(resultBytes, name);
-      log(`${PASS_LABELS[type]} done → ${name} (${resultBytes.length} bytes). Shown in the "After" Netron pane; download available.`);
-    } catch (err) {
-      log(`${PASS_LABELS[type]} error: ${err && err.message ? err.message : err}`);
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  for (const [type, btn] of Object.entries(buttons)) {
-    if (btn) btn.addEventListener("click", () => runPass(type));
-  }
-}
-
-// Decode a "data:...;base64,<b64>" URL into a Uint8Array.
-function dataUrlToBytes(dataUrl) {
-  const b64 = dataUrl.slice(dataUrl.indexOf(",") + 1);
-  const bin = atob(b64);
-  const bytes = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-  return bytes;
-}
-
 initParsePanel();
-initSinglePanel();

--- a/scripts/convertmodel/hf_load.mjs
+++ b/scripts/convertmodel/hf_load.mjs
@@ -17,6 +17,7 @@ import {
   humanBytes,
 } from "./hf_models.mjs";
 import { openXetCache, makeCachingFetch } from "./xet_cache.mjs";
+import { parseInputParams, applyOptionParams } from "./query_params.mjs";
 
 const select = document.getElementById("hf-model-select");
 const refInput = document.getElementById("hf-model-input");
@@ -485,3 +486,51 @@ if (xetToggle) {
 window.addEventListener("onnxsim:converted", () => {
   if (statusEl) statusEl.textContent = "";
 });
+
+// --- Query-parameter input -------------------------------------------------
+// Let a shareable link drive the input model and conversion options, e.g.
+//   ?model=onnxmodelzoo/resnet18d_Opset18
+//   ?model=https://…/foo.onnx&optimizer=optimize&cf=0
+//   ?model=…&autoload=0        (prefill the box + options but don't auto-run)
+// The model reference reuses the Hugging Face loader's repo-id / .onnx-URL path,
+// so nothing is uploaded and the conversion is the same one an upload drives.
+(function initFromQueryParams() {
+  let params;
+  try {
+    params = parseInputParams(window.location.search);
+  } catch {
+    return;
+  }
+  // Prefill the conversion option controls so both an auto-run and a later
+  // manual run honor the link's options.
+  try {
+    const changed = applyOptionParams(params, document);
+    if (changed.length) log(`applied options from URL: ${changed.join(", ")}`);
+  } catch {
+    // Best-effort: a missing control just leaves that option at its default.
+  }
+  // Prefill the backend-test panel's URL (it reads the input when Run is clicked).
+  if (params.backend) {
+    const el = document.getElementById("backend-url");
+    if (el) el.value = params.backend;
+  }
+  if (!params.model) return;
+  if (refInput) refInput.value = params.model;
+  // Wait until both WASM runtimes are ready (index.html dispatches
+  // "onnxsim:ready" from maybeEnableInput) before loading, so the conversion
+  // entry point exists; if it already fired, go now.
+  const start = () => {
+    if (params.autoload) {
+      log(`loading input model from URL parameter: ${params.model}`);
+      doLoad();
+    } else {
+      // Just preview size / list files so the user can review before loading.
+      onRefCommitted(params.model);
+    }
+  };
+  if (window.__onnxsimReady) {
+    start();
+  } else {
+    window.addEventListener("onnxsim:ready", start, { once: true });
+  }
+})();

--- a/scripts/convertmodel/hf_load.mjs
+++ b/scripts/convertmodel/hf_load.mjs
@@ -17,7 +17,7 @@ import {
   humanBytes,
 } from "./hf_models.mjs";
 import { openXetCache, makeCachingFetch } from "./xet_cache.mjs";
-import { parseInputParams, applyOptionParams } from "./query_params.mjs";
+import { parseInputParams, applyOptionParams, syncInputUrl } from "./query_params.mjs";
 
 const select = document.getElementById("hf-model-select");
 const refInput = document.getElementById("hf-model-input");
@@ -289,6 +289,10 @@ async function doLoad() {
   loadBtn.disabled = true;
   if (fileInput) fileInput.disabled = true;
   if (statusEl) statusEl.textContent = "loading…";
+  // Reflect this input in the address bar so the link is shareable/reproducible
+  // (a Hugging Face repo id or a direct .onnx URL). Uploaded local files have no
+  // URL and are handled by the file-input path, which does not call this.
+  syncInputUrl("model", ref);
   try {
     log(`loading model from Hugging Face: ${ref}`);
     // Live download progress + speed in the status line. Speed is smoothed with

--- a/scripts/convertmodel/hf_load.mjs
+++ b/scripts/convertmodel/hf_load.mjs
@@ -17,7 +17,7 @@ import {
   humanBytes,
 } from "./hf_models.mjs";
 import { openXetCache, makeCachingFetch } from "./xet_cache.mjs";
-import { parseInputParams, applyOptionParams, syncInputUrl } from "./query_params.mjs";
+import { parseInputParams, applyOptionParams, syncInputUrl, syncUrlParam } from "./query_params.mjs";
 
 const select = document.getElementById("hf-model-select");
 const refInput = document.getElementById("hf-model-input");
@@ -492,10 +492,12 @@ window.addEventListener("onnxsim:converted", () => {
 });
 
 // --- Query-parameter input -------------------------------------------------
-// Let a shareable link drive the input model and conversion options, e.g.
+// Let a shareable link drive the input and conversion options, e.g.
 //   ?model=onnxmodelzoo/resnet18d_Opset18
 //   ?model=https://…/foo.onnx&optimizer=optimize&cf=0
-//   ?model=…&autoload=0        (prefill the box + options but don't auto-run)
+//   ?graph=<onnx text>&optimizer=fold_constant   (parse a text graph, then run)
+//   ?backend=<onnx backend test-case URL>        (prefill the backend panel)
+//   ?…&autoload=0                                 (prefill but don't auto-run)
 // The model reference reuses the Hugging Face loader's repo-id / .onnx-URL path,
 // so nothing is uploaded and the conversion is the same one an upload drives.
 (function initFromQueryParams() {
@@ -505,25 +507,51 @@ window.addEventListener("onnxsim:converted", () => {
   } catch {
     return;
   }
-  // Prefill the conversion option controls so both an auto-run and a later
-  // manual run honor the link's options.
+  // Prefill the conversion option controls (including the processor / mode radio
+  // from ?optimizer=) so both an auto-run and a later manual run honor the link.
   try {
     const changed = applyOptionParams(params, document);
     if (changed.length) log(`applied options from URL: ${changed.join(", ")}`);
   } catch {
     // Best-effort: a missing control just leaves that option at its default.
   }
+  // Reflect the conversion processor in the URL whenever the mode radio changes,
+  // so the current processor is always part of the shareable link.
+  for (const radio of document.querySelectorAll('input[name="optimizer"]')) {
+    radio.addEventListener("change", () => {
+      if (radio.checked) syncUrlParam("optimizer", radio.value);
+    });
+  }
   // Prefill the backend-test panel's URL (it reads the input when Run is clicked).
   if (params.backend) {
     const el = document.getElementById("backend-url");
     if (el) el.value = params.backend;
   }
+  // Run one of the input sources once both WASM runtimes are ready (index.html
+  // dispatches "onnxsim:ready" from maybeEnableInput), so the conversion entry
+  // point and the page runtime both exist; if it already fired, go now.
+  const whenReady = (fn) => {
+    if (window.__onnxsimReady) fn();
+    else window.addEventListener("onnxsim:ready", fn, { once: true });
+  };
+
+  // A text graph: prefill the parse box and, on autoload, click Parse (which
+  // parses and — with "convert after parsing" on — runs the selected mode).
+  if (params.graph) {
+    const ta = document.getElementById("parse-graph-text");
+    if (ta) ta.value = params.graph;
+    if (params.autoload) {
+      whenReady(() => {
+        const b = document.getElementById("parse-graph-button");
+        if (b) b.click();
+      });
+    }
+    return;
+  }
+
   if (!params.model) return;
   if (refInput) refInput.value = params.model;
-  // Wait until both WASM runtimes are ready (index.html dispatches
-  // "onnxsim:ready" from maybeEnableInput) before loading, so the conversion
-  // entry point exists; if it already fired, go now.
-  const start = () => {
+  whenReady(() => {
     if (params.autoload) {
       log(`loading input model from URL parameter: ${params.model}`);
       doLoad();
@@ -531,10 +559,5 @@ window.addEventListener("onnxsim:converted", () => {
       // Just preview size / list files so the user can review before loading.
       onRefCommitted(params.model);
     }
-  };
-  if (window.__onnxsimReady) {
-    start();
-  } else {
-    window.addEventListener("onnxsim:ready", start, { once: true });
-  }
+  });
 })();

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -379,6 +379,44 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                 </div>
             </div>
         </div>
+        <div id="backend-loader" style="margin-top: 0.6em;">
+            <label for="backend-select">…or run an
+                <a href="https://github.com/onnx/onnx/tree/main/onnx/backend/test/data" target="_blank" rel="noopener">ONNX backend test case</a>:</label>
+            <select id="backend-select">
+                <option value="">— pick a backend node test —</option>
+            </select>
+            <input type="text" id="backend-url" size="52"
+                placeholder="…or a GitHub tree / raw URL to a test-case directory">
+            <button id="backend-run" type="button">Run test case</button>
+            <span id="backend-status"></span>
+            <div style="color: #666; font-size: 0.85em; margin-top: 0.25em;">
+                Fetches <code>model.onnx</code> and the test data
+                (<code>test_data_set_N/</code> of <code>input_*.pb</code> /
+                <code>output_*.pb</code>) from GitHub, runs the model through
+                onnxruntime-web <b>with the test inputs</b>, and checks each output
+                against the expected tensor within tolerance. Pick a preset above or
+                paste a GitHub <code>tree</code> / <code>raw.githubusercontent.com</code>
+                URL; listing uses GitHub's public (rate-limited) API. With
+                <b>convert the model</b> on, the fetched model is also run through the
+                selected convert mode below (and shown in the Netron panes).
+            </div>
+            <div style="margin-top: 0.25em;">
+                <input type="checkbox" id="backend-convert" checked>
+                <label for="backend-convert">convert the model too</label>
+                <label for="backend-ep" style="margin-left: 0.6em;">execution provider</label>
+                <select id="backend-ep">
+                    <option value="wasm">WASM</option>
+                    <option value="webgpu">WebGPU (fallback to WASM)</option>
+                </select>
+                <label for="backend-atol" style="margin-left: 0.4em;">atol</label>
+                <input type="number" id="backend-atol" value="0.0001" step="any" style="width: 6em;">
+                <label for="backend-rtol">rtol</label>
+                <input type="number" id="backend-rtol" value="0.001" step="any" style="width: 6em;">
+                <button id="backend-download-log" type="button">Download log</button>
+            </div>
+            <textarea id="backend-output" readonly rows="8" style="width: 100%; box-sizing: border-box; margin-top: 0.25em;"></textarea>
+        </div>
+        <script type="module" src="./backend_test.mjs"></script>
         <div>
             <input type="radio" name="optimizer" value="simplify" id="optimizer_simplify" checked>
             <label for="optimizer_simplify">
@@ -573,47 +611,5 @@ agraph (float[N] X) =&gt; (float[N] Y) {
         <div id="inference-trace"></div>
         <script type="module" src="./inference_browser.mjs"></script>
 
-        <h2>Run an ONNX backend test case</h2>
-        <div class="tool-panel">
-            <p class="tool-note">
-                Paste a URL to an
-                <a href="https://github.com/onnx/onnx/tree/main/onnx/backend/test/data" target="_blank" rel="noopener">ONNX backend test case</a>
-                directory (a folder holding <code>model.onnx</code> and one or more
-                <code>test_data_set_N/</code> of <code>input_*.pb</code> /
-                <code>output_*.pb</code>). The model and its test data are fetched from
-                GitHub, the model is run through onnxruntime-web with the given inputs,
-                and each output is compared with the expected tensor within tolerance.
-                GitHub <code>tree</code> URLs and <code>raw.githubusercontent.com</code>
-                URLs both work; listing uses GitHub's public (rate-limited) API.
-                With <b>convert the model</b> on, the fetched <code>model.onnx</code>
-                is also sent straight through the Simplify / Optimize path above (and
-                shown in the Netron panes), so a backend test case doubles as a
-                converter input.
-            </p>
-            <div class="debug-actions">
-                <input type="text" id="backend-url" size="70"
-                    placeholder="https://github.com/onnx/onnx/tree/main/onnx/backend/test/data/node/test_relu"
-                    style="flex: 1 1 30em;">
-            </div>
-            <div class="debug-actions">
-                <input type="checkbox" id="backend-convert" checked>
-                <label for="backend-convert">convert the model (Simplify/Optimize) too</label>
-            </div>
-            <div class="debug-actions">
-                <label for="backend-ep">execution provider</label>
-                <select id="backend-ep">
-                    <option value="wasm">WASM</option>
-                    <option value="webgpu">WebGPU (fallback to WASM)</option>
-                </select>
-                <label for="backend-atol">atol</label>
-                <input type="number" id="backend-atol" value="0.0001" step="any" style="width: 7em;">
-                <label for="backend-rtol">rtol</label>
-                <input type="number" id="backend-rtol" value="0.001" step="any" style="width: 7em;">
-                <button id="backend-run" type="button">Run test case</button>
-                <button id="backend-download-log" type="button">Download log</button>
-            </div>
-            <textarea id="backend-output" readonly rows="12" style="width: 100%; box-sizing: border-box;"></textarea>
-        </div>
-        <script type="module" src="./backend_test.mjs"></script>
     </body>
 </html>

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -105,11 +105,6 @@
 
             window.onload = () => {
                 const worker = new Worker("worker.js");
-                // Publish the worker so the single-feature debug panel can send
-                // it its passes (which need the same executor Simplify uses) and
-                // listen for their "debug-done" replies.
-                window.__onnxsimWorker = worker;
-                window.dispatchEvent(new Event("onnxsim:worker-ready"));
                 const log_output = document.getElementById("log-output");
                 const input = document.getElementById("file-input");
                 const dl_btn = document.getElementById("download-button");
@@ -284,10 +279,10 @@
                 <a href="https://onnx.ai/onnx/repo-docs/Syntax.html" target="_blank" rel="noopener">textual representation</a>
                 — the form <code>onnx.parser.parse_graph</code> / <code>parse_model</code> accept.
                 It is parsed into a model by the WebAssembly module (a bare graph is
-                wrapped into a model with a default-domain opset import), then shown in
-                the <b>Before</b> Netron pane and made the input for the
-                <b>single-feature</b> debugging passes. With <b>convert after parsing</b>
-                on, it is also run straight through the Simplify / Optimize path.
+                wrapped into a model with a default-domain opset import) and shown in
+                the <b>Before</b> Netron pane. With <b>convert after parsing</b> on, it
+                is also run straight through the currently selected convert mode below
+                (Simplify / Optimize, or a single debug pass).
             </p>
             <textarea id="parse-graph-text" rows="8" style="width: 100%; box-sizing: border-box; font-family: monospace;"
                 placeholder="&lt;
@@ -394,6 +389,13 @@ agraph (float[N] X) =&gt; (float[N] Y) {
             <label for="optimizer_optimize_fixed">
                 Fixed <a href="https://github.com/onnx/optimizer" target="_blank">Optimize</a>
             </label>
+            <span style="margin-left: 0.6em; color: #666;">| single pass (debug):</span>
+            <input type="radio" name="optimizer" value="infer_shapes" id="optimizer_infer_shapes">
+            <label for="optimizer_infer_shapes" title="Run ONNX shape inference once (not in the fixed point)">Shape inference</label>
+            <input type="radio" name="optimizer" value="data_propagation" id="optimizer_data_propagation">
+            <label for="optimizer_data_propagation" title="Run ONNX data propagation once (not in the fixed point)">Data propagation</label>
+            <input type="radio" name="optimizer" value="fold_constant" id="optimizer_fold_constant">
+            <label for="optimizer_fold_constant" title="Run one constant-folding round (not in the fixed point); uses the tensor size threshold below">Constant folding</label>
         </div>
         <div id="passes">
             <input type="checkbox" name="simplify_constant_fold" id="id_simplify_constant_fold" checked>
@@ -402,7 +404,7 @@ agraph (float[N] X) =&gt; (float[N] Y) {
             <input type="checkbox" name="simplify_shape_inference" id="id_simplify_shape_inference" checked>
             <label for="id_simplify_shape_inference">shape inference (simplify only)</label>
             <br/>
-            <label>tensor size threshold (simplify only)</label>
+            <label>tensor size threshold (simplify / constant folding)</label>
             <input type="number" name="simplify_tensor_size_threshold" id="id_simplify_tensor_size_threshold" value="1000000000">
             <br/>
             <label>target opset version (simplify only, 0 = keep)</label>
@@ -458,33 +460,6 @@ agraph (float[N] X) =&gt; (float[N] Y) {
         </div>
         <script type="module" src="./netron_view.mjs"></script>
         <script type="module" src="./hf_load.mjs"></script>
-
-        <h2>Run a single feature (debugging)</h2>
-        <div class="tool-panel">
-            <p class="tool-note">
-                Run exactly one of the transforms that <b>Simplify</b> otherwise drives
-                to a fixed point — <b>shape inference</b>, ONNX <b>data propagation</b>,
-                or <b>constant folding</b> — once, so its isolated effect can be
-                inspected. Pick the model with the file input below, or reuse the
-                converted result / a parsed graph above. The result is shown in the
-                <b>After</b> Netron pane, offered as a download, and becomes the new
-                source so passes can be chained (e.g. shape inference, then folding).
-            </p>
-            <div class="debug-actions">
-                <input type="file" id="debug-file-input" />
-                <button id="debug-use-converted" type="button">use last converted result</button>
-                <span id="debug-source-name" class="tool-note">no model loaded yet</span>
-            </div>
-            <div class="debug-actions">
-                <button id="debug-infer-shapes" type="button">Shape inference</button>
-                <button id="debug-data-propagation" type="button">Data propagation</button>
-                <button id="debug-fold-constant" type="button">Constant folding</button>
-                <label for="debug-tensor-size-threshold">fold tensor size threshold</label>
-                <input type="number" id="debug-tensor-size-threshold" value="1000000000" style="width: 10em;">
-                <button id="debug-download" type="button" style="display: none;">download result ↓</button>
-            </div>
-            <textarea id="debug-output" readonly rows="8" style="width: 100%; box-sizing: border-box;"></textarea>
-        </div>
 
         <h2>Console outputs:</h2>
         <textarea id="log-output" readonly rows="20" style="width: 100%; box-sizing: border-box;"></textarea>

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -275,6 +275,39 @@
         <div id="versions-panel" title="Library versions built into this WebAssembly module (also included in a bug report).">
             <span class="version-badge"><span class="version-k">versions</span><span class="version-v">loading…</span></span>
         </div>
+        <script type="module" src="./versions.mjs"></script>
+
+        <h2>Parse a text graph</h2>
+        <div class="tool-panel">
+            <p class="tool-note">
+                Paste an ONNX model or graph in the
+                <a href="https://onnx.ai/onnx/repo-docs/Syntax.html" target="_blank" rel="noopener">textual representation</a>
+                — the form <code>onnx.parser.parse_graph</code> / <code>parse_model</code> accept.
+                It is parsed into a model by the WebAssembly module (a bare graph is
+                wrapped into a model with a default-domain opset import), then shown in
+                the <b>Before</b> Netron pane and made the input for the
+                <b>single-feature</b> debugging passes. With <b>convert after parsing</b>
+                on, it is also run straight through the Simplify / Optimize path.
+            </p>
+            <textarea id="parse-graph-text" rows="8" style="width: 100%; box-sizing: border-box; font-family: monospace;"
+                placeholder="&lt;
+   ir_version: 7,
+   opset_import: [&quot;&quot; : 13]
+&gt;
+agraph (float[N] X) =&gt; (float[N] Y) {
+   Y = Relu(X)
+}"></textarea>
+            <div class="debug-actions">
+                <button id="parse-graph-button" type="button">Parse graph</button>
+                <input type="checkbox" id="parse-graph-convert" checked>
+                <label for="parse-graph-convert">convert after parsing</label>
+                <button id="parse-graph-download" type="button" style="display: none;">download model ↓</button>
+                <span id="parse-graph-status" class="tool-note"></span>
+            </div>
+        </div>
+        <script type="module" src="./debug_tools.mjs"></script>
+
+        <h2>Convert a model</h2>
         <input type="file" id="file-input" disabled title="Loading WebAssembly runtime…" />
         <span id="loading-status">⏳ Loading WebAssembly runtime… the file picker is disabled until it is ready.</span>
         <button id="download-button" disabled>Download</button>
@@ -424,35 +457,6 @@
         <script type="module" src="./netron_view.mjs"></script>
         <script type="module" src="./hf_load.mjs"></script>
 
-        <h2>Parse a text graph</h2>
-        <div class="tool-panel">
-            <p class="tool-note">
-                Paste an ONNX model or graph in the
-                <a href="https://onnx.ai/onnx/repo-docs/Syntax.html" target="_blank" rel="noopener">textual representation</a>
-                — the form <code>onnx.parser.parse_graph</code> / <code>parse_model</code> accept.
-                It is parsed into a model by the WebAssembly module (a bare graph is
-                wrapped into a model with a default-domain opset import), then shown in
-                the <b>Before</b> Netron pane and made the input for the
-                <b>single-feature</b> passes below. With <b>convert after parsing</b> on,
-                it is also run straight through the Simplify path above.
-            </p>
-            <textarea id="parse-graph-text" rows="8" style="width: 100%; box-sizing: border-box; font-family: monospace;"
-                placeholder="&lt;
-   ir_version: 7,
-   opset_import: [&quot;&quot; : 13]
-&gt;
-agraph (float[N] X) =&gt; (float[N] Y) {
-   Y = Relu(X)
-}"></textarea>
-            <div class="debug-actions">
-                <button id="parse-graph-button" type="button">Parse graph</button>
-                <input type="checkbox" id="parse-graph-convert" checked>
-                <label for="parse-graph-convert">convert after parsing</label>
-                <button id="parse-graph-download" type="button" style="display: none;">download model ↓</button>
-                <span id="parse-graph-status" class="tool-note"></span>
-            </div>
-        </div>
-
         <h2>Run a single feature (debugging)</h2>
         <div class="tool-panel">
             <p class="tool-note">
@@ -479,7 +483,6 @@ agraph (float[N] X) =&gt; (float[N] Y) {
             </div>
             <textarea id="debug-output" readonly rows="8" style="width: 100%; box-sizing: border-box;"></textarea>
         </div>
-        <script type="module" src="./debug_tools.mjs"></script>
 
         <h2>Console outputs:</h2>
         <textarea id="log-output" readonly rows="20" style="width: 100%; box-sizing: border-box;"></textarea>

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -376,7 +376,14 @@
             the original model on the left and the simplified/optimized result on
             the right, so you can compare them side by side. Nothing is uploaded —
             the model bytes are posted straight into the embedded Netron in your
-            browser, so there is no model-size limit.
+            browser, so there is no model-size limit. Use <b>export SVG</b> to save
+            the rendered graph as an SVG image.
+        </p>
+        <p class="macs-note">
+            Netron is driven here purely as an embeddable model-preview component
+            over a <code>postMessage</code> protocol; that idea and protocol are
+            being discussed upstream in
+            <a href="https://github.com/lutzroeder/netron/pull/1591#issuecomment-5148706256" target="_blank" rel="noopener">lutzroeder/netron#1591</a>.
         </p>
         <div id="netron-panes" style="display: flex; gap: 1em; flex-wrap: wrap;">
             <div class="netron-pane">
@@ -384,6 +391,7 @@
                     <strong>Before</strong> —
                     <button id="netron-before-open" type="button" style="display: none;">open in a new tab ↗</button>
                     <button id="netron-before-download" type="button" style="display: none;">download model ↓</button>
+                    <button id="netron-before-svg" type="button" style="display: none;">export SVG ↓</button>
                 </div>
                 <iframe id="netron-before-frame" class="netron-frame" title="Netron — original model" style="display: none;"></iframe>
                 <div id="netron-before-note" class="netron-note"></div>
@@ -393,6 +401,7 @@
                     <strong>After</strong> —
                     <button id="netron-after-open" type="button" style="display: none;">open in a new tab ↗</button>
                     <button id="netron-after-download" type="button" style="display: none;">download model ↓</button>
+                    <button id="netron-after-svg" type="button" style="display: none;">export SVG ↓</button>
                 </div>
                 <iframe id="netron-after-frame" class="netron-frame" title="Netron — simplified model" style="display: none;"></iframe>
                 <div id="netron-after-note" class="netron-note"></div>

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -439,6 +439,7 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                     <button id="netron-before-open" type="button" style="display: none;">open in a new tab ↗</button>
                     <button id="netron-before-download" type="button" style="display: none;">download model ↓</button>
                     <button id="netron-before-svg" type="button" style="display: none;">export SVG ↓</button>
+                    <button id="netron-before-png" type="button" style="display: none;">export PNG ↓</button>
                 </div>
                 <iframe id="netron-before-frame" class="netron-frame" title="Netron — original model" style="display: none;"></iframe>
                 <div id="netron-before-note" class="netron-note"></div>
@@ -449,6 +450,7 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                     <button id="netron-after-open" type="button" style="display: none;">open in a new tab ↗</button>
                     <button id="netron-after-download" type="button" style="display: none;">download model ↓</button>
                     <button id="netron-after-svg" type="button" style="display: none;">export SVG ↓</button>
+                    <button id="netron-after-png" type="button" style="display: none;">export PNG ↓</button>
                 </div>
                 <iframe id="netron-after-frame" class="netron-frame" title="Netron — simplified model" style="display: none;"></iframe>
                 <div id="netron-after-note" class="netron-note"></div>

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -605,11 +605,19 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                 and each output is compared with the expected tensor within tolerance.
                 GitHub <code>tree</code> URLs and <code>raw.githubusercontent.com</code>
                 URLs both work; listing uses GitHub's public (rate-limited) API.
+                With <b>convert the model</b> on, the fetched <code>model.onnx</code>
+                is also sent straight through the Simplify / Optimize path above (and
+                shown in the Netron panes), so a backend test case doubles as a
+                converter input.
             </p>
             <div class="debug-actions">
                 <input type="text" id="backend-url" size="70"
                     placeholder="https://github.com/onnx/onnx/tree/main/onnx/backend/test/data/node/test_relu"
                     style="flex: 1 1 30em;">
+            </div>
+            <div class="debug-actions">
+                <input type="checkbox" id="backend-convert" checked>
+                <label for="backend-convert">convert the model (Simplify/Optimize) too</label>
             </div>
             <div class="debug-actions">
                 <label for="backend-ep">execution provider</label>

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -304,6 +304,20 @@
                 one <code>.onnx</code>, the largest is auto-detected; use the
                 <b>file</b> selector to convert a different one.
             </div>
+            <div style="color: #666; font-size: 0.85em; margin-top: 0.25em;">
+                <b>Shareable link:</b> the input model and options can be set from
+                the URL — e.g.
+                <code>?model=onnxmodelzoo/resnet18d_Opset18</code> or
+                <code>?model=https://…/foo.onnx&amp;optimizer=optimize&amp;cf=0</code>.
+                It loads and converts automatically (add <code>&amp;autoload=0</code>
+                to only prefill). Keys: <code>model</code>
+                (<code>hf</code>/<code>url</code>), <code>optimizer</code>,
+                <code>constant_fold</code>/<code>cf</code>,
+                <code>shape_inference</code>/<code>si</code>,
+                <code>tensor_size_threshold</code>/<code>tst</code>,
+                <code>target_opset</code>/<code>opset</code>,
+                <code>backend</code> (prefills the backend-test URL below).
+            </div>
             <div style="margin-top: 0.25em;">
                 <input type="checkbox" id="hf-use-xet" checked>
                 <label for="hf-use-xet">

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -339,12 +339,15 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                 <code>?model=https://…/foo.onnx&amp;optimizer=optimize&amp;cf=0</code>.
                 It loads and converts automatically (add <code>&amp;autoload=0</code>
                 to only prefill). Keys: <code>model</code>
-                (<code>hf</code>/<code>url</code>), <code>optimizer</code>,
+                (<code>hf</code>/<code>url</code>), <code>graph</code> (an ONNX text
+                graph to parse), <code>optimizer</code> (the convert mode —
+                <code>simplify</code>/<code>optimize</code>/<code>optimize_fixed</code>/<code>infer_shapes</code>/<code>data_propagation</code>/<code>fold_constant</code>),
                 <code>constant_fold</code>/<code>cf</code>,
                 <code>shape_inference</code>/<code>si</code>,
                 <code>tensor_size_threshold</code>/<code>tst</code>,
                 <code>target_opset</code>/<code>opset</code>,
-                <code>backend</code> (prefills the backend-test URL below).
+                <code>backend</code> (prefills the backend-test URL). Setting an
+                input updates this URL so it stays shareable (uploads excepted).
             </div>
             <div style="margin-top: 0.25em;">
                 <input type="checkbox" id="hf-use-xet" checked>

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -17,6 +17,14 @@
             .macs-table th, .macs-table td { border-bottom: 1px solid #eee; padding: 3px 10px; text-align: right; }
             .macs-table th:first-child, .macs-table td:first-child { text-align: left; }
             .macs-note { color: #666; font-size: 0.85em; margin-top: 0.4em; }
+            #versions-panel { display: flex; flex-wrap: wrap; gap: 0.5em; margin: 0.4em 0 0.8em; }
+            .version-badge { border: 1px solid #ccc; border-radius: 999px; padding: 0.15em 0.7em; font-size: 0.85em; display: inline-flex; gap: 0.4em; align-items: baseline; }
+            .version-k { color: #666; }
+            .version-v { font-weight: 600; font-variant-numeric: tabular-nums; }
+            .tool-panel { border: 1px solid #ddd; border-radius: 6px; padding: 0.6em 0.8em; margin: 0.8em 0; }
+            .tool-panel h3 { margin: 0 0 0.4em; }
+            .tool-note { color: #666; font-size: 0.85em; margin: 0.3em 0; }
+            .debug-actions { display: flex; flex-wrap: wrap; gap: 0.5em; align-items: center; margin: 0.4em 0; }
         </style>
         <script type="text/javascript" src="./onnxsim.js"></script>
         <script type="text/javascript">
@@ -46,9 +54,21 @@
                 }
                 const status = document.getElementById("loading-status");
                 if (status) status.style.display = "none";
+                // Signal the module panels (the single-feature debug passes)
+                // that BOTH runtimes are up, so a pass posted to the worker is
+                // no longer at risk of being dropped before it starts listening.
+                if (!window.__onnxsimReady) {
+                    window.__onnxsimReady = true;
+                    window.dispatchEvent(new Event("onnxsim:ready"));
+                }
             };
 
-            create_onnxsim().then((runtime) => {
+            // Publish the runtime (and a promise for it) so the ES-module panels
+            // — versions, "parse a text graph", and the single-feature debug
+            // passes — can call the module directly. None of them need
+            // onnxruntime-web, so this page's runtime is enough for them.
+            window.__onnxsimRuntimePromise = create_onnxsim().then((runtime) => {
+                window.__onnxsimRuntime = runtime;
                 to_ary = (vec) => {
                     return new Array(vec.size()).fill(0).map((_, id) => vec.get(id))
                 };
@@ -73,6 +93,7 @@
                 }
                 runtimeReady = true;
                 maybeEnableInput();
+                return runtime;
             });
 
             // The most recent conversion parameters, captured so that the
@@ -84,6 +105,11 @@
 
             window.onload = () => {
                 const worker = new Worker("worker.js");
+                // Publish the worker so the single-feature debug panel can send
+                // it its passes (which need the same executor Simplify uses) and
+                // listen for their "debug-done" replies.
+                window.__onnxsimWorker = worker;
+                window.dispatchEvent(new Event("onnxsim:worker-ready"));
                 const log_output = document.getElementById("log-output");
                 const input = document.getElementById("file-input");
                 const dl_btn = document.getElementById("download-button");
@@ -246,6 +272,9 @@
     </head>
     <body>
         <h1>Model converter</h1>
+        <div id="versions-panel" title="Library versions built into this WebAssembly module (also included in a bug report).">
+            <span class="version-badge"><span class="version-k">versions</span><span class="version-v">loading…</span></span>
+        </div>
         <input type="file" id="file-input" disabled title="Loading WebAssembly runtime…" />
         <span id="loading-status">⏳ Loading WebAssembly runtime… the file picker is disabled until it is ready.</span>
         <button id="download-button" disabled>Download</button>
@@ -371,6 +400,64 @@
         </div>
         <script type="module" src="./netron_view.mjs"></script>
         <script type="module" src="./hf_load.mjs"></script>
+
+        <h2>Parse a text graph</h2>
+        <div class="tool-panel">
+            <p class="tool-note">
+                Paste an ONNX model or graph in the
+                <a href="https://onnx.ai/onnx/repo-docs/Syntax.html" target="_blank" rel="noopener">textual representation</a>
+                — the form <code>onnx.parser.parse_graph</code> / <code>parse_model</code> accept.
+                It is parsed into a model by the WebAssembly module (a bare graph is
+                wrapped into a model with a default-domain opset import), then shown in
+                the <b>Before</b> Netron pane and made the input for the
+                <b>single-feature</b> passes below. With <b>convert after parsing</b> on,
+                it is also run straight through the Simplify path above.
+            </p>
+            <textarea id="parse-graph-text" rows="8" style="width: 100%; box-sizing: border-box; font-family: monospace;"
+                placeholder="&lt;
+   ir_version: 7,
+   opset_import: [&quot;&quot; : 13]
+&gt;
+agraph (float[N] X) =&gt; (float[N] Y) {
+   Y = Relu(X)
+}"></textarea>
+            <div class="debug-actions">
+                <button id="parse-graph-button" type="button">Parse graph</button>
+                <input type="checkbox" id="parse-graph-convert" checked>
+                <label for="parse-graph-convert">convert after parsing</label>
+                <button id="parse-graph-download" type="button" style="display: none;">download model ↓</button>
+                <span id="parse-graph-status" class="tool-note"></span>
+            </div>
+        </div>
+
+        <h2>Run a single feature (debugging)</h2>
+        <div class="tool-panel">
+            <p class="tool-note">
+                Run exactly one of the transforms that <b>Simplify</b> otherwise drives
+                to a fixed point — <b>shape inference</b>, ONNX <b>data propagation</b>,
+                or <b>constant folding</b> — once, so its isolated effect can be
+                inspected. Pick the model with the file input below, or reuse the
+                converted result / a parsed graph above. The result is shown in the
+                <b>After</b> Netron pane, offered as a download, and becomes the new
+                source so passes can be chained (e.g. shape inference, then folding).
+            </p>
+            <div class="debug-actions">
+                <input type="file" id="debug-file-input" />
+                <button id="debug-use-converted" type="button">use last converted result</button>
+                <span id="debug-source-name" class="tool-note">no model loaded yet</span>
+            </div>
+            <div class="debug-actions">
+                <button id="debug-infer-shapes" type="button">Shape inference</button>
+                <button id="debug-data-propagation" type="button">Data propagation</button>
+                <button id="debug-fold-constant" type="button">Constant folding</button>
+                <label for="debug-tensor-size-threshold">fold tensor size threshold</label>
+                <input type="number" id="debug-tensor-size-threshold" value="1000000000" style="width: 10em;">
+                <button id="debug-download" type="button" style="display: none;">download result ↓</button>
+            </div>
+            <textarea id="debug-output" readonly rows="8" style="width: 100%; box-sizing: border-box;"></textarea>
+        </div>
+        <script type="module" src="./debug_tools.mjs"></script>
+
         <h2>Console outputs:</h2>
         <textarea id="log-output" readonly rows="20" style="width: 100%; box-sizing: border-box;"></textarea>
         <div>
@@ -409,6 +496,7 @@
                         pageUrl: location.href,
                         userAgent: navigator.userAgent,
                         runInfo: window.__onnxsimLastRunInfo || null,
+                        versions: window.__onnxsimVersions || null,
                         log: (logEl && logEl.value) || "",
                     });
                     window.open(url, "_blank", "noopener");
@@ -478,5 +566,40 @@
         </p>
         <div id="inference-trace"></div>
         <script type="module" src="./inference_browser.mjs"></script>
+
+        <h2>Run an ONNX backend test case</h2>
+        <div class="tool-panel">
+            <p class="tool-note">
+                Paste a URL to an
+                <a href="https://github.com/onnx/onnx/tree/main/onnx/backend/test/data" target="_blank" rel="noopener">ONNX backend test case</a>
+                directory (a folder holding <code>model.onnx</code> and one or more
+                <code>test_data_set_N/</code> of <code>input_*.pb</code> /
+                <code>output_*.pb</code>). The model and its test data are fetched from
+                GitHub, the model is run through onnxruntime-web with the given inputs,
+                and each output is compared with the expected tensor within tolerance.
+                GitHub <code>tree</code> URLs and <code>raw.githubusercontent.com</code>
+                URLs both work; listing uses GitHub's public (rate-limited) API.
+            </p>
+            <div class="debug-actions">
+                <input type="text" id="backend-url" size="70"
+                    placeholder="https://github.com/onnx/onnx/tree/main/onnx/backend/test/data/node/test_relu"
+                    style="flex: 1 1 30em;">
+            </div>
+            <div class="debug-actions">
+                <label for="backend-ep">execution provider</label>
+                <select id="backend-ep">
+                    <option value="wasm">WASM</option>
+                    <option value="webgpu">WebGPU (fallback to WASM)</option>
+                </select>
+                <label for="backend-atol">atol</label>
+                <input type="number" id="backend-atol" value="0.0001" step="any" style="width: 7em;">
+                <label for="backend-rtol">rtol</label>
+                <input type="number" id="backend-rtol" value="0.001" step="any" style="width: 7em;">
+                <button id="backend-run" type="button">Run test case</button>
+                <button id="backend-download-log" type="button">Download log</button>
+            </div>
+            <textarea id="backend-output" readonly rows="12" style="width: 100%; box-sizing: border-box;"></textarea>
+        </div>
+        <script type="module" src="./backend_test.mjs"></script>
     </body>
 </html>

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -340,7 +340,8 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                 It loads and converts automatically (add <code>&amp;autoload=0</code>
                 to only prefill). Keys: <code>model</code>
                 (<code>hf</code>/<code>url</code>), <code>graph</code> (an ONNX text
-                graph to parse), <code>optimizer</code> (the convert mode —
+                graph to parse), <code>optimizer</code> (a.k.a. <code>mode</code>/<code>processor</code>; the
+                convert mode —
                 <code>simplify</code>/<code>optimize</code>/<code>optimize_fixed</code>/<code>infer_shapes</code>/<code>data_propagation</code>/<code>fold_constant</code>),
                 <code>constant_fold</code>/<code>cf</code>,
                 <code>shape_inference</code>/<code>si</code>,

--- a/scripts/convertmodel/inference_browser.mjs
+++ b/scripts/convertmodel/inference_browser.mjs
@@ -116,6 +116,10 @@ async function runOnModel(modelBytes, { iterations, batch, preferWebGPU, profile
     model: modelBytes,
     inputName,
     input: feeds[inputName],
+    // Feed *all* the model's inputs, not just the first — a multi-input model
+    // (e.g. a MatMul with a separate weight input) otherwise fails with
+    // "input '<name>' is missing in 'feeds'".
+    feeds,
     providers,
     iterations,
     profile,

--- a/scripts/convertmodel/inference_core.mjs
+++ b/scripts/convertmodel/inference_core.mjs
@@ -77,6 +77,7 @@ export async function runInference(ort, {
   model,
   inputName,
   input,
+  feeds = null,
   outputName,
   providers,
   iterations = 5,
@@ -104,6 +105,12 @@ export async function runInference(ort, {
   }
   const resolvedInputName = inputName || session.inputNames[0];
   const resolvedOutputName = outputName || session.outputNames[0];
+  // Feed every model input. A caller with a multi-input model passes the whole
+  // `feeds` map ({ name: tensor }); the single-input callers (and the Node smoke
+  // test) pass just `input`, which we bind to the first/only input name. Without
+  // this, a model like MatMul(X, W) + Add(_, B) fails with
+  // "input 'W' is missing in 'feeds'".
+  const runFeeds = feeds || { [resolvedInputName]: input };
 
   let first = null;
   let lastDims = null;
@@ -112,7 +119,7 @@ export async function runInference(ort, {
   try {
     for (let i = 0; i < iterations; i++) {
       const t0 = performance.now();
-      const results = await session.run({ [resolvedInputName]: input });
+      const results = await session.run(runFeeds);
       const durMs = performance.now() - t0;
       timings.push(durMs);
       runs.push({ index: i, startMs: t0, durMs });

--- a/scripts/convertmodel/interface.cpp
+++ b/scripts/convertmodel/interface.cpp
@@ -2,6 +2,18 @@
 #include "model_info.h"
 #include "onnxoptimizer/optimize.h"
 #include "onnx/checker.h"
+#include "onnx/defs/parser.h"
+#include "onnx/defs/schema.h"
+
+// Version strings baked in by CMake (read from VERSION and
+// third_party/onnx-optimizer/VERSION_NUMBER). Fall back to "unknown" so the
+// file still compiles outside the CMake build (e.g. an IDE/static check).
+#ifndef ONNXSIM_VERSION_STRING
+#define ONNXSIM_VERSION_STRING "unknown"
+#endif
+#ifndef ONNX_OPTIMIZER_VERSION_STRING
+#define ONNX_OPTIMIZER_VERSION_STRING "unknown"
+#endif
 
 // In the ORT-web build (ONNXSIM_WASM_ORT_WEB) onnxsim is compiled with
 // NO_BUILTIN_ORT -- no ONNX Runtime is linked in -- and constant folding is
@@ -56,6 +68,84 @@ std::string ReadAndClearProfileTrace() {
     }
     std::remove(kProfileTracePath);
     return trace;
+}
+
+// Serialize `model` into the shared static buffer and hand JS a typed-memory
+// view over it (null on failure). The buffer is `static` so the view stays
+// valid after this function returns; the worker copies it out immediately
+// (toBase64 / a fresh Uint8Array), and calls are sequential, so a single shared
+// buffer is safe -- matching how the other bindings here return model bytes.
+em::val SerializeModel(const onnx::ModelProto& model) {
+    static std::string result;
+    if (!model.SerializeToString(&result)) {
+        std::cerr << "Serialize failed" << std::endl;
+        return em::val::null();
+    }
+    return em::val(em::typed_memory_view(result.size(),
+                                         reinterpret_cast<uint8_t*>(result.data())));
+}
+
+// Materialize the raw little-endian bytes of `tensor` into `out`, reading either
+// its `raw_data` or the typed repeated fields (float_data/int64_data/...). The
+// wasm target is little-endian, so writing native bytes yields the
+// little-endian layout onnxruntime-web's typed arrays expect. Returns false for
+// a dtype we do not pack (STRING / COMPLEX / the narrow float variants stored
+// out of band); the caller reports it. The bridged dtypes match
+// CppModelExecutor / the ONNX backend node tests.
+bool TensorProtoToRawBytes(const onnx::TensorProto& tensor, std::string& out) {
+    using TP = onnx::TensorProto;
+    out.clear();
+    if (tensor.has_raw_data()) {
+        out = tensor.raw_data();
+        return true;
+    }
+    auto append = [&out](const void* p, size_t n) {
+        out.append(reinterpret_cast<const char*>(p), n);
+    };
+    switch (tensor.data_type()) {
+        case TP::FLOAT:
+            for (float v : tensor.float_data()) append(&v, sizeof(v));
+            return true;
+        case TP::DOUBLE:
+            for (double v : tensor.double_data()) append(&v, sizeof(v));
+            return true;
+        case TP::INT64:
+            for (int64_t v : tensor.int64_data()) append(&v, sizeof(v));
+            return true;
+        case TP::UINT64:
+            for (uint64_t v : tensor.uint64_data()) append(&v, sizeof(v));
+            return true;
+        case TP::INT32:
+            for (int32_t v : tensor.int32_data()) append(&v, sizeof(v));
+            return true;
+        case TP::UINT32:
+            // uint32 values live in uint64_data per the TensorProto encoding.
+            for (uint64_t v : tensor.uint64_data()) {
+                uint32_t w = static_cast<uint32_t>(v);
+                append(&w, sizeof(w));
+            }
+            return true;
+        case TP::INT16:
+        case TP::UINT16:
+        case TP::FLOAT16:
+        case TP::BFLOAT16:
+            // Stored widened in int32_data; pack the low 16 bits.
+            for (int32_t v : tensor.int32_data()) {
+                uint16_t w = static_cast<uint16_t>(v);
+                append(&w, sizeof(w));
+            }
+            return true;
+        case TP::INT8:
+        case TP::UINT8:
+        case TP::BOOL:
+            for (int32_t v : tensor.int32_data()) {
+                uint8_t b = static_cast<uint8_t>(v);
+                append(&b, sizeof(b));
+            }
+            return true;
+        default:
+            return false;
+    }
 }
 
 }  // namespace
@@ -249,6 +339,181 @@ em::val onnxsim_annotate_model_info(const std::string& data) {
     return em::val(em::typed_memory_view(result.size(), reinterpret_cast<uint8_t*>(result.data())));
 }
 
+// Report the versions of the libraries baked into this module, for detailed
+// bug reports. onnxsim and onnx-optimizer come from CMake (their VERSION files);
+// onnx is reported as its max IR version + the highest opset it supports for the
+// default (ai.onnx) domain, both read from the linked onnx at runtime; protobuf
+// is decoded from GOOGLE_PROTOBUF_VERSION. Returns a plain JS object of strings.
+em::val onnxsim_versions() {
+    em::val out = em::val::object();
+    out.set("onnxsim", std::string(ONNXSIM_VERSION_STRING));
+    out.set("onnx_optimizer", std::string(ONNX_OPTIMIZER_VERSION_STRING));
+
+    // onnx: IR version + highest supported opset for the default ONNX domain.
+    {
+        int max_opset = 0;
+        const auto& ranges =
+            onnx::OpSchemaRegistry::DomainToVersionRange::Instance().Map();
+        auto it = ranges.find("");  // "" is the default ONNX domain (ai.onnx)
+        if (it != ranges.end()) {
+            max_opset = it->second.second;
+        }
+        std::ostringstream os;
+        os << "IR v" << static_cast<int>(onnx::IR_VERSION) << ", opset "
+           << max_opset;
+        out.set("onnx", os.str());
+    }
+
+    // protobuf: GOOGLE_PROTOBUF_VERSION is major*1000000 + minor*1000 + patch.
+#ifdef GOOGLE_PROTOBUF_VERSION
+    {
+        int pv = GOOGLE_PROTOBUF_VERSION;
+        std::ostringstream os;
+        os << (pv / 1000000) << "." << (pv / 1000 % 1000) << "." << (pv % 1000);
+        out.set("protobuf", os.str());
+    }
+#else
+    out.set("protobuf", std::string("unknown"));
+#endif
+    return out;
+}
+
+// Parse an ONNX *text* representation into a model and return its bytes. Accepts
+// either a whole-model text (with an `<ir_version: ..., opset_import: [...]>`
+// prolog) or a bare graph body -- the textual form onnx.parser.parse_graph
+// accepts. A bare graph is wrapped in a minimal ModelProto with a default-domain
+// opset import at the highest opset this build supports, so the parsed graph can
+// then be simplified / visualized / run like an uploaded model. Returns
+// { model: Uint8Array } on success or { error: string } describing the parse
+// failure(s).
+em::val onnxsim_parse_graph(const std::string& text) {
+    em::val out = em::val::object();
+    // Try whole-model text first.
+    onnx::ModelProto model;
+    onnx::Common::Status model_st = onnx::OnnxParser::Parse(model, text);
+    if (!model_st.IsOK()) {
+        // Fall back to graph-only text and wrap it into a model.
+        onnx::GraphProto graph;
+        onnx::Common::Status graph_st = onnx::OnnxParser::Parse(graph, text);
+        if (!graph_st.IsOK()) {
+            out.set("error", std::string("failed to parse as a model (") +
+                                 model_st.ErrorMessage() +
+                                 ") and as a graph (" + graph_st.ErrorMessage() +
+                                 ")");
+            return out;
+        }
+        model.Clear();
+        model.set_ir_version(onnx::IR_VERSION);
+        *model.mutable_graph() = graph;
+        int max_opset = 0;
+        const auto& ranges =
+            onnx::OpSchemaRegistry::DomainToVersionRange::Instance().Map();
+        auto it = ranges.find("");  // default ONNX domain (ai.onnx)
+        if (it != ranges.end()) {
+            max_opset = it->second.second;
+        }
+        auto* opset = model.add_opset_import();
+        opset->set_domain("");  // default ONNX domain
+        opset->set_version(max_opset > 0 ? max_opset : 1);
+    }
+    em::val bytes = SerializeModel(model);
+    if (bytes.isNull()) {
+        out.set("error", std::string("failed to serialize the parsed model"));
+        return out;
+    }
+    out.set("model", bytes);
+    return out;
+}
+
+// Parse a serialized onnx.TensorProto (e.g. an input_N.pb / output_N.pb from an
+// ONNX backend test case) into a form onnxruntime-web can consume in JS.
+// Returns { dtype: int (TensorProto.DataType), name: string, dims: [int...],
+// data: Uint8Array (raw little-endian) } or { error: string }.
+em::val onnxsim_parse_tensor(const std::string& data) {
+    em::val out = em::val::object();
+    onnx::TensorProto tensor;
+    if (!tensor.ParseFromArray(data.data(), data.size())) {
+        out.set("error", std::string("failed to parse TensorProto"));
+        return out;
+    }
+    static std::string raw;
+    if (!TensorProtoToRawBytes(tensor, raw)) {
+        std::ostringstream os;
+        os << "unsupported tensor data type " << tensor.data_type()
+           << " (STRING / COMPLEX and similar are not bridged)";
+        out.set("error", os.str());
+        return out;
+    }
+    out.set("dtype", static_cast<int>(tensor.data_type()));
+    out.set("name", tensor.name());
+    em::val dims = em::val::array();
+    for (int i = 0; i < tensor.dims_size(); ++i) {
+        dims.set(i, static_cast<double>(tensor.dims(i)));
+    }
+    out.set("dims", dims);
+    out.set("data", em::val(em::typed_memory_view(
+                        raw.size(), reinterpret_cast<uint8_t*>(raw.data()))));
+    return out;
+}
+
+// Run a single simplification building block once (not in the fixed point) for
+// debugging, returning the transformed model bytes (null on failure). Shape
+// inference and data propagation need no model executor. Constant folding runs
+// through the same executor Simplify uses -- in the ORT-web build that awaits
+// onnxruntime-web, so (like onnxsimplify_export) onnxsim_fold_constant is
+// Asyncified and returns a Promise the worker awaits.
+em::val onnxsim_infer_shapes(const std::string& data) {
+    InitEnv();
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    try {
+        return SerializeModel(InferShapesOnce(xmodel));
+    } catch (const std::exception& e) {
+        std::cerr << "shape inference error: " << e.what() << std::endl;
+        return em::val::null();
+    }
+}
+
+em::val onnxsim_data_propagation(const std::string& data) {
+    InitEnv();
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    try {
+        return SerializeModel(PropagateDataOnce(xmodel));
+    } catch (const std::exception& e) {
+        std::cerr << "data propagation error: " << e.what() << std::endl;
+        return em::val::null();
+    }
+}
+
+em::val onnxsim_fold_constant(const std::string& data, size_t tensor_size_threshold) {
+    InitEnv();
+    onnx::ModelProto xmodel;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    try {
+        onnx::ModelProto folded = FoldConstantOnce(
+#ifdef ONNXSIM_WASM_ORT_WEB
+            *GetJsModelExecutor(),
+#else
+            *GetBuiltinModelExecutor(),
+#endif
+            xmodel, tensor_size_threshold);
+        return SerializeModel(folded);
+    } catch (const std::exception& e) {
+        std::cerr << "constant folding error: " << e.what() << std::endl;
+        return em::val::null();
+    }
+}
+
 // True when this module was built to delegate constant folding to
 // onnxruntime-web (ONNXSIM_WASM_ORT_WEB). The worker uses this to decide whether
 // it must load onnxruntime-web and register a runner on the Module before
@@ -279,6 +544,14 @@ EMSCRIPTEN_BINDINGS(module) {
     em::function("onnxoptimizer_passes", &onnxoptimizer_passes);
     em::function("onnxoptimizer_fuse_elimination_passes", &onnxoptimizer_fuse_elimination_passes);
     em::function("onnxsim_needs_ort_web", &onnxsim_needs_ort_web);
+    // Version reporting, text-graph parsing, TensorProto parsing, and the
+    // single-pass debugging entry points (see the definitions above).
+    em::function("onnxsim_versions", &onnxsim_versions);
+    em::function("onnxsim_parse_graph", &onnxsim_parse_graph);
+    em::function("onnxsim_parse_tensor", &onnxsim_parse_tensor);
+    em::function("onnxsim_infer_shapes", &onnxsim_infer_shapes);
+    em::function("onnxsim_data_propagation", &onnxsim_data_propagation);
+    em::function("onnxsim_fold_constant", &onnxsim_fold_constant);
 
     em::register_vector<std::string>("string_list");
 }

--- a/scripts/convertmodel/interface.cpp
+++ b/scripts/convertmodel/interface.cpp
@@ -388,13 +388,17 @@ em::val onnxsim_versions() {
 // failure(s).
 em::val onnxsim_parse_graph(const std::string& text) {
     em::val out = em::val::object();
-    // Try whole-model text first.
+    // Try whole-model text first. Each OnnxParser consumes its input, so a fresh
+    // parser is constructed per attempt (the member Parse API is stable across
+    // onnx versions).
     onnx::ModelProto model;
-    onnx::Common::Status model_st = onnx::OnnxParser::Parse(model, text);
+    onnx::OnnxParser model_parser(text.c_str());
+    onnx::Common::Status model_st = model_parser.Parse(model);
     if (!model_st.IsOK()) {
         // Fall back to graph-only text and wrap it into a model.
         onnx::GraphProto graph;
-        onnx::Common::Status graph_st = onnx::OnnxParser::Parse(graph, text);
+        onnx::OnnxParser graph_parser(text.c_str());
+        onnx::Common::Status graph_st = graph_parser.Parse(graph);
         if (!graph_st.IsOK()) {
             out.set("error", std::string("failed to parse as a model (") +
                                  model_st.ErrorMessage() +

--- a/scripts/convertmodel/issue_report.mjs
+++ b/scripts/convertmodel/issue_report.mjs
@@ -24,7 +24,7 @@ const TRUNCATED_PREFIX =
 
 // The fixed (non-log) lines of the issue body, built from the page context and
 // the most recent conversion parameters (`runInfo`, may be null).
-function headerLines({ pageUrl, userAgent, runInfo }) {
+function headerLines({ pageUrl, userAgent, runInfo, versions }) {
   const lines = [];
   lines.push("**Describe the bug**");
   lines.push("<!-- A clear and concise description of what went wrong. -->");
@@ -36,6 +36,14 @@ function headerLines({ pageUrl, userAgent, runInfo }) {
   lines.push("**Environment (WASM converter)**");
   lines.push("- Page: " + (pageUrl || "(unknown)"));
   lines.push("- User agent: " + (userAgent || "(unknown)"));
+  // Library versions baked into the module (from onnxsim_versions), so the
+  // report says exactly which onnxsim / onnx-optimizer / onnx / protobuf ran.
+  if (versions) {
+    lines.push("- onnxsim: " + (versions.onnxsim || "unknown"));
+    lines.push("- onnx-optimizer: " + (versions.onnx_optimizer || "unknown"));
+    lines.push("- onnx: " + (versions.onnx || "unknown"));
+    lines.push("- protobuf: " + (versions.protobuf || "unknown"));
+  }
   if (runInfo) {
     lines.push("- Optimizer: " + runInfo.optimizer);
     lines.push("- File: " + runInfo.file_name);

--- a/scripts/convertmodel/netron.mjs
+++ b/scripts/convertmodel/netron.mjs
@@ -25,6 +25,24 @@ export const NETRON_EMBED_URL = `${NETRON_PATH}?embed`;
 export const NETRON_PING = "PING";
 export const NETRON_PONG = "PONG";
 
+// The self-hosted Netron is driven purely over this postMessage protocol, i.e.
+// it is used here as an embeddable model-preview component. That idea and this
+// protocol are being discussed upstream in
+// https://github.com/lutzroeder/netron/pull/1591 — follow that thread for the
+// canonical protocol as it converges.
+export const NETRON_PR_1591 =
+  "https://github.com/lutzroeder/netron/pull/1591#issuecomment-5148706256";
+
+// Build the message that asks the embedded Netron to render the currently shown
+// graph and post the image bytes back (rather than downloading them inside the
+// frame). `format` is "svg" (default) or "png"; `name` sets the suggested file
+// name. Netron replies with
+// `{ netron: { command: "export", status, format, name, buffer } }`.
+export function buildExportMessage(format = "svg", name) {
+  const fmt = format === "png" ? "png" : "svg";
+  return { netron: { command: "export", format: fmt, name: name || "model" } };
+}
+
 // Normalize model bytes to a standalone ArrayBuffer holding exactly those
 // bytes. Accepts an ArrayBuffer or any typed-array / DataView view, and always
 // returns a fresh copy so the source is never detached when the buffer is

--- a/scripts/convertmodel/netron_view.mjs
+++ b/scripts/convertmodel/netron_view.mjs
@@ -19,6 +19,7 @@ import {
   toArrayBuffer,
   dataUrlToArrayBuffer,
   buildModelMessage,
+  buildExportMessage,
 } from "./netron.mjs";
 import { downloadBytes } from "./download.mjs";
 
@@ -150,6 +151,37 @@ function renderPane(which, buffer, name) {
       if (pane.buffer) downloadBytes(pane.buffer, pane.name || `${which}.onnx`);
     };
   }
+
+  // Arm the "export SVG" button: ask the pane's Netron to render the current
+  // graph to SVG and download the returned bytes. The base name drops the
+  // model's extension so the file is e.g. "model.svg".
+  const svg = document.getElementById(`netron-${which}-svg`);
+  if (svg) {
+    svg.style.display = "";
+    svg.onclick = () => {
+      const base = (pane.name || which).replace(/\.[^./\\]*$/, "");
+      const prev = svg.textContent;
+      svg.disabled = true;
+      svg.textContent = "exporting…";
+      const finish = () => {
+        svg.disabled = false;
+        svg.textContent = prev;
+      };
+      exportFromNetron(
+        frame.contentWindow,
+        "svg",
+        base,
+        (bytes, fname) => {
+          downloadBytes(bytes, fname || `${base}.svg`);
+          finish();
+        },
+        (msg) => {
+          if (note) note.textContent = `SVG export failed: ${msg}`;
+          finish();
+        },
+      );
+    };
+  }
 }
 
 // Open the pane's current model in a new Netron tab. Must run from a user
@@ -169,6 +201,43 @@ function openInNewTab(which) {
     return;
   }
   driveNetron(win, pane.buffer, pane.name);
+}
+
+// Ask the Netron already showing a model in `target` to render the current
+// graph and hand back the image bytes, then deliver them to `onDone(bytes,
+// name)`. The pane has already completed the load handshake, so the window is
+// ready; we post the export command and wait for the matching reply. `onError`
+// is called with a message on failure or timeout.
+function exportFromNetron(target, format, name, onDone, onError) {
+  let settled = false;
+  const onMessage = (e) => {
+    if (e.source !== target) {
+      return;
+    }
+    const d = e.data;
+    if (d && typeof d === "object" && d.netron && d.netron.command === "export") {
+      teardown();
+      if (d.netron.status === "success" && d.netron.buffer) {
+        onDone(new Uint8Array(d.netron.buffer), d.netron.name || `${name}.${format}`);
+      } else if (onError) {
+        onError(d.netron.message || "Netron could not export the graph.");
+      }
+    }
+  };
+  const timeout = setTimeout(() => {
+    teardown();
+    if (onError) onError("Netron did not respond to the export request.");
+  }, 20000);
+  function teardown() {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    clearTimeout(timeout);
+    window.removeEventListener("message", onMessage);
+  }
+  window.addEventListener("message", onMessage);
+  target.postMessage(buildExportMessage(format, name), NETRON_ORIGIN);
 }
 
 function initNetronPanel() {

--- a/scripts/convertmodel/netron_view.mjs
+++ b/scripts/convertmodel/netron_view.mjs
@@ -152,31 +152,32 @@ function renderPane(which, buffer, name) {
     };
   }
 
-  // Arm the "export SVG" button: ask the pane's Netron to render the current
-  // graph to SVG and download the returned bytes. The base name drops the
-  // model's extension so the file is e.g. "model.svg".
-  const svg = document.getElementById(`netron-${which}-svg`);
-  if (svg) {
-    svg.style.display = "";
-    svg.onclick = () => {
+  // Arm the "export SVG"/"export PNG" buttons: ask the pane's Netron to render
+  // the current graph to that format and download the returned bytes. The base
+  // name drops the model's extension so the file is e.g. "model.svg".
+  for (const format of ["svg", "png"]) {
+    const button = document.getElementById(`netron-${which}-${format}`);
+    if (!button) continue;
+    button.style.display = "";
+    button.onclick = () => {
       const base = (pane.name || which).replace(/\.[^./\\]*$/, "");
-      const prev = svg.textContent;
-      svg.disabled = true;
-      svg.textContent = "exporting…";
+      const prev = button.textContent;
+      button.disabled = true;
+      button.textContent = "exporting…";
       const finish = () => {
-        svg.disabled = false;
-        svg.textContent = prev;
+        button.disabled = false;
+        button.textContent = prev;
       };
       exportFromNetron(
         frame.contentWindow,
-        "svg",
+        format,
         base,
         (bytes, fname) => {
-          downloadBytes(bytes, fname || `${base}.svg`);
+          downloadBytes(bytes, fname || `${base}.${format}`);
           finish();
         },
         (msg) => {
-          if (note) note.textContent = `SVG export failed: ${msg}`;
+          if (note) note.textContent = `${format.toUpperCase()} export failed: ${msg}`;
           finish();
         },
       );

--- a/scripts/convertmodel/package.json
+++ b/scripts/convertmodel/package.json
@@ -12,7 +12,9 @@
     "test:hf": "node test/hf_models.test.mjs",
     "test:xet": "node test/xet_cache.test.mjs",
     "test:issue": "node test/issue_report.test.mjs",
-    "test:all": "npm run test:netron && npm run test:trace && npm run test:macs && npm run test:hf && npm run test:xet && npm run test:issue && npm run test:inference",
+    "test:versions": "node test/versions.test.mjs",
+    "test:backend": "node test/backend_test.test.mjs",
+    "test:all": "npm run test:netron && npm run test:trace && npm run test:macs && npm run test:hf && npm run test:xet && npm run test:issue && npm run test:versions && npm run test:backend && npm run test:inference",
     "coverage": "c8 npm run test:all"
   },
   "dependencies": {

--- a/scripts/convertmodel/package.json
+++ b/scripts/convertmodel/package.json
@@ -14,7 +14,8 @@
     "test:issue": "node test/issue_report.test.mjs",
     "test:versions": "node test/versions.test.mjs",
     "test:backend": "node test/backend_test.test.mjs",
-    "test:all": "npm run test:netron && npm run test:trace && npm run test:macs && npm run test:hf && npm run test:xet && npm run test:issue && npm run test:versions && npm run test:backend && npm run test:inference",
+    "test:query": "node test/query_params.test.mjs",
+    "test:all": "npm run test:netron && npm run test:trace && npm run test:macs && npm run test:hf && npm run test:xet && npm run test:issue && npm run test:versions && npm run test:backend && npm run test:query && npm run test:inference",
     "coverage": "c8 npm run test:all"
   },
   "dependencies": {

--- a/scripts/convertmodel/query_params.mjs
+++ b/scripts/convertmodel/query_params.mjs
@@ -31,7 +31,16 @@ function toInt(v) {
   return Number.isFinite(n) ? n : null;
 }
 
-const OPTIMIZERS = ["simplify", "optimize", "optimize_fixed"];
+// The converter's mode radio values: the three optimizers plus the single-pass
+// debug modes (each runs one of Simplify's fixed-point steps once).
+const OPTIMIZERS = [
+  "simplify",
+  "optimize",
+  "optimize_fixed",
+  "infer_shapes",
+  "data_propagation",
+  "fold_constant",
+];
 
 // Parse a `location.search` (or any query string) into a normalized config.
 // Fields are null when the parameter is absent, except `autoload` which
@@ -54,6 +63,10 @@ export function parseInputParams(search) {
   return {
     model: trimmed(first("model", "hf", "url", "input")),
     backend: trimmed(first("backend", "testcase", "test")),
+    // The ONNX text graph to parse (onnx.parser syntax). Not trimmed of interior
+    // whitespace — only null when the key is absent or empty — since the graph
+    // body's own formatting matters.
+    graph: first("graph", "text"),
     autoload: autoloadRaw === null ? true : autoloadRaw,
     optimizer,
     constantFold: toBool(first("constant_fold", "cf")),
@@ -65,19 +78,50 @@ export function parseInputParams(search) {
 
 // Every query key that names an input source; setting one canonical input
 // clears all of these so the URL always reflects a single current input.
-const INPUT_KEYS = ["model", "hf", "url", "input", "backend", "testcase", "test"];
+const INPUT_KEYS = [
+  "model", "hf", "url", "input",
+  "backend", "testcase", "test",
+  "graph", "text",
+];
+
+// The canonical query key for each input kind.
+const INPUT_KEY = { backend: "backend", graph: "graph", model: "model" };
 
 // Return a new query string (leading "?" or "") that names `value` as the input,
-// under the canonical key for `kind` ("backend" -> `backend`, anything else ->
-// `model`), dropping every other input key while preserving option params
-// (optimizer, cf, …). Pure, for unit testing.
+// under the canonical key for `kind` ("backend"/"graph", else "model"), dropping
+// every other input key while preserving option params (optimizer, cf, …).
+// Pure, for unit testing.
 export function setInputParam(search, kind, value) {
   const p = new URLSearchParams(search || "");
   for (const k of INPUT_KEYS) p.delete(k);
-  const key = kind === "backend" ? "backend" : "model";
-  p.set(key, value);
+  p.set(INPUT_KEY[kind] || "model", value);
   const s = p.toString();
   return s ? `?${s}` : "";
+}
+
+// Set (or, for an empty value, delete) a single non-input param, preserving
+// everything else — used to reflect the conversion processor (?optimizer=).
+// Pure, for unit testing.
+export function setUrlParam(search, key, value) {
+  const p = new URLSearchParams(search || "");
+  if (value === null || value === undefined || value === "") {
+    p.delete(key);
+  } else {
+    p.set(key, value);
+  }
+  const s = p.toString();
+  return s ? `?${s}` : "";
+}
+
+// Reflect a single param in the address bar (history.replaceState). Best-effort.
+export function syncUrlParam(key, value) {
+  try {
+    if (typeof window === "undefined" || !window.history) return;
+    const search = setUrlParam(window.location.search, key, value);
+    window.history.replaceState(null, "", window.location.pathname + search + window.location.hash);
+  } catch {
+    // ignore — a failed URL update must not break anything.
+  }
 }
 
 // Reflect a just-set input model in the address bar (history.replaceState, so no

--- a/scripts/convertmodel/query_params.mjs
+++ b/scripts/convertmodel/query_params.mjs
@@ -56,7 +56,9 @@ export function parseInputParams(search) {
   };
   const trimmed = (v) => (v === null ? null : v.trim() || null);
 
-  const optimizerRaw = trimmed(first("optimizer", "opt"));
+  // The conversion processor / mode: optimizer (opt) is the canonical key;
+  // mode / processor are friendlier aliases.
+  const optimizerRaw = trimmed(first("optimizer", "opt", "mode", "processor"));
   const optimizer = optimizerRaw && OPTIMIZERS.includes(optimizerRaw) ? optimizerRaw : null;
   const autoloadRaw = toBool(first("autoload", "run", "convert"));
 

--- a/scripts/convertmodel/query_params.mjs
+++ b/scripts/convertmodel/query_params.mjs
@@ -63,6 +63,39 @@ export function parseInputParams(search) {
   };
 }
 
+// Every query key that names an input source; setting one canonical input
+// clears all of these so the URL always reflects a single current input.
+const INPUT_KEYS = ["model", "hf", "url", "input", "backend", "testcase", "test"];
+
+// Return a new query string (leading "?" or "") that names `value` as the input,
+// under the canonical key for `kind` ("backend" -> `backend`, anything else ->
+// `model`), dropping every other input key while preserving option params
+// (optimizer, cf, …). Pure, for unit testing.
+export function setInputParam(search, kind, value) {
+  const p = new URLSearchParams(search || "");
+  for (const k of INPUT_KEYS) p.delete(k);
+  const key = kind === "backend" ? "backend" : "model";
+  p.set(key, value);
+  const s = p.toString();
+  return s ? `?${s}` : "";
+}
+
+// Reflect a just-set input model in the address bar (history.replaceState, so no
+// navigation / history entry), so the link is shareable and reproducible. Used
+// for the Hugging Face / URL loader ("model") and the backend-test panel
+// ("backend"); uploaded local files have no URL representation and are skipped
+// by their callers. Best-effort: never throws into the caller.
+export function syncInputUrl(kind, value) {
+  try {
+    if (typeof window === "undefined" || !window.history || !value) return;
+    const search = setInputParam(window.location.search, kind, value);
+    const url = window.location.pathname + search + window.location.hash;
+    window.history.replaceState(null, "", url);
+  } catch {
+    // ignore — a failed URL update must not break loading.
+  }
+}
+
 // Prefill the converter's option controls from a parsed config, so both an
 // auto-run and a later manual run honor the link's options. `doc` is the
 // document (injected for testability); only set fields are touched. Returns the

--- a/scripts/convertmodel/query_params.mjs
+++ b/scripts/convertmodel/query_params.mjs
@@ -1,0 +1,100 @@
+// Parse the converter page's input configuration from URL query parameters, so a
+// model (and the conversion options) can be driven straight from a shareable
+// link — e.g. `?model=https://…/foo.onnx` or `?model=onnxmodelzoo/resnet18d_Opset18`.
+//
+// Kept pure (no DOM/network) so the parsing is unit-tested; hf_load.mjs imports
+// these and does the browser wiring (prefilling controls and driving the load).
+//
+// Recognized parameters (aliases in parentheses):
+//   model (hf, url, input) — a Hugging Face repo id or a direct .onnx URL; the
+//     same reference the "Load from Hugging Face" box accepts.
+//   backend (testcase, test) — an ONNX backend test-case URL to prefill the
+//     "Run an ONNX backend test case" panel.
+//   autoload (run, convert) — whether to start the conversion automatically once
+//     a model is given (default: true).
+//   optimizer (opt) — "simplify" | "optimize" | "optimize_fixed".
+//   constant_fold (cf), shape_inference (si) — booleans.
+//   tensor_size_threshold (tst), target_opset (opset) — integers.
+
+// Parse a boolean-ish value: an empty value (a bare `?cf`) means "on"; returns
+// null for absent or unrecognized so callers can tell "not set" from false.
+function toBool(v) {
+  if (v === null || v === undefined) return null;
+  const s = String(v).trim().toLowerCase();
+  if (s === "" || s === "1" || s === "true" || s === "yes" || s === "on") return true;
+  if (s === "0" || s === "false" || s === "no" || s === "off") return false;
+  return null;
+}
+
+function toInt(v) {
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+const OPTIMIZERS = ["simplify", "optimize", "optimize_fixed"];
+
+// Parse a `location.search` (or any query string) into a normalized config.
+// Fields are null when the parameter is absent, except `autoload` which
+// defaults to true (only meaningful when a model is given).
+export function parseInputParams(search) {
+  const p = new URLSearchParams(search || "");
+  const first = (...keys) => {
+    for (const k of keys) {
+      const v = p.get(k);
+      if (v !== null) return v;
+    }
+    return null;
+  };
+  const trimmed = (v) => (v === null ? null : v.trim() || null);
+
+  const optimizerRaw = trimmed(first("optimizer", "opt"));
+  const optimizer = optimizerRaw && OPTIMIZERS.includes(optimizerRaw) ? optimizerRaw : null;
+  const autoloadRaw = toBool(first("autoload", "run", "convert"));
+
+  return {
+    model: trimmed(first("model", "hf", "url", "input")),
+    backend: trimmed(first("backend", "testcase", "test")),
+    autoload: autoloadRaw === null ? true : autoloadRaw,
+    optimizer,
+    constantFold: toBool(first("constant_fold", "cf")),
+    shapeInference: toBool(first("shape_inference", "si")),
+    tensorSizeThreshold: toInt(first("tensor_size_threshold", "tst")),
+    targetOpset: toInt(first("target_opset", "opset")),
+  };
+}
+
+// Prefill the converter's option controls from a parsed config, so both an
+// auto-run and a later manual run honor the link's options. `doc` is the
+// document (injected for testability); only set fields are touched. Returns the
+// list of control ids it changed (handy for tests / logging).
+export function applyOptionParams(params, doc) {
+  const changed = [];
+  const setChecked = (id, val) => {
+    if (val === null || val === undefined) return;
+    const el = doc.getElementById(id);
+    if (el) {
+      el.checked = val;
+      changed.push(id);
+    }
+  };
+  const setValue = (id, val) => {
+    if (val === null || val === undefined) return;
+    const el = doc.getElementById(id);
+    if (el) {
+      el.value = String(val);
+      changed.push(id);
+    }
+  };
+  if (params.optimizer) {
+    const radio = doc.getElementById(`optimizer_${params.optimizer}`);
+    if (radio) {
+      radio.checked = true;
+      changed.push(`optimizer_${params.optimizer}`);
+    }
+  }
+  setChecked("id_simplify_constant_fold", params.constantFold);
+  setChecked("id_simplify_shape_inference", params.shapeInference);
+  setValue("id_simplify_tensor_size_threshold", params.tensorSizeThreshold);
+  setValue("id_simplify_target_opset", params.targetOpset);
+  return changed;
+}

--- a/scripts/convertmodel/test/README.md
+++ b/scripts/convertmodel/test/README.md
@@ -73,6 +73,62 @@ its error-bearing tail) so the URL stays under the cap. No DOM or network:
 npm run test:issue
 ```
 
+## Library versions
+
+The page shows the **versions** of the libraries built into the WebAssembly
+module — onnxsim, onnx-optimizer, onnx (its IR version + highest supported
+opset), and protobuf — as a row of badges under the title, and includes them in
+the **Report an issue** body. onnxsim and onnx-optimizer come from their
+`VERSION` files (baked in by CMake); onnx and protobuf are read from the linked
+libraries at runtime by the `onnxsim_versions` binding. `npm run test:versions`
+unit-tests the pure `versions.mjs` helpers (normalization + badge rendering
+against a tiny fake DOM); no DOM or network:
+
+```bash
+npm run test:versions
+```
+
+## Parse a text graph
+
+The **Parse a text graph** panel takes an ONNX
+[textual representation](https://onnx.ai/onnx/repo-docs/Syntax.html) — the form
+`onnx.parser.parse_graph` / `parse_model` accept — and parses it into a model
+with the `onnxsim_parse_graph` binding (whole-model text is used as-is; a bare
+graph is wrapped into a model with a default-domain opset import). The parsed
+model is shown in the **Before** Netron pane, becomes the source for the
+single-feature passes, and — with *convert after parsing* on — is run straight
+through the Simplify path.
+
+## Run a single feature (debugging)
+
+The **Run a single feature** panel runs exactly one of the transforms that
+`Simplify` otherwise drives to a fixed point — **shape inference**, ONNX **data
+propagation**, or **constant folding** — once, on a chosen model, so its
+isolated effect can be inspected. These map to onnxsim's
+`InferShapesOnce` / `PropagateDataOnce` / `FoldConstantOnce` core helpers, exposed
+to the page as the `onnxsim_infer_shapes` / `onnxsim_data_propagation` /
+`onnxsim_fold_constant` bindings. Constant folding runs through the same model
+executor `Simplify` uses (onnxruntime-web in the ORT-web build), so that pass
+goes through the conversion worker. Each result is shown in the **After** Netron
+pane, offered as a download, and becomes the new source so passes can be chained.
+
+## Run an ONNX backend test case
+
+The **Run an ONNX backend test case** panel takes a URL to an
+[ONNX backend test case](https://github.com/onnx/onnx/tree/main/onnx/backend/test/data)
+directory (a `model.onnx` plus one or more `test_data_set_N/` of `input_*.pb` /
+`output_*.pb` TensorProtos), fetches the model and test data from GitHub, runs
+the model through onnxruntime-web with the given inputs, and compares each output
+against the expected tensor within tolerance. TensorProtos are decoded by the
+`onnxsim_parse_tensor` binding. `npm run test:backend` unit-tests the pure
+`backend_test.mjs` helpers — GitHub URL parsing (tree / blob /
+`raw.githubusercontent.com` / contents-API forms), numeric ordering of
+`input_N.pb` files, and float/int/shape tensor comparison; no DOM or network:
+
+```bash
+npm run test:backend
+```
+
 ## Profiling traces
 
 Both the browser panels can emit a [Chrome Trace Event][cte] JSON that the page

--- a/scripts/convertmodel/test/README.md
+++ b/scripts/convertmodel/test/README.md
@@ -34,8 +34,15 @@ renders each model with a **self-hosted** [Netron](https://github.com/onnxsim/ne
 (built into the site at `./netron/` by the deploy workflow) and hands it the
 model bytes over a postMessage embedding protocol — so nothing is uploaded and
 there is no model-size limit (the old URL-based path was capped at ~2 MB by the
-browser). The test covers buffer normalization, data-URL decoding, and the
-message shape; it needs no dependencies or network:
+browser). Each pane also has an **export SVG** button that asks Netron (over the
+same protocol's `export` command) to render the shown graph and hand the SVG
+bytes back for download. The test covers buffer normalization, data-URL
+decoding, and the model/export message shapes; it needs no dependencies or
+network:
+
+Netron is used here as an embeddable **model-preview component** driven entirely
+over `postMessage`; that idea and protocol are being discussed upstream in
+[lutzroeder/netron#1591](https://github.com/lutzroeder/netron/pull/1591#issuecomment-5148706256).
 
 ```bash
 npm run test:netron

--- a/scripts/convertmodel/test/README.md
+++ b/scripts/convertmodel/test/README.md
@@ -111,8 +111,13 @@ Face loader's repo-id / `.onnx`-URL path (nothing is uploaded):
 Keys (aliases in parentheses): `model` (`hf`/`url`/`input`), `optimizer`,
 `constant_fold` (`cf`), `shape_inference` (`si`), `tensor_size_threshold`
 (`tst`), `target_opset` (`opset`), `autoload` (`run`/`convert`), and `backend`
-(prefills the backend-test panel). `npm run test:query` unit-tests the pure
-`query_params.mjs` parser + option-prefiller (against a fake DOM); no
+(prefills the backend-test panel).
+
+Conversely, **setting** an input model updates the address bar (via
+`history.replaceState`) to the matching `?model=` / `?backend=` link, so the
+current input is always shareable — except an uploaded local file, which has no
+URL. `npm run test:query` unit-tests the pure `query_params.mjs` parser, the
+option-prefiller (against a fake DOM), and the `setInputParam` URL builder; no
 DOM/network:
 
 ```bash
@@ -130,18 +135,18 @@ model is shown in the **Before** Netron pane, becomes the source for the
 single-feature passes, and — with *convert after parsing* on — is run straight
 through the Simplify path.
 
-## Run a single feature (debugging)
+## Single-pass debug modes
 
-The **Run a single feature** panel runs exactly one of the transforms that
-`Simplify` otherwise drives to a fixed point — **shape inference**, ONNX **data
-propagation**, or **constant folding** — once, on a chosen model, so its
-isolated effect can be inspected. These map to onnxsim's
-`InferShapesOnce` / `PropagateDataOnce` / `FoldConstantOnce` core helpers, exposed
-to the page as the `onnxsim_infer_shapes` / `onnxsim_data_propagation` /
-`onnxsim_fold_constant` bindings. Constant folding runs through the same model
-executor `Simplify` uses (onnxruntime-web in the ORT-web build), so that pass
-goes through the conversion worker. Each result is shown in the **After** Netron
-pane, offered as a download, and becomes the new source so passes can be chained.
+Alongside **Simplify** / **Optimize** / **Fixed Optimize**, the converter's mode
+radios include **Shape inference**, **Data propagation**, and **Constant
+folding** — each runs exactly one of the transforms `Simplify` otherwise drives
+to a fixed point, once, so its isolated effect can be inspected. They map to
+onnxsim's `InferShapesOnce` / `PropagateDataOnce` / `FoldConstantOnce` core
+helpers, exposed as the `onnxsim_infer_shapes` / `onnxsim_data_propagation` /
+`onnxsim_fold_constant` bindings, and run through the same conversion worker (so
+constant folding uses the same model executor `Simplify` does — onnxruntime-web
+in the ORT-web build). The result flows through the normal convert path: shown in
+the **After** Netron pane, downloadable, and runnable in the inference panel.
 
 ## Run an ONNX backend test case
 

--- a/scripts/convertmodel/test/README.md
+++ b/scripts/convertmodel/test/README.md
@@ -95,6 +95,30 @@ against a tiny fake DOM); no DOM or network:
 npm run test:versions
 ```
 
+## URL-driven input (query parameters)
+
+The input model and conversion options can be set straight from the page URL, so
+a link converts a specific model on open. The model reference reuses the Hugging
+Face loader's repo-id / `.onnx`-URL path (nothing is uploaded):
+
+```
+?model=onnxmodelzoo/resnet18d_Opset18
+?model=https://…/foo.onnx&optimizer=optimize&cf=0
+?model=…&autoload=0          # prefill the box + options but don't auto-run
+?backend=https://github.com/onnx/onnx/tree/main/onnx/backend/test/data/node/test_relu
+```
+
+Keys (aliases in parentheses): `model` (`hf`/`url`/`input`), `optimizer`,
+`constant_fold` (`cf`), `shape_inference` (`si`), `tensor_size_threshold`
+(`tst`), `target_opset` (`opset`), `autoload` (`run`/`convert`), and `backend`
+(prefills the backend-test panel). `npm run test:query` unit-tests the pure
+`query_params.mjs` parser + option-prefiller (against a fake DOM); no
+DOM/network:
+
+```bash
+npm run test:query
+```
+
 ## Parse a text graph
 
 The **Parse a text graph** panel takes an ONNX

--- a/scripts/convertmodel/test/README.md
+++ b/scripts/convertmodel/test/README.md
@@ -150,16 +150,21 @@ the **After** Netron pane, downloadable, and runnable in the inference panel.
 
 ## Run an ONNX backend test case
 
-The **Run an ONNX backend test case** panel takes a URL to an
-[ONNX backend test case](https://github.com/onnx/onnx/tree/main/onnx/backend/test/data)
-directory (a `model.onnx` plus one or more `test_data_set_N/` of `input_*.pb` /
-`output_*.pb` TensorProtos), fetches the model and test data from GitHub, runs
-the model through onnxruntime-web with the given inputs, and compares each output
-against the expected tensor within tolerance. TensorProtos are decoded by the
-`onnxsim_parse_tensor` binding. `npm run test:backend` unit-tests the pure
-`backend_test.mjs` helpers — GitHub URL parsing (tree / blob /
-`raw.githubusercontent.com` / contents-API forms), numeric ordering of
-`input_N.pb` files, and float/int/shape tensor comparison; no DOM or network:
+The **ONNX backend test case** picker (next to the Hugging Face model selector)
+takes an [ONNX backend test case](https://github.com/onnx/onnx/tree/main/onnx/backend/test/data)
+directory — a `model.onnx` plus one or more `test_data_set_N/` of `input_*.pb` /
+`output_*.pb` TensorProtos. A dropdown offers a curated set of common node tests
+(`test_relu`, `test_matmul_2d`, …); the free-text box accepts any GitHub `tree` /
+`raw.githubusercontent.com` URL. It fetches the model and test data from GitHub,
+**runs the model through onnxruntime-web with the test inputs** (the `input_*.pb`
+tensors, not dummy data), and compares each output against the expected
+`output_*.pb` tensor within tolerance. With **convert the model** on, the fetched
+model also runs through the selected convert mode (Netron panes + download).
+TensorProtos are decoded by the `onnxsim_parse_tensor` binding. `npm run
+test:backend` unit-tests the pure `backend_test.mjs` helpers — GitHub URL parsing
+(tree / blob / `raw.githubusercontent.com` / contents-API forms), numeric
+ordering of `input_N.pb` files, float/int/shape tensor comparison, and that every
+curated preset is a parseable node-test URL; no DOM or network:
 
 ```bash
 npm run test:backend

--- a/scripts/convertmodel/test/backend_test.test.mjs
+++ b/scripts/convertmodel/test/backend_test.test.mjs
@@ -11,6 +11,7 @@ import {
   tensorIndex,
   compareTensors,
   ONNX_DTYPE,
+  BACKEND_PRESETS,
 } from "../backend_test.mjs";
 
 let passed = 0;
@@ -109,6 +110,18 @@ check("int64 (bigint) outputs compare exactly", () => {
   const bad = new BigInt64Array([1n, 2n, 4n]);
   assert.ok(compareTensors(good, [3], expected, {}).ok);
   assert.equal(compareTensors(bad, [3], expected, {}).ok, false);
+});
+
+check("backend presets are node-test dirs parseable by the URL parser", () => {
+  assert.ok(BACKEND_PRESETS.length >= 10);
+  for (const { name, url } of BACKEND_PRESETS) {
+    assert.ok(name.startsWith("test_"), `preset name ${name} should start with test_`);
+    const loc = parseGithubDirUrl(url);
+    assert.ok(loc, `preset URL ${url} should parse`);
+    assert.equal(loc.owner, "onnx");
+    assert.equal(loc.repo, "onnx");
+    assert.ok(loc.path.endsWith(`/node/${name}`), `path ${loc.path} should end with the test name`);
+  }
 });
 
 check("dtype table maps the common ONNX types", () => {

--- a/scripts/convertmodel/test/backend_test.test.mjs
+++ b/scripts/convertmodel/test/backend_test.test.mjs
@@ -1,0 +1,121 @@
+// Unit tests for the pure helpers behind the "Run an ONNX backend test case"
+// panel: GitHub URL parsing, tensor ordering, and tensor comparison. No DOM or
+// network needed (the DOM/onnxruntime-web glue is browser-only).
+//
+// Usage:
+//   node test/backend_test.test.mjs
+
+import assert from "node:assert/strict";
+import {
+  parseGithubDirUrl,
+  tensorIndex,
+  compareTensors,
+  ONNX_DTYPE,
+} from "../backend_test.mjs";
+
+let passed = 0;
+function check(name, fn) {
+  fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+
+check("parses a github tree URL", () => {
+  const loc = parseGithubDirUrl(
+    "https://github.com/onnx/onnx/tree/main/onnx/backend/test/data/node/test_relu",
+  );
+  assert.deepEqual(loc, {
+    owner: "onnx",
+    repo: "onnx",
+    ref: "main",
+    path: "onnx/backend/test/data/node/test_relu",
+  });
+});
+
+check("parses a github blob URL", () => {
+  const loc = parseGithubDirUrl(
+    "https://github.com/onnx/onnx/blob/rel-1.16.0/onnx/backend/test/data/node/test_abs",
+  );
+  assert.equal(loc.ref, "rel-1.16.0");
+  assert.equal(loc.path, "onnx/backend/test/data/node/test_abs");
+});
+
+check("parses a raw.githubusercontent URL", () => {
+  const loc = parseGithubDirUrl(
+    "https://raw.githubusercontent.com/onnx/onnx/main/onnx/backend/test/data/node/test_relu",
+  );
+  assert.deepEqual(loc, {
+    owner: "onnx",
+    repo: "onnx",
+    ref: "main",
+    path: "onnx/backend/test/data/node/test_relu",
+  });
+});
+
+check("parses an api.github.com contents URL", () => {
+  const loc = parseGithubDirUrl(
+    "https://api.github.com/repos/onnx/onnx/contents/onnx/backend/test/data/node/test_relu?ref=main",
+  );
+  assert.equal(loc.owner, "onnx");
+  assert.equal(loc.path, "onnx/backend/test/data/node/test_relu");
+  assert.equal(loc.ref, "main");
+});
+
+check("rejects non-GitHub / malformed URLs", () => {
+  assert.equal(parseGithubDirUrl("https://example.com/foo/bar"), null);
+  assert.equal(parseGithubDirUrl("not a url"), null);
+  assert.equal(parseGithubDirUrl("https://github.com/onnx/onnx"), null);
+});
+
+check("orders tensor files numerically, not lexically", () => {
+  const names = ["input_10.pb", "input_2.pb", "input_1.pb"];
+  names.sort((a, b) => tensorIndex(a) - tensorIndex(b));
+  assert.deepEqual(names, ["input_1.pb", "input_2.pb", "input_10.pb"]);
+});
+
+// Build an expected-tensor object (as parseTensor would produce) from a typed
+// array: raw little-endian bytes + dtype + dims.
+function expectedTensor(dtype, dims, typed) {
+  const bytes = new Uint8Array(typed.buffer.slice(0));
+  return { dtype, dims, bytes };
+}
+
+check("float outputs pass within tolerance", () => {
+  const expected = expectedTensor(1, [2], new Float32Array([1.0, 2.0]));
+  const actual = new Float32Array([1.00001, 2.00005]);
+  const cmp = compareTensors(actual, [2], expected, { atol: 1e-4, rtol: 1e-3 });
+  assert.ok(cmp.ok, `expected pass, got ${JSON.stringify(cmp)}`);
+});
+
+check("float outputs fail outside tolerance", () => {
+  const expected = expectedTensor(1, [2], new Float32Array([1.0, 2.0]));
+  const actual = new Float32Array([1.0, 2.5]);
+  const cmp = compareTensors(actual, [2], expected, { atol: 1e-4, rtol: 1e-3 });
+  assert.equal(cmp.ok, false);
+  assert.ok(cmp.maxDiff > 0.4);
+});
+
+check("shape mismatch fails even when values line up", () => {
+  const expected = expectedTensor(1, [1, 2], new Float32Array([1.0, 2.0]));
+  const actual = new Float32Array([1.0, 2.0]);
+  const cmp = compareTensors(actual, [2], expected, {});
+  assert.equal(cmp.ok, false);
+  assert.equal(cmp.shapeOk, false);
+});
+
+check("int64 (bigint) outputs compare exactly", () => {
+  const expected = expectedTensor(7, [3], new BigInt64Array([1n, 2n, 3n]));
+  const good = new BigInt64Array([1n, 2n, 3n]);
+  const bad = new BigInt64Array([1n, 2n, 4n]);
+  assert.ok(compareTensors(good, [3], expected, {}).ok);
+  assert.equal(compareTensors(bad, [3], expected, {}).ok, false);
+});
+
+check("dtype table maps the common ONNX types", () => {
+  assert.equal(ONNX_DTYPE[1].ort, "float32");
+  assert.equal(ONNX_DTYPE[7].ort, "int64");
+  assert.equal(ONNX_DTYPE[9].ort, "bool");
+  assert.equal(ONNX_DTYPE[11].ort, "float64");
+});
+
+console.log(`PASS: ${passed} checks`);

--- a/scripts/convertmodel/test/netron.test.mjs
+++ b/scripts/convertmodel/test/netron.test.mjs
@@ -13,6 +13,7 @@ import {
   toArrayBuffer,
   dataUrlToArrayBuffer,
   buildModelMessage,
+  buildExportMessage,
 } from "../netron.mjs";
 
 let passed = 0;
@@ -85,6 +86,21 @@ check("buildModelMessage falls back to a default identifier", () => {
 
 check("buildModelMessage requires an ArrayBuffer", () => {
   assert.throws(() => buildModelMessage(new Uint8Array([1]), "x"));
+});
+
+check("buildExportMessage defaults to an svg export command", () => {
+  const message = buildExportMessage(undefined, "my model.onnx");
+  assert.equal(message.netron.command, "export");
+  assert.equal(message.netron.format, "svg");
+  assert.equal(message.netron.name, "my model.onnx");
+});
+
+check("buildExportMessage accepts png and defaults the name", () => {
+  const png = buildExportMessage("png");
+  assert.equal(png.netron.format, "png");
+  assert.equal(png.netron.name, "model");
+  // An unknown format falls back to svg.
+  assert.equal(buildExportMessage("gif").netron.format, "svg");
 });
 
 console.log(`PASS: ${passed} checks`);

--- a/scripts/convertmodel/test/query_params.test.mjs
+++ b/scripts/convertmodel/test/query_params.test.mjs
@@ -1,0 +1,103 @@
+// Unit tests for query_params.mjs, the pure parser + control-prefiller behind
+// the converter page's URL-driven input (e.g. ?model=…). No DOM/network needed;
+// applyOptionParams is driven through a tiny fake document.
+//
+// Usage:
+//   node test/query_params.test.mjs
+
+import assert from "node:assert/strict";
+import { parseInputParams, applyOptionParams } from "../query_params.mjs";
+
+let passed = 0;
+function check(name, fn) {
+  fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+
+check("parses a model URL and defaults autoload to true", () => {
+  const c = parseInputParams("?model=https://example.com/foo.onnx");
+  assert.equal(c.model, "https://example.com/foo.onnx");
+  assert.equal(c.autoload, true);
+  assert.equal(c.optimizer, null);
+  assert.equal(c.constantFold, null);
+});
+
+check("accepts model aliases (hf, url, input)", () => {
+  assert.equal(parseInputParams("?hf=onnxmodelzoo/resnet18d_Opset18").model, "onnxmodelzoo/resnet18d_Opset18");
+  assert.equal(parseInputParams("?url=https://x/y.onnx").model, "https://x/y.onnx");
+  assert.equal(parseInputParams("?input=owner/repo").model, "owner/repo");
+});
+
+check("returns null model when absent", () => {
+  const c = parseInputParams("?optimizer=optimize");
+  assert.equal(c.model, null);
+  assert.equal(c.optimizer, "optimize");
+});
+
+check("parses booleans, empty flag, and aliases", () => {
+  assert.equal(parseInputParams("?cf=0").constantFold, false);
+  assert.equal(parseInputParams("?constant_fold=true").constantFold, true);
+  assert.equal(parseInputParams("?cf").constantFold, true); // bare flag = on
+  assert.equal(parseInputParams("?si=off").shapeInference, false);
+  assert.equal(parseInputParams("?shape_inference=1").shapeInference, true);
+});
+
+check("autoload can be turned off", () => {
+  assert.equal(parseInputParams("?model=x&autoload=0").autoload, false);
+  assert.equal(parseInputParams("?model=x&run=false").autoload, false);
+  assert.equal(parseInputParams("?model=x").autoload, true);
+});
+
+check("parses integer options and ignores garbage", () => {
+  assert.equal(parseInputParams("?tst=500000").tensorSizeThreshold, 500000);
+  assert.equal(parseInputParams("?tensor_size_threshold=42").tensorSizeThreshold, 42);
+  assert.equal(parseInputParams("?opset=17").targetOpset, 17);
+  assert.equal(parseInputParams("?opset=notanumber").targetOpset, null);
+});
+
+check("only accepts known optimizer values", () => {
+  assert.equal(parseInputParams("?optimizer=optimize_fixed").optimizer, "optimize_fixed");
+  assert.equal(parseInputParams("?optimizer=bogus").optimizer, null);
+});
+
+check("parses a backend test-case URL", () => {
+  const c = parseInputParams("?backend=https://github.com/onnx/onnx/tree/main/onnx/backend/test/data/node/test_relu");
+  assert.ok(c.backend.endsWith("test_relu"));
+});
+
+// A minimal document stand-in whose getElementById returns recording elements.
+function fakeDoc(ids) {
+  const els = {};
+  for (const id of ids) els[id] = { checked: false, value: "" };
+  return { els, getElementById: (id) => els[id] || null };
+}
+
+check("applyOptionParams prefills only the given controls", () => {
+  const doc = fakeDoc([
+    "optimizer_optimize",
+    "id_simplify_constant_fold",
+    "id_simplify_shape_inference",
+    "id_simplify_tensor_size_threshold",
+    "id_simplify_target_opset",
+  ]);
+  const params = parseInputParams("?optimizer=optimize&cf=0&si=1&tst=1000&opset=18");
+  const changed = applyOptionParams(params, doc);
+  assert.equal(doc.els.optimizer_optimize.checked, true);
+  assert.equal(doc.els.id_simplify_constant_fold.checked, false);
+  assert.equal(doc.els.id_simplify_shape_inference.checked, true);
+  assert.equal(doc.els.id_simplify_tensor_size_threshold.value, "1000");
+  assert.equal(doc.els.id_simplify_target_opset.value, "18");
+  assert.ok(changed.includes("optimizer_optimize"));
+});
+
+check("applyOptionParams leaves untouched controls alone", () => {
+  const doc = fakeDoc(["id_simplify_constant_fold"]);
+  doc.els.id_simplify_constant_fold.checked = true;
+  const changed = applyOptionParams(parseInputParams("?model=x"), doc);
+  // No option params present, so nothing is changed.
+  assert.equal(changed.length, 0);
+  assert.equal(doc.els.id_simplify_constant_fold.checked, true);
+});
+
+console.log(`PASS: ${passed} checks`);

--- a/scripts/convertmodel/test/query_params.test.mjs
+++ b/scripts/convertmodel/test/query_params.test.mjs
@@ -69,6 +69,12 @@ check("only accepts known optimizer values, incl. single-pass modes", () => {
   assert.equal(parseInputParams("?optimizer=bogus").optimizer, null);
 });
 
+check("optimizer accepts mode/processor/opt aliases", () => {
+  assert.equal(parseInputParams("?mode=simplify").optimizer, "simplify");
+  assert.equal(parseInputParams("?processor=fold_constant").optimizer, "fold_constant");
+  assert.equal(parseInputParams("?opt=optimize").optimizer, "optimize");
+});
+
 check("parses a text graph param (graph/text), preserving interior whitespace", () => {
   const graph = "agraph (float[N] X) => (float[N] Y) {\n  Y = Relu(X)\n}";
   const c = parseInputParams("?graph=" + encodeURIComponent(graph));

--- a/scripts/convertmodel/test/query_params.test.mjs
+++ b/scripts/convertmodel/test/query_params.test.mjs
@@ -6,7 +6,12 @@
 //   node test/query_params.test.mjs
 
 import assert from "node:assert/strict";
-import { parseInputParams, applyOptionParams, setInputParam } from "../query_params.mjs";
+import {
+  parseInputParams,
+  applyOptionParams,
+  setInputParam,
+  setUrlParam,
+} from "../query_params.mjs";
 
 let passed = 0;
 function check(name, fn) {
@@ -56,9 +61,20 @@ check("parses integer options and ignores garbage", () => {
   assert.equal(parseInputParams("?opset=notanumber").targetOpset, null);
 });
 
-check("only accepts known optimizer values", () => {
+check("only accepts known optimizer values, incl. single-pass modes", () => {
   assert.equal(parseInputParams("?optimizer=optimize_fixed").optimizer, "optimize_fixed");
+  assert.equal(parseInputParams("?optimizer=fold_constant").optimizer, "fold_constant");
+  assert.equal(parseInputParams("?optimizer=infer_shapes").optimizer, "infer_shapes");
+  assert.equal(parseInputParams("?optimizer=data_propagation").optimizer, "data_propagation");
   assert.equal(parseInputParams("?optimizer=bogus").optimizer, null);
+});
+
+check("parses a text graph param (graph/text), preserving interior whitespace", () => {
+  const graph = "agraph (float[N] X) => (float[N] Y) {\n  Y = Relu(X)\n}";
+  const c = parseInputParams("?graph=" + encodeURIComponent(graph));
+  assert.equal(c.graph, graph);
+  assert.equal(parseInputParams("?text=" + encodeURIComponent(graph)).graph, graph);
+  assert.equal(parseInputParams("?model=x").graph, null);
 });
 
 check("parses a backend test-case URL", () => {
@@ -119,6 +135,22 @@ check("setInputParam round-trips through parseInputParams", () => {
   const s = setInputParam("", "model", "https://x/y.onnx");
   assert.ok(s.startsWith("?"));
   assert.equal(parseInputParams(s).model, "https://x/y.onnx");
+});
+
+check("setInputParam sets graph and clears other inputs", () => {
+  const s = setInputParam("?model=owner/repo&optimizer=fold_constant", "graph", "agraph () => () {}");
+  const p = new URLSearchParams(s);
+  assert.equal(p.get("graph"), "agraph () => () {}");
+  assert.equal(p.get("model"), null);
+  assert.equal(p.get("optimizer"), "fold_constant"); // option preserved
+});
+
+check("setUrlParam sets/deletes one param, preserving inputs", () => {
+  assert.equal(new URLSearchParams(setUrlParam("?model=x", "optimizer", "optimize")).get("optimizer"), "optimize");
+  // Existing input param is preserved.
+  assert.equal(new URLSearchParams(setUrlParam("?model=x", "optimizer", "optimize")).get("model"), "x");
+  // Empty value deletes the key.
+  assert.equal(new URLSearchParams(setUrlParam("?model=x&optimizer=optimize", "optimizer", "")).get("optimizer"), null);
 });
 
 console.log(`PASS: ${passed} checks`);

--- a/scripts/convertmodel/test/query_params.test.mjs
+++ b/scripts/convertmodel/test/query_params.test.mjs
@@ -6,7 +6,7 @@
 //   node test/query_params.test.mjs
 
 import assert from "node:assert/strict";
-import { parseInputParams, applyOptionParams } from "../query_params.mjs";
+import { parseInputParams, applyOptionParams, setInputParam } from "../query_params.mjs";
 
 let passed = 0;
 function check(name, fn) {
@@ -98,6 +98,27 @@ check("applyOptionParams leaves untouched controls alone", () => {
   // No option params present, so nothing is changed.
   assert.equal(changed.length, 0);
   assert.equal(doc.els.id_simplify_constant_fold.checked, true);
+});
+
+check("setInputParam sets model and drops other input keys", () => {
+  const s = setInputParam("?hf=old/repo&optimizer=optimize", "model", "owner/new");
+  const p = new URLSearchParams(s);
+  assert.equal(p.get("model"), "owner/new");
+  assert.equal(p.get("hf"), null); // old input key dropped
+  assert.equal(p.get("optimizer"), "optimize"); // option param preserved
+});
+
+check("setInputParam sets backend and clears model", () => {
+  const s = setInputParam("?model=owner/repo", "backend", "https://github.com/onnx/onnx/tree/main/x");
+  const p = new URLSearchParams(s);
+  assert.equal(p.get("backend"), "https://github.com/onnx/onnx/tree/main/x");
+  assert.equal(p.get("model"), null);
+});
+
+check("setInputParam round-trips through parseInputParams", () => {
+  const s = setInputParam("", "model", "https://x/y.onnx");
+  assert.ok(s.startsWith("?"));
+  assert.equal(parseInputParams(s).model, "https://x/y.onnx");
 });
 
 console.log(`PASS: ${passed} checks`);

--- a/scripts/convertmodel/test/versions.test.mjs
+++ b/scripts/convertmodel/test/versions.test.mjs
@@ -1,0 +1,84 @@
+// Unit tests for the pure helpers behind the converter page's "Versions" panel.
+// The initVersions() DOM/runtime glue is browser-only (guarded by a window
+// check in the module), so we test only normalizeVersions and renderVersions
+// here, driving the latter through a tiny fake DOM.
+//
+// Usage:
+//   node test/versions.test.mjs
+
+import assert from "node:assert/strict";
+import { normalizeVersions, renderVersions } from "../versions.mjs";
+
+let passed = 0;
+function check(name, fn) {
+  fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+
+check("normalizes a full versions object", () => {
+  const v = normalizeVersions({
+    onnxsim: "0.7.0",
+    onnx_optimizer: "0.4.2",
+    onnx: "IR v10, opset 22",
+    protobuf: "4.25.1",
+  });
+  assert.deepEqual(v, {
+    onnxsim: "0.7.0",
+    onnx_optimizer: "0.4.2",
+    onnx: "IR v10, opset 22",
+    protobuf: "4.25.1",
+  });
+});
+
+check("fills missing fields with 'unknown' and handles null", () => {
+  assert.equal(normalizeVersions(null), null);
+  const v = normalizeVersions({ onnxsim: "0.7.0" });
+  assert.equal(v.onnxsim, "0.7.0");
+  assert.equal(v.onnx_optimizer, "unknown");
+  assert.equal(v.onnx, "unknown");
+  assert.equal(v.protobuf, "unknown");
+});
+
+// A minimal element stand-in recording appended children and their text.
+function fakeElement() {
+  return {
+    className: "",
+    textContent: "",
+    children: [],
+    appendChild(c) {
+      this.children.push(c);
+    },
+  };
+}
+
+check("renders one badge per library with label and value", () => {
+  // renderVersions calls document.createElement; stub a minimal document.
+  globalThis.document = { createElement: () => fakeElement() };
+  const panel = fakeElement();
+  renderVersions(panel, {
+    onnxsim: "0.7.0",
+    onnx_optimizer: "0.4.2",
+    onnx: "IR v10, opset 22",
+    protobuf: "4.25.1",
+  });
+  // Four badges appended.
+  assert.equal(panel.children.length, 4);
+  // Flatten all the text that ended up in the panel.
+  const text = JSON.stringify(collectText(panel));
+  assert.ok(text.includes("onnxsim"));
+  assert.ok(text.includes("0.7.0"));
+  assert.ok(text.includes("onnx-optimizer"));
+  assert.ok(text.includes("0.4.2"));
+  assert.ok(text.includes("protobuf"));
+  delete globalThis.document;
+});
+
+function collectText(el) {
+  const out = [];
+  if (el.textContent) out.push(el.textContent);
+  for (const c of el.children || []) out.push(...collectText(c));
+  return out;
+}
+
+console.log(`PASS: ${passed} checks`);

--- a/scripts/convertmodel/versions.mjs
+++ b/scripts/convertmodel/versions.mjs
@@ -1,0 +1,68 @@
+// Fills the "Versions" panel on the converter page and publishes the versions
+// for the "Report an issue" body, so bug reports say exactly which onnxsim /
+// onnx-optimizer / onnx / protobuf the WebAssembly module was built against.
+//
+// The numbers come from the module itself: `onnxsim_versions()` (interface.cpp)
+// reports the onnxsim and onnx-optimizer versions baked in by CMake, plus the
+// onnx IR/opset and protobuf versions read from the linked libraries. We call it
+// on this page's runtime (the same one that populates the pass list), which
+// needs no onnxruntime-web, so the panel fills as soon as the runtime is ready.
+
+// Normalize the embind-returned object into a plain JS object of strings.
+export function normalizeVersions(v) {
+  if (!v) return null;
+  return {
+    onnxsim: v.onnxsim ?? "unknown",
+    onnx_optimizer: v.onnx_optimizer ?? "unknown",
+    onnx: v.onnx ?? "unknown",
+    protobuf: v.protobuf ?? "unknown",
+  };
+}
+
+// The human labels shown in the panel and the issue report, in display order.
+const LABELS = [
+  ["onnxsim", "onnxsim"],
+  ["onnx_optimizer", "onnx-optimizer"],
+  ["onnx", "onnx"],
+  ["protobuf", "protobuf"],
+];
+
+// Render the versions object into `panel` as a row of labelled badges.
+export function renderVersions(panel, versions) {
+  if (!panel) return;
+  panel.textContent = "";
+  for (const [key, label] of LABELS) {
+    const badge = document.createElement("span");
+    badge.className = "version-badge";
+    const k = document.createElement("span");
+    k.className = "version-k";
+    k.textContent = label;
+    const val = document.createElement("span");
+    val.className = "version-v";
+    val.textContent = versions[key];
+    badge.appendChild(k);
+    badge.appendChild(val);
+    panel.appendChild(badge);
+  }
+}
+
+async function initVersions() {
+  const panel = document.getElementById("versions-panel");
+  try {
+    // Set by index.html's inline loader as soon as create_onnxsim() is called.
+    const runtime = await window.__onnxsimRuntimePromise;
+    const versions = normalizeVersions(runtime.onnxsim_versions());
+    // Publish for the issue-report builder (read in index.html).
+    window.__onnxsimVersions = versions;
+    renderVersions(panel, versions);
+  } catch (err) {
+    if (panel) {
+      panel.textContent = "could not read versions: " + (err && err.message ? err.message : err);
+    }
+  }
+}
+
+// Only run in the browser; the exports above stay importable by the Node test.
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  initVersions();
+}

--- a/scripts/convertmodel/worker.js
+++ b/scripts/convertmodel/worker.js
@@ -90,8 +90,50 @@ create_onnxsim({
     // "Choose file" picker. Registering the message listener below only
     // happens now, so any file posted earlier would be dropped.
     postMessage(["ready"]);
+
+    // The single-feature debugging passes (the "Run a single feature" panel):
+    // each takes a model and returns a transformed model, without the full
+    // fixed-point Simplify. They post back ["debug-done", type, dataUrl, error]
+    // so the debug module can tell its responses apart from a conversion.
+    const DEBUG_TYPES = new Set(["infer_shapes", "data_propagation", "fold_constant"]);
+    async function handleDebug(e) {
+        const type = e.data[0];
+        const buf = e.data[1];
+        try {
+            let model = null;
+            if (type === "infer_shapes") {
+                model = runtime.onnxsim_infer_shapes(buf);
+            } else if (type === "data_propagation") {
+                model = runtime.onnxsim_data_propagation(buf);
+            } else if (type === "fold_constant") {
+                // Constant folding runs through the executor; in the ORT-web
+                // build it is Asyncified and returns a Promise to await.
+                let r = runtime.onnxsim_fold_constant(buf, e.data[2]);
+                if (r && typeof r.then === "function") r = await r;
+                model = r;
+            }
+            if (!model) {
+                postMessage(["debug-done", type, null,
+                    type + " produced no model (see the log above)"]);
+                return;
+            }
+            const data_url = "data:application/octet-stream;base64," + model.toBase64();
+            postMessage(["debug-done", type, data_url, null]);
+        } catch (err) {
+            const detail = String((err && err.message) || err);
+            if (isOutOfMemory(detail)) {
+                postMessage(["stderr", memoryLimitMessage(detail)]);
+            }
+            postMessage(["debug-done", type, null, detail]);
+        }
+    }
+
     addEventListener("message", async (e) => {
         console.log(e.data);
+        if (DEBUG_TYPES.has(e.data[0])) {
+            await handleDebug(e);
+            return;
+        }
         const buf = e.data[1];
         // `model` is the converted model bytes (a Uint8Array view); `trace` is
         // the onnxsim profiling trace JSON for "simplify" when profiling was

--- a/scripts/convertmodel/worker.js
+++ b/scripts/convertmodel/worker.js
@@ -91,49 +91,8 @@ create_onnxsim({
     // happens now, so any file posted earlier would be dropped.
     postMessage(["ready"]);
 
-    // The single-feature debugging passes (the "Run a single feature" panel):
-    // each takes a model and returns a transformed model, without the full
-    // fixed-point Simplify. They post back ["debug-done", type, dataUrl, error]
-    // so the debug module can tell its responses apart from a conversion.
-    const DEBUG_TYPES = new Set(["infer_shapes", "data_propagation", "fold_constant"]);
-    async function handleDebug(e) {
-        const type = e.data[0];
-        const buf = e.data[1];
-        try {
-            let model = null;
-            if (type === "infer_shapes") {
-                model = runtime.onnxsim_infer_shapes(buf);
-            } else if (type === "data_propagation") {
-                model = runtime.onnxsim_data_propagation(buf);
-            } else if (type === "fold_constant") {
-                // Constant folding runs through the executor; in the ORT-web
-                // build it is Asyncified and returns a Promise to await.
-                let r = runtime.onnxsim_fold_constant(buf, e.data[2]);
-                if (r && typeof r.then === "function") r = await r;
-                model = r;
-            }
-            if (!model) {
-                postMessage(["debug-done", type, null,
-                    type + " produced no model (see the log above)"]);
-                return;
-            }
-            const data_url = "data:application/octet-stream;base64," + model.toBase64();
-            postMessage(["debug-done", type, data_url, null]);
-        } catch (err) {
-            const detail = String((err && err.message) || err);
-            if (isOutOfMemory(detail)) {
-                postMessage(["stderr", memoryLimitMessage(detail)]);
-            }
-            postMessage(["debug-done", type, null, detail]);
-        }
-    }
-
     addEventListener("message", async (e) => {
         console.log(e.data);
-        if (DEBUG_TYPES.has(e.data[0])) {
-            await handleDebug(e);
-            return;
-        }
         const buf = e.data[1];
         // `model` is the converted model bytes (a Uint8Array view); `trace` is
         // the onnxsim profiling trace JSON for "simplify" when profiling was
@@ -185,6 +144,23 @@ create_onnxsim({
                     e.data[8], // annotate model info (MACs/FLOPs) into metadata_props
                 );
                 break;
+            // Single-pass debugging modes: run exactly one of Simplify's
+            // fixed-point building blocks once. Shape inference and data
+            // propagation need no executor; constant folding does (Asyncified in
+            // the ORT-web build, so await when it returns a Promise). They all
+            // return the model bytes through the same convert-done path below.
+            case "infer_shapes":
+                model = runtime.onnxsim_infer_shapes(buf);
+                break;
+            case "data_propagation":
+                model = runtime.onnxsim_data_propagation(buf);
+                break;
+            case "fold_constant": {
+                let r = runtime.onnxsim_fold_constant(buf, e.data[5]); // tensor size threshold
+                if (r && typeof r.then === "function") r = await r;
+                model = r;
+                break;
+            }
             default:
                 postMessage(["stderr", "unknown conversion type: " + e.data[0]]);
                 return;


### PR DESCRIPTION
Extends the in-browser model converter (`scripts/convertmodel/`) with several testing, debugging, and sharing features. All of it runs in the browser — nothing is uploaded.

## Features

**Run an ONNX backend test case**
- A picker next to the Hugging Face selector: a dropdown of curated common node tests (`test_relu`, `test_matmul_2d`, …) plus a free-text box for any GitHub `tree` / `raw.githubusercontent.com` URL.
- Fetches `model.onnx` and the test data (`test_data_set_N/` of `input_*.pb` / `output_*.pb`) from GitHub, runs the model through onnxruntime-web **with the real test inputs**, and compares each output to the expected tensor within (configurable) tolerance. TensorProtos are decoded by a new `onnxsim_parse_tensor` binding.
- With **convert the model** on, the fetched model also runs through the selected convert mode (shown in the Netron panes).

**Parse a text graph** (top of the page)
- Parses the ONNX textual representation (the form `onnx.parser.parse_graph` / `parse_model` accept) into a model via a new `onnxsim_parse_graph` binding — a bare graph is wrapped in a model with a default-domain opset import — then feeds it into the Simplify / Netron path.

**Single-pass debug modes**
- **Shape inference**, **Data propagation**, and **Constant folding** are convert-mode radios next to Simplify / Optimize / Fixed Optimize. Each runs exactly one of Simplify's fixed-point building blocks once, for debugging, and the result flows through the normal convert path (After Netron pane, download, inference).
- Backed by new onnxsim core helpers `InferShapesOnce` / `PropagateDataOnce` / `FoldConstantOnce` and the `onnxsim_infer_shapes` / `onnxsim_data_propagation` / `onnxsim_fold_constant` bindings (folding uses the same model executor `Simplify` does).

**Library versions panel**
- Shows the onnxsim / onnx-optimizer / onnx (IR + opset) / protobuf versions built into the module (new `onnxsim_versions` binding; onnxsim & onnx-optimizer baked in by CMake, onnx & protobuf read at runtime), as badges and in the Report-an-issue body.

**Netron SVG / PNG export**
- Each Netron pane gets **export SVG** / **export PNG** buttons that ask the embedded Netron (over an added `export` command in the postMessage protocol) to render the shown graph and hand back the image bytes. Requires the companion Netron-fork branch below.

**URL-driven input**
- The input and convert mode are settable from the URL and reflected back into it (shareable links), e.g. `?model=onnxmodelzoo/resnet18d_Opset18`, `?model=https://…/foo.onnx&mode=fold_constant&cf=0`, `?graph=<onnx text>`, `?backend=<test-case URL>`.
- Keys (aliases in parens): `model` (`hf`/`url`/`input`), `graph` (`text`), `backend` (`testcase`/`test`), `optimizer` (`mode`/`processor`/`opt`), `constant_fold` (`cf`), `shape_inference` (`si`), `tensor_size_threshold` (`tst`), `target_opset` (`opset`), `autoload` (`run`/`convert`). Setting an input updates the address bar via `history.replaceState` (uploaded local files excepted — they have no URL).

**Fixes**
- Multi-input inference: the inference panel fed only the first input; it now feeds every model input, so multi-input models (e.g. `MatMul(X, W) + Add(_, B)`) run.

## Build system
- `CMakeLists.txt` reads the onnxsim / onnx-optimizer `VERSION` files and bakes them into the WASM module as defines for `onnxsim_versions()`.
- Deploy (`static.yml`) points `NETRON_REF` at the Netron-fork branch carrying the embedding protocol on Netron 9.1.9 plus the new `export` command.

## Companion change (separate repo)
- `onnxsim/netron` branch `claude/wasm-netron-svg-export`: adds the `export` command to the embedding protocol and documents Netron-as-a-model-preview-component, referencing the upstream discussion in [lutzroeder/netron#1591](https://github.com/lutzroeder/netron/pull/1591).

## Tests
- New Node unit tests for the pure logic — `versions`, `backend_test` (GitHub URL parsing, tensor comparison, preset URLs), `query_params` (parsing, option prefill, URL builders), and `netron` (export message) — wired into the inference + coverage workflows. The C++ bindings are exercised by the per-PR WASM build/deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014VERDjRVegJJ1JXBWt6Yt1