### PR TITLE
Add WebNN execution provider support to inference panel

### DIFF
--- a/.github/workflows/convertmodel-inference.yml
+++ b/.github/workflows/convertmodel-inference.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Run Xet chunk-cache unit test
         working-directory: scripts/convertmodel
         run: npm run test:xet
+      - name: Run WebNN helper unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:webnn
       - name: Run inference smoke test (wasm EP)
         working-directory: scripts/convertmodel
         run: npm run test:inference

--- a/docs/webnn.md
+++ b/docs/webnn.md
@@ -1,0 +1,71 @@
+# WebNN in the WASM converter UI
+
+**Status: experimental.** The converter page's **Run inference** panel can now
+run a model through [WebNN](https://www.w3.org/TR/webnn/) as an onnxruntime-web
+execution provider, alongside the existing WebGPU and WebAssembly options. This
+document records the state of WebNN as of onnxsim's move to onnxruntime-web
+1.27 (early 2026) and how the panel uses it.
+
+## What WebNN is
+
+WebNN (the W3C Web Neural Network API, exposed as `navigator.ml`) lets a web
+page run a neural network on the platform's own machine-learning stack —
+DirectML on Windows, Core ML on macOS, and the platform NN API elsewhere —
+reaching the GPU and, where present, a dedicated NPU, without shipping a
+compute backend in the page.
+
+## Status (early 2026)
+
+- **Specification:** WebNN is a W3C Candidate Recommendation, still evolving.
+- **Browsers:** available in recent Chromium-based browsers (Chrome, Edge, and
+  relatives) behind the *"Enables WebNN API"* flag —
+  `chrome://flags/#web-machine-learning-neural-network`. Coverage is broadest on
+  **Windows**; GPU and NPU paths on other platforms are still maturing. Not yet
+  in Firefox or Safari stable.
+- **onnxruntime-web:** the WebNN backend is an **experimental** execution
+  provider. It is not part of the default `ort.min.mjs` bundle — it ships in the
+  "all" bundle (`ort.all.min.mjs`).
+
+Because of that, WebNN is **usable but not guaranteed** on any given visitor's
+browser: treat it as an acceleration opportunity with a required fallback, not a
+baseline.
+
+## How the panel uses it
+
+`scripts/convertmodel/webnn.mjs` holds the browser-free pieces (all unit-tested
+in `test/webnn.test.mjs`):
+
+- **`detectWebnn(navigator)`** probes `navigator.ml` at page load, attempting to
+  create an `MLContext` for each device type (`gpu`, `npu`, `cpu`). The panel
+  renders the result as a live **WebNN status** line under the inference
+  controls, so a visitor can see whether WebNN will run before selecting it.
+- **`providersForEp(value)`** maps each EP dropdown choice to an ordered
+  onnxruntime-web provider list. The WebNN choices are:
+
+  | dropdown value | providers tried (in order)                                   |
+  | -------------- | ------------------------------------------------------------ |
+  | `webnn-gpu`    | `{ name: "webnn", deviceType: "gpu", powerPreference: … }`, `wasm` |
+  | `webnn-npu`    | `{ name: "webnn", deviceType: "npu", powerPreference: … }`, `wasm` |
+  | `webnn-cpu`    | `{ name: "webnn", deviceType: "cpu" }`, `wasm`               |
+
+  Every WebNN (and WebGPU) choice ends in `wasm`, so onnxruntime-web
+  transparently falls back to WebAssembly when the WebNN context — or a
+  particular operator — is unsupported. `inference_core.mjs` reports which
+  provider actually won (e.g. `webnn:gpu` or the `wasm` fallback).
+
+- The WebNN provider lives only in the "all" onnxruntime-web bundle, so the
+  panel loads `ort.all.min.mjs` on demand the first time a WebNN EP is selected,
+  and keeps the smaller default bundle for the common WebGPU/WASM path. Both
+  bundles pull the same JSEP wasm artifacts, so the CDN `wasmPaths` are
+  unchanged.
+
+Nothing about the model conversion (Simplify / Optimize) path changes — WebNN is
+only an option for the post-conversion inference check.
+
+## References
+
+- WebNN API — https://www.w3.org/TR/webnn/
+- onnxruntime-web WebNN EP —
+  https://onnxruntime.ai/docs/tutorials/web/ep-webnn.html
+- WebNN operator support in onnxruntime-web —
+  https://github.com/microsoft/onnxruntime/blob/main/js/web/docs/webnn-operators.md

--- a/scripts/convertmodel/.c8rc.json
+++ b/scripts/convertmodel/.c8rc.json
@@ -13,6 +13,7 @@
     "macs.mjs",
     "netron.mjs",
     "trace_build.mjs",
+    "webnn.mjs",
     "xet_cache.mjs"
   ],
   "exclude": [

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -436,6 +436,17 @@
             to WebAssembly when unavailable.
         </p>
         <p>
+            The execution-provider picker also offers
+            <a href="https://www.w3.org/TR/webnn/" target="_blank" rel="noopener">WebNN</a>
+            (GPU / NPU / CPU), which runs the model through the browser's own
+            ML stack. WebNN is <b>experimental</b> and ships behind a flag
+            (Chrome/Edge: <code>chrome://flags/#web-machine-learning-neural-network</code>),
+            with the broadest support on Windows — the <b>WebNN status</b> line
+            below the controls reports whether it is usable in your browser, and
+            any WebNN run falls back to WebAssembly when the chosen device or an
+            operator is unsupported.
+        </p>
+        <p>
             If the model carries onnxsim's MAC/FLOP metrics in its
             <code>metadata_props</code> (onnxsim
             <a href="https://github.com/onnxsim/onnxsim/pull/527" target="_blank" rel="noopener">PR #527</a>,
@@ -455,6 +466,9 @@
             <label for="inference-ep">execution provider</label>
             <select id="inference-ep">
                 <option value="webgpu">WebGPU (fallback to WASM)</option>
+                <option value="webnn-gpu">WebNN · GPU (fallback to WASM)</option>
+                <option value="webnn-npu">WebNN · NPU (fallback to WASM)</option>
+                <option value="webnn-cpu">WebNN · CPU (fallback to WASM)</option>
                 <option value="wasm">WASM</option>
             </select>
             <label for="inference-iters">iterations</label>
@@ -467,6 +481,7 @@
             <button id="run-inference">Run inference</button>
             <button id="download-inference-log-button" type="button">Download log</button>
         </div>
+        <div id="webnn-status" style="color: #666; font-size: 0.85em; margin-top: 0.3em;" title="">WebNN status: probing…</div>
         <textarea id="inference-output" readonly rows="12" style="width: 100%; box-sizing: border-box;"></textarea>
         <div id="inference-macs"></div>
         <p>

--- a/scripts/convertmodel/inference_browser.mjs
+++ b/scripts/convertmodel/inference_browser.mjs
@@ -15,6 +15,7 @@ import { runInference } from "./inference_core.mjs";
 import { summarizeOrtTrace } from "./trace_build.mjs";
 import { renderTrace } from "./trace_viewer.mjs";
 import { downloadText } from "./download.mjs";
+import { providersForEp, isWebnnEp, detectWebnn, formatWebnnStatus } from "./webnn.mjs";
 import {
   readAnnotations,
   perOpSummary,
@@ -29,17 +30,24 @@ import {
 const ORT_VERSION = "1.27.0";
 const ORT_BASE = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ORT_VERSION}/dist/`;
 
-let ortPromise = null;
-function loadOrt() {
-  if (!ortPromise) {
-    ortPromise = import(/* @vite-ignore */ `${ORT_BASE}ort.min.mjs`).then((m) => {
+// onnxruntime-web ships several EP bundles. The default (`ort.min.mjs`) carries
+// WASM + WebGPU; WebNN lives only in the "all" bundle (`ort.all.min.mjs`). Both
+// use the same JSEP wasm artifacts from ORT_BASE, so switching bundles keeps
+// wasmPaths valid. We load the WebNN bundle on demand (only when a WebNN EP is
+// picked) so the common WebGPU/WASM path keeps its smaller download.
+const ORT_BUNDLE = { default: "ort.min.mjs", all: "ort.all.min.mjs" };
+const ortPromises = {};
+function loadOrt(variant = "default") {
+  if (!ortPromises[variant]) {
+    const file = ORT_BUNDLE[variant] || ORT_BUNDLE.default;
+    ortPromises[variant] = import(/* @vite-ignore */ `${ORT_BASE}${file}`).then((m) => {
       const ort = m.default ?? m;
       // Pull the matching wasm binaries from the same CDN directory.
       ort.env.wasm.wasmPaths = ORT_BASE;
       return ort;
     });
   }
-  return ortPromise;
+  return ortPromises[variant];
 }
 
 const TYPED_ARRAY = {
@@ -88,9 +96,8 @@ function makeDummyInputs(ort, session, batch = 1) {
   return feeds;
 }
 
-async function runOnModel(modelBytes, { iterations, batch, preferWebGPU, profile }, log) {
-  const ort = await loadOrt();
-  const providers = preferWebGPU ? ["webgpu", "wasm"] : ["wasm"];
+async function runOnModel(modelBytes, { iterations, batch, providers, needWebnn, profile }, log) {
+  const ort = await loadOrt(needWebnn ? "all" : "default");
 
   // Build inputs from a throwaway wasm session's metadata (cheap and always
   // available), then run the real iterations through the chosen provider.
@@ -286,6 +293,7 @@ export function initInferencePanel() {
   const traceContainer = document.getElementById("inference-trace");
   const macsContainer = document.getElementById("inference-macs");
   const dlLogBtn = document.getElementById("download-inference-log-button");
+  const webnnStatusEl = document.getElementById("webnn-status");
   if (!btn) return;
 
   // The inference output is a readonly textarea (mirroring the simplify console
@@ -294,6 +302,26 @@ export function initInferencePanel() {
     out.value += msg + "\n";
     out.scrollTop = out.scrollHeight;
   };
+
+  // Probe the WebNN API once at load and show a live status next to the EP
+  // picker, so a user can see whether the WebNN options will actually run
+  // before selecting one. detectWebnn never throws.
+  if (webnnStatusEl) {
+    webnnStatusEl.textContent = "WebNN status: probing…";
+    detectWebnn()
+      .then((report) => {
+        webnnStatusEl.textContent = formatWebnnStatus(report);
+        webnnStatusEl.title = report.apiPresent
+          ? `device availability — ${["gpu", "npu", "cpu"]
+              .map((d) => `${d}: ${report.devices[d] ? "yes" : "no"}`)
+              .join(", ")}`
+          : "";
+      })
+      .catch(() => {
+        webnnStatusEl.textContent =
+          "WebNN status: ❌ could not probe navigator.ml.";
+      });
+  }
 
   if (dlLogBtn) {
     dlLogBtn.addEventListener("click", () => {
@@ -311,16 +339,23 @@ export function initInferencePanel() {
       const { bytes, label } = await resolveModelBytes(source, fileInput);
       const iterations = Math.max(1, parseInt(itersInput.value, 10) || 5);
       const batch = Math.max(1, parseInt(batchInput ? batchInput.value : "1", 10) || 1);
-      const preferWebGPU = epSelect.value === "webgpu";
+      const epValue = epSelect.value;
+      const { providers, needWebnn } = providersForEp(epValue);
       const profile = !profileChk || profileChk.checked;
       log(`running ${label}`);
       // Static MACs/FLOPs from the model's onnxsim metadata_props (PR #527),
       // shown before the run so they appear even if inference fails.
       renderMacs(macsContainer, log, bytes, null);
+      if (isWebnnEp(epValue)) {
+        log(
+          "WebNN is experimental; falling back to WASM if the WebNN device " +
+            "or an operator is unsupported.",
+        );
+      }
       log(`loading onnxruntime-web ${ORT_VERSION}…`);
       const res = await runOnModel(
         bytes,
-        { iterations, batch, preferWebGPU, profile },
+        { iterations, batch, providers, needWebnn, profile },
         log,
       );
       log(

--- a/scripts/convertmodel/inference_core.mjs
+++ b/scripts/convertmodel/inference_core.mjs
@@ -14,6 +14,7 @@
 // is returned as a ready-to-render Chrome Trace Event object.
 
 import { buildOrtTrace } from "./trace_build.mjs";
+import { providerLabel } from "./webnn.mjs";
 
 function maxAbsDiff(a, b) {
   let m = 0;
@@ -22,21 +23,24 @@ function maxAbsDiff(a, b) {
 }
 
 // Try each execution provider in order; return the session created on the first
-// one that succeeds, along with the provider name that won. Throws only if every
-// provider fails.
+// one that succeeds, along with the provider name that won. Providers may be
+// bare name strings ("wasm", "webgpu") or onnxruntime-web options objects (e.g.
+// { name: "webnn", deviceType: "gpu" }); the returned/logged `ep` is always the
+// readable label from providerLabel(). Throws only if every provider fails.
 export async function createSessionWithFallback(ort, model, providers, onLog = () => {}) {
   const errors = [];
   for (const ep of providers) {
+    const label = providerLabel(ep);
     try {
       const session = await ort.InferenceSession.create(model, {
         executionProviders: [ep],
         graphOptimizationLevel: "all",
       });
-      return { session, ep };
+      return { session, ep: label };
     } catch (e) {
       const msg = e && e.message ? e.message : String(e);
-      onLog(`execution provider '${ep}' unavailable: ${msg}`);
-      errors.push(`${ep}: ${msg}`);
+      onLog(`execution provider '${label}' unavailable: ${msg}`);
+      errors.push(`${label}: ${msg}`);
     }
   }
   throw new Error(`no usable execution provider (${errors.join(" | ")})`);

--- a/scripts/convertmodel/package.json
+++ b/scripts/convertmodel/package.json
@@ -12,7 +12,8 @@
     "test:hf": "node test/hf_models.test.mjs",
     "test:xet": "node test/xet_cache.test.mjs",
     "test:issue": "node test/issue_report.test.mjs",
-    "test:all": "npm run test:netron && npm run test:trace && npm run test:macs && npm run test:hf && npm run test:xet && npm run test:issue && npm run test:inference",
+    "test:webnn": "node test/webnn.test.mjs",
+    "test:all": "npm run test:netron && npm run test:trace && npm run test:macs && npm run test:hf && npm run test:xet && npm run test:issue && npm run test:webnn && npm run test:inference",
     "coverage": "c8 npm run test:all"
   },
   "dependencies": {

--- a/scripts/convertmodel/test/README.md
+++ b/scripts/convertmodel/test/README.md
@@ -73,6 +73,22 @@ its error-bearing tail) so the URL stays under the cap. No DOM or network:
 npm run test:issue
 ```
 
+## WebNN helpers
+
+`npm run test:webnn` unit-tests `webnn.mjs`, the browser-free helpers behind the
+inference panel's [WebNN](https://www.w3.org/TR/webnn/) execution-provider
+options (see [`docs/webnn.md`](../../../docs/webnn.md)). It covers building the
+onnxruntime-web WebNN provider objects (`gpu`/`npu`/`cpu`, with a
+`powerPreference` only on the accelerator devices), the readable provider labels,
+the dropdown-value → provider-list mapping (each ending in a `wasm` fallback),
+and `detectWebnn()` — the `navigator.ml` probe — driven with an injected
+navigator so the absent-API, some-devices-usable, and no-device-usable cases are
+all exercised without a real browser. No DOM or network:
+
+```bash
+npm run test:webnn
+```
+
 ## Profiling traces
 
 Both the browser panels can emit a [Chrome Trace Event][cte] JSON that the page
@@ -96,6 +112,12 @@ onnxruntime-web exposes the `wasm` execution provider everywhere and the
 `webgpu` provider where the host has a WebGPU runtime (a browser, or Node built
 with one). A plain CI/Node container has no GPU, so CI runs the `wasm` provider;
 the browser page defaults to `webgpu` and falls back to `wasm`.
+
+The panel also offers the experimental `webnn` provider (GPU / NPU / CPU device
+types), which needs a browser with the WebNN API enabled — see
+[`docs/webnn.md`](../../../docs/webnn.md). Its pure helpers are covered by
+`test:webnn`; the live `navigator.ml` path only exists in a browser, so CI does
+not exercise it end to end.
 
 ## Regenerate the fixture
 

--- a/scripts/convertmodel/test/webnn.test.mjs
+++ b/scripts/convertmodel/test/webnn.test.mjs
@@ -1,0 +1,142 @@
+// Unit test for the pure WebNN helpers behind the converter page's inference
+// panel EP picker (webnn.mjs). No DOM, no onnxruntime-web, no real navigator —
+// detectWebnn() takes an injected navigator so the probe is testable.
+//
+// Usage:
+//   node test/webnn.test.mjs
+
+import assert from "node:assert/strict";
+import {
+  WEBNN_DEVICE_TYPES,
+  webnnProvider,
+  providerLabel,
+  providersForEp,
+  isWebnnEp,
+  detectWebnn,
+  formatWebnnStatus,
+} from "../webnn.mjs";
+
+let passed = 0;
+// Runs fn (sync or async) and logs a tick. Callers `await` it so the async
+// probes finish in order before the final count.
+async function check(name, fn) {
+  await fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+
+// webnnProvider builds the ORT options object with a powerPreference only for
+// the accelerator devices.
+await check("webnnProvider shapes the ORT execution-provider entry", () => {
+  assert.deepEqual(webnnProvider("gpu"), {
+    name: "webnn",
+    deviceType: "gpu",
+    powerPreference: "default",
+  });
+  assert.deepEqual(webnnProvider("npu"), {
+    name: "webnn",
+    deviceType: "npu",
+    powerPreference: "default",
+  });
+  assert.deepEqual(webnnProvider("cpu"), { name: "webnn", deviceType: "cpu" });
+  assert.throws(() => webnnProvider("tpu"), /unknown WebNN device type/);
+});
+
+// providerLabel keeps existing string EPs intact and gives WebNN objects a
+// readable name (so inference-core's log/returned ep stays a string).
+await check("providerLabel renders strings and WebNN objects", () => {
+  assert.equal(providerLabel("wasm"), "wasm");
+  assert.equal(providerLabel("webgpu"), "webgpu");
+  assert.equal(providerLabel(webnnProvider("gpu")), "webnn:gpu");
+  assert.equal(providerLabel({ name: "webnn" }), "webnn");
+  assert.equal(providerLabel({ name: "cuda" }), "cuda");
+});
+
+// Every WebNN/WebGPU choice ends in a wasm fallback; needWebnn flags the choices
+// that require the WebNN-capable bundle.
+await check("providersForEp maps dropdown values to provider lists", () => {
+  assert.deepEqual(providersForEp("wasm"), {
+    providers: ["wasm"],
+    needWebnn: false,
+  });
+  assert.deepEqual(providersForEp("webgpu"), {
+    providers: ["webgpu", "wasm"],
+    needWebnn: false,
+  });
+
+  const gpu = providersForEp("webnn-gpu");
+  assert.equal(gpu.needWebnn, true);
+  assert.deepEqual(gpu.providers, [webnnProvider("gpu"), "wasm"]);
+
+  const npu = providersForEp("webnn-npu");
+  assert.equal(npu.needWebnn, true);
+  assert.deepEqual(npu.providers, [webnnProvider("npu"), "wasm"]);
+
+  const cpu = providersForEp("webnn-cpu");
+  assert.equal(cpu.needWebnn, true);
+  assert.deepEqual(cpu.providers, [webnnProvider("cpu"), "wasm"]);
+
+  // Unknown values degrade to plain wasm.
+  assert.deepEqual(providersForEp("nonsense"), {
+    providers: ["wasm"],
+    needWebnn: false,
+  });
+});
+
+await check("isWebnnEp recognizes only the WebNN dropdown values", () => {
+  assert.equal(isWebnnEp("webnn-gpu"), true);
+  assert.equal(isWebnnEp("webnn-cpu"), true);
+  assert.equal(isWebnnEp("webgpu"), false);
+  assert.equal(isWebnnEp("wasm"), false);
+  assert.equal(isWebnnEp(undefined), false);
+});
+
+// detectWebnn with no navigator.ml reports the API as absent (never throws).
+await check("detectWebnn reports absent API", async () => {
+  const report = await detectWebnn({});
+  assert.equal(report.apiPresent, false);
+  assert.equal(report.supported, false);
+  assert.match(report.message, /not available/);
+  assert.equal(formatWebnnStatus(report).startsWith("WebNN status: ❌"), true);
+});
+
+// A navigator whose ml.createContext succeeds only for some device types: those
+// become supported, the rest false, and supported reflects "at least one".
+await check("detectWebnn probes each device type", async () => {
+  const calls = [];
+  const nav = {
+    ml: {
+      async createContext({ deviceType }) {
+        calls.push(deviceType);
+        if (deviceType === "gpu") return { destroy() {} };
+        throw new Error(`no ${deviceType}`);
+      },
+    },
+  };
+  const report = await detectWebnn(nav);
+  assert.deepEqual(calls, WEBNN_DEVICE_TYPES); // probed gpu, npu, cpu
+  assert.equal(report.apiPresent, true);
+  assert.equal(report.supported, true);
+  assert.deepEqual(report.devices, { gpu: true, npu: false, cpu: false });
+  assert.match(report.message, /gpu/);
+  assert.equal(formatWebnnStatus(report).startsWith("WebNN status: ✅"), true);
+});
+
+// navigator.ml present but no device usable → apiPresent true, supported false,
+// warning glyph.
+await check("detectWebnn handles API present but no usable device", async () => {
+  const nav = {
+    ml: {
+      async createContext() {
+        throw new Error("unsupported");
+      },
+    },
+  };
+  const report = await detectWebnn(nav);
+  assert.equal(report.apiPresent, true);
+  assert.equal(report.supported, false);
+  assert.deepEqual(report.devices, { gpu: false, npu: false, cpu: false });
+  assert.equal(formatWebnnStatus(report).startsWith("WebNN status: ⚠️"), true);
+});
+
+console.log(`\nwebnn: ${passed} checks passed`);

--- a/scripts/convertmodel/webnn.mjs
+++ b/scripts/convertmodel/webnn.mjs
@@ -1,0 +1,136 @@
+// WebNN helpers for the converter page's "Run inference" panel.
+//
+// WebNN (the W3C Web Neural Network API, https://www.w3.org/TR/webnn/) lets a
+// page run a neural network on the platform's own ML stack — DirectML on
+// Windows, Core ML on macOS, and NN APIs elsewhere — reaching the GPU and,
+// where present, a dedicated NPU. onnxruntime-web exposes it as an execution
+// provider (EP), so the inference panel can offer it alongside WebGPU and WASM.
+//
+// As of onnxruntime-web 1.27 / early 2026 the WebNN backend is still an
+// *experimental* feature and the browser API ships behind a flag (Chrome/Edge:
+// chrome://flags/#web-machine-learning-neural-network), with the best coverage
+// on Windows. So we never assume it is there: the panel probes navigator.ml at
+// load time to show a live status, always lists WASM as a fallback provider,
+// and lets onnxruntime-web transparently fall back when a WebNN context or a
+// given device type cannot be created.
+//
+// This module holds the pure, browser-free pieces (provider construction,
+// labelling, and the navigator.ml probe accepting an injected navigator) so
+// they can be unit-tested under Node; the DOM wiring lives in
+// inference_browser.mjs.
+
+// Device types WebNN's MLContext accepts, most-capable first. "gpu" and "npu"
+// also take a powerPreference; "cpu" does not.
+export const WEBNN_DEVICE_TYPES = ["gpu", "npu", "cpu"];
+
+// Build the onnxruntime-web execution-provider entry for a WebNN device. ORT
+// accepts EPs either as a bare name string or as an options object; WebNN needs
+// the object form to carry deviceType (and, for accelerator devices, a
+// powerPreference).
+export function webnnProvider(deviceType) {
+  if (!WEBNN_DEVICE_TYPES.includes(deviceType)) {
+    throw new Error(`unknown WebNN device type '${deviceType}'`);
+  }
+  const ep = { name: "webnn", deviceType };
+  // powerPreference is meaningful for the accelerator devices; CPU ignores it.
+  if (deviceType === "gpu" || deviceType === "npu") {
+    ep.powerPreference = "default";
+  }
+  return ep;
+}
+
+// A short human-readable name for a provider entry (string or options object),
+// used in the panel log and inference-core's returned `ep` field. Strings pass
+// through unchanged so the existing "wasm"/"webgpu" labels are preserved; a
+// WebNN object becomes e.g. "webnn:gpu".
+export function providerLabel(ep) {
+  if (typeof ep === "string") return ep;
+  if (ep && ep.name === "webnn") {
+    return ep.deviceType ? `webnn:${ep.deviceType}` : "webnn";
+  }
+  if (ep && ep.name) return ep.name;
+  return String(ep);
+}
+
+// Map an inference-panel EP dropdown value to the ordered provider list to try
+// and whether the WebNN-capable onnxruntime-web bundle is required. Every WebNN
+// (and WebGPU) choice ends in "wasm" so a session still gets created when the
+// accelerated provider is unavailable.
+export function providersForEp(epValue) {
+  switch (epValue) {
+    case "webgpu":
+      return { providers: ["webgpu", "wasm"], needWebnn: false };
+    case "webnn-gpu":
+      return { providers: [webnnProvider("gpu"), "wasm"], needWebnn: true };
+    case "webnn-npu":
+      return { providers: [webnnProvider("npu"), "wasm"], needWebnn: true };
+    case "webnn-cpu":
+      return { providers: [webnnProvider("cpu"), "wasm"], needWebnn: true };
+    case "wasm":
+    default:
+      return { providers: ["wasm"], needWebnn: false };
+  }
+}
+
+// True when the EP dropdown value names a WebNN provider.
+export function isWebnnEp(epValue) {
+  return typeof epValue === "string" && epValue.startsWith("webnn-");
+}
+
+// Probe the WebNN API on an injected navigator (defaults to the page's).
+// Returns { apiPresent, supported, devices: {gpu,npu,cpu}, message }: apiPresent
+// reflects navigator.ml being exposed at all; `devices[type]` is true when an
+// MLContext for that device type could actually be created; `supported` is true
+// when at least one device type worked. Never throws — any failure is reported
+// as unsupported so a caller can render it directly.
+export async function detectWebnn(
+  nav = typeof navigator !== "undefined" ? navigator : undefined,
+) {
+  const ml = nav && nav.ml;
+  if (!ml || typeof ml.createContext !== "function") {
+    return {
+      apiPresent: false,
+      supported: false,
+      devices: {},
+      message:
+        "WebNN API (navigator.ml) is not available in this browser. Try a " +
+        "recent Chrome/Edge with the WebNN flag enabled " +
+        "(chrome://flags/#web-machine-learning-neural-network).",
+    };
+  }
+
+  const devices = {};
+  for (const deviceType of WEBNN_DEVICE_TYPES) {
+    try {
+      const ctx = await ml.createContext({ deviceType });
+      devices[deviceType] = !!ctx;
+      // Best-effort release; not all implementations expose destroy().
+      if (ctx && typeof ctx.destroy === "function") {
+        try {
+          ctx.destroy();
+        } catch {
+          /* ignore */
+        }
+      }
+    } catch {
+      devices[deviceType] = false;
+    }
+  }
+
+  const usable = WEBNN_DEVICE_TYPES.filter((d) => devices[d]);
+  return {
+    apiPresent: true,
+    supported: usable.length > 0,
+    devices,
+    message: usable.length
+      ? `WebNN available — device types: ${usable.join(", ")}.`
+      : "navigator.ml exists, but no WebNN device (gpu/npu/cpu) could be " +
+        "created here. The API may be present without a working backend.",
+  };
+}
+
+// Format a detectWebnn() report as a one-line status string for the panel.
+export function formatWebnnStatus(report) {
+  const prefix = report.supported ? "✅" : report.apiPresent ? "⚠️" : "❌";
+  return `WebNN status: ${prefix} ${report.message}`;
+}


### PR DESCRIPTION
Adds experimental WebNN (Web Neural Network API) support to the converter page's "Run inference" panel, allowing models to run on the browser's native ML stack (GPU, NPU, CPU) via onnxruntime-web's WebNN execution provider.

## Changes

- **New module `webnn.mjs`**: Pure, browser-free helpers for WebNN provider management:
  - `webnnProvider(deviceType)`: Builds onnxruntime-web execution-provider objects for GPU/NPU/CPU with appropriate `powerPreference` settings
  - `providersForEp(epValue)`: Maps dropdown selections to ordered provider lists (each ending in WASM fallback)
  - `detectWebnn(navigator)`: Probes `navigator.ml` to detect available device types; accepts injected navigator for testability
  - `formatWebnnStatus(report)`: Formats probe results as user-facing status text with emoji indicators

- **New test suite `test/webnn.test.mjs`**: Comprehensive unit tests covering provider construction, labeling, dropdown mapping, and all three WebNN detection scenarios (API absent, some devices available, no devices available)

- **Updated `inference_browser.mjs`**:
  - Loads onnxruntime-web "all" bundle (`ort.all.min.mjs`) on demand when WebNN is selected, keeping the smaller default bundle for WebGPU/WASM paths
  - Probes WebNN API at panel load and displays live status next to EP picker
  - Passes provider list and bundle variant to inference runner
  - Adds warning message when WebNN is selected, noting experimental status and WASM fallback behavior

- **Updated `inference_core.mjs`**: Uses `providerLabel()` to convert provider objects to readable strings for logging and return values

- **Updated `index.html`**: 
  - Adds three new EP dropdown options: WebNN · GPU/NPU/CPU
  - Adds explanatory text about WebNN's experimental status, flag requirement, and platform support
  - Adds `webnn-status` element to display live API availability

- **Documentation `docs/webnn.md`**: Comprehensive guide covering WebNN status (W3C spec, browser support, onnxruntime-web experimental backend), how the panel uses it, and references

- **Test infrastructure**: Adds `npm run test:webnn` script and CI workflow step; includes `webnn.mjs` in code coverage

## Implementation notes

- WebNN is treated as an acceleration opportunity with required WASM fallback, not a baseline feature
- The probe never throws; failures are reported as unsupported so the UI can render them directly
- Device type probing attempts GPU/NPU/CPU in order and reports which succeeded
- Both ORT bundles use the same JSEP wasm artifacts, so `wasmPaths` configuration remains unchanged
- The WebNN provider is only available in onnxruntime-web's "all" bundle, not the default `ort.min.mjs`

https://claude.ai/code/session_01UUh3CpoUA8TNmW5R63Fgr2