### PR TITLE
Add before/after model comparison to inference panel

### DIFF
--- a/.github/workflows/convertmodel-inference.yml
+++ b/.github/workflows/convertmodel-inference.yml
@@ -44,3 +44,6 @@ jobs:
       - name: Run inference smoke test (wasm EP)
         working-directory: scripts/convertmodel
         run: npm run test:inference
+      - name: Run before/after comparison test (wasm EP)
+        working-directory: scripts/convertmodel
+        run: npm run test:compare

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -17,6 +17,12 @@
             .macs-table th, .macs-table td { border-bottom: 1px solid #eee; padding: 3px 10px; text-align: right; }
             .macs-table th:first-child, .macs-table td:first-child { text-align: left; }
             .macs-note { color: #666; font-size: 0.85em; margin-top: 0.4em; }
+            /* before/after comparison summary (Run inference "compare" mode) */
+            .cmp-table th { text-align: left; color: #666; font-weight: 600; white-space: nowrap; }
+            .cmp-table td { text-align: left; }
+            .cmp-ok { color: #0a7d24; font-weight: 600; }
+            .cmp-bad { color: #a00; font-weight: 600; }
+            .cmp-warn { color: #a06000; font-weight: 600; }
         </style>
         <script type="text/javascript" src="./onnxsim.js"></script>
         <script type="text/javascript">
@@ -428,12 +434,17 @@
         <h2>Run inference (onnxruntime-web)</h2>
         <p>
             Runs a model for a few iterations to check it executes, using dummy
-            inputs generated from the model's input shapes. Pick whether to run
-            the <b>converted</b> result (the simplify/optimize output) or the
-            <b>original</b> upload, so you can compare the two. The <b>batch</b>
-            control sizes the model's dynamic batch (first) axis; it has no
-            effect on inputs whose first dimension is fixed. WebGPU falls back
-            to WebAssembly when unavailable.
+            inputs generated from the model's input shapes. The <b>model</b>
+            picker chooses what to run: <b>compare (before vs after
+            conversion)</b> — the default — runs <i>both</i> the original upload
+            and the converted result on the <b>same</b> deterministic input and
+            reports how far their outputs diverge (max |Δ|) plus the speed
+            difference, so you can confirm the simplify/optimize step preserved
+            the model's numerics and see how much faster it got. You can also run
+            just the <b>converted</b> result or the <b>original</b> upload on
+            their own. The <b>batch</b> control sizes the model's dynamic batch
+            (first) axis; it has no effect on inputs whose first dimension is
+            fixed. WebGPU falls back to WebAssembly when unavailable.
         </p>
         <p>
             The execution-provider picker also offers
@@ -460,6 +471,7 @@
         <div>
             <label for="inference-source">model</label>
             <select id="inference-source">
+                <option value="compare">compare (before vs after conversion)</option>
                 <option value="converted">converted (simplify/optimize output)</option>
                 <option value="original">original (uploaded)</option>
             </select>

--- a/scripts/convertmodel/inference_browser.mjs
+++ b/scripts/convertmodel/inference_browser.mjs
@@ -11,7 +11,7 @@
 // on `window.__onnxsimConverted` (set in index.html when a conversion
 // finishes); "original" reads the file input directly.
 
-import { runInference } from "./inference_core.mjs";
+import { runInference, compareInference } from "./inference_core.mjs";
 import { summarizeOrtTrace } from "./trace_build.mjs";
 import { renderTrace } from "./trace_viewer.mjs";
 import { downloadText } from "./download.mjs";
@@ -81,7 +81,31 @@ function concreteShape(shape, batch = 1) {
   });
 }
 
-function makeDummyInputs(ort, session, batch = 1) {
+// Fill a float typed-array in place with small deterministic pseudo-random
+// values in [-1, 1) (a seeded xorshift32, so every call produces the same
+// sequence). Used by the before/after comparison: all-zero inputs can mask a
+// divergence introduced by a graph change (many ops map 0 -> 0), whereas varied
+// inputs actually exercise the graph. Integer/bool inputs are left at zero,
+// which is the safe default for index-like tensors (Gather, etc.) where an
+// arbitrary value could go out of bounds. Determinism matters because
+// runInference() re-feeds the same tensor every iteration and asserts the output
+// never changes.
+function fillPseudoRandom(arr, type) {
+  if (type !== "float32" && type !== "float64") return; // zeros for ints/bool
+  let s = 0x2545f491; // fixed non-zero seed
+  for (let i = 0; i < arr.length; i++) {
+    // xorshift32 (bitwise ops keep `s` a 32-bit signed int throughout).
+    s ^= s << 13;
+    s ^= s >>> 17;
+    s ^= s << 5;
+    arr[i] = s / 0x80000000; // 32-bit signed / 2^31 -> [-1, 1)
+  }
+}
+
+// Build a feeds object for every model input. `fill` is "zero" (the default,
+// matching a plain single-model run) or "random" (deterministic non-zero float
+// values, used by the compare path so the before/after diff is meaningful).
+function makeDummyInputs(ort, session, batch = 1, fill = "zero") {
   const feeds = {};
   for (const meta of session.inputMetadata) {
     if (!meta.isTensor) {
@@ -91,24 +115,26 @@ function makeDummyInputs(ort, session, batch = 1) {
     const count = dims.reduce((a, b) => a * b, 1);
     const Ctor = TYPED_ARRAY[meta.type];
     if (!Ctor) throw new Error(`unsupported input type '${meta.type}'`);
-    feeds[meta.name] = new ort.Tensor(meta.type, new Ctor(count), dims);
+    const buf = new Ctor(count);
+    if (fill === "random") fillPseudoRandom(buf, meta.type);
+    feeds[meta.name] = new ort.Tensor(meta.type, buf, dims);
   }
   return feeds;
 }
 
-async function runOnModel(modelBytes, { iterations, batch, providers, needWebnn, profile }, log) {
-  const ort = await loadOrt(needWebnn ? "all" : "default");
-
-  // Build inputs from a throwaway wasm session's metadata (cheap and always
-  // available), then run the real iterations through the chosen provider.
+// Build the dummy inputs for a model from a throwaway wasm session's metadata
+// (cheap and always available) and report the leading (batch) input. Shared by
+// the single-model and compare paths so the compare path can build ONE set of
+// inputs and feed the SAME tensor to both models. Returns
+// { feeds, inputName, leadMeta, leadingDynamic }.
+async function prepareInputs(ort, modelBytes, batch, fill, log) {
   const metaSession = await ort.InferenceSession.create(modelBytes, {
     executionProviders: ["wasm"],
   });
-  const feeds = makeDummyInputs(ort, metaSession, batch);
+  const feeds = makeDummyInputs(ort, metaSession, batch, fill);
   const inputName = metaSession.inputNames[0];
   const leadMeta = metaSession.inputMetadata.find((mm) => mm.name === inputName);
   const leadingDynamic = isDynamicDim(leadMeta?.shape?.[0]);
-  log(`input '${inputName}' dims [${feeds[inputName].dims.join(", ")}]`);
   // Explain a dropped batch request: onnxruntime enforces a model's declared
   // static shapes, so a fixed leading dimension can't be resized here.
   if (batch > 1 && !leadingDynamic) {
@@ -118,6 +144,20 @@ async function runOnModel(modelBytes, { iterations, batch, providers, needWebnn,
         `dynamic batch axis to change it.`,
     );
   }
+  return { feeds, inputName, leadMeta, leadingDynamic };
+}
+
+async function runOnModel(modelBytes, { iterations, batch, providers, needWebnn, profile }, log) {
+  const ort = await loadOrt(needWebnn ? "all" : "default");
+
+  const { feeds, inputName, leadingDynamic } = await prepareInputs(
+    ort,
+    modelBytes,
+    batch,
+    "zero",
+    log,
+  );
+  log(`input '${inputName}' dims [${feeds[inputName].dims.join(", ")}]`);
 
   const res = await runInference(ort, {
     model: modelBytes,
@@ -133,6 +173,45 @@ async function runOnModel(modelBytes, { iterations, batch, providers, needWebnn,
   // leaves the metrics untouched (batch is a no-op there).
   res.batchScale = leadingDynamic ? batch : 1;
   return res;
+}
+
+// Run the "compare (before vs after)" path: feed ONE shared, deterministic
+// input to both the original and converted models and report how far their
+// outputs diverge plus the speed difference. Building the input from the
+// original model (whose I/O the conversion preserves) and reusing the exact same
+// tensor for both isolates the effect of the graph change.
+async function runCompare(
+  originalBytes,
+  convertedBytes,
+  { iterations, batch, providers, needWebnn, profile },
+  log,
+) {
+  const ort = await loadOrt(needWebnn ? "all" : "default");
+
+  const { feeds, inputName, leadingDynamic } = await prepareInputs(
+    ort,
+    originalBytes,
+    batch,
+    "random",
+    log,
+  );
+  const input = feeds[inputName];
+  log(`shared input '${inputName}' dims [${input.dims.join(", ")}] (deterministic)`);
+
+  const cmp = await compareInference(ort, {
+    before: { model: originalBytes, label: "original" },
+    after: { model: convertedBytes, label: "converted" },
+    inputName,
+    input,
+    providers,
+    iterations,
+    profile,
+    onLog: log,
+  });
+  const batchScale = leadingDynamic ? batch : 1;
+  cmp.before.batchScale = batchScale;
+  cmp.after.batchScale = batchScale;
+  return cmp;
 }
 
 // Resolve the model bytes for the chosen source. "converted" uses the bytes the
@@ -281,6 +360,93 @@ function renderMacs(container, log, bytes, res) {
   }
 }
 
+// Read a model's annotated per-sample MACs (onnxsim PR #527 metadata_props),
+// or null when the model carries none / can't be parsed.
+function modelMacs(bytes) {
+  try {
+    const ann = readAnnotations(bytes);
+    return ann.annotated ? evalMetric(ann.model.macs) : null;
+  } catch {
+    return null;
+  }
+}
+
+// Render the before/after comparison summary into `container`: a verdict on
+// whether the conversion preserved the numerics (max |Δ| vs tolerance), the
+// per-iteration latency of each model with the resulting speedup, and — when
+// both models are MAC-annotated — the MAC reduction. `cmp` is the object from
+// runCompare()/compareInference(). Also logs a compact text summary.
+function renderCompare(container, log, originalBytes, convertedBytes, cmp, tolerance) {
+  const { before, after, maxAbsDiff, dimsMatch, comparable, equivalent, speedup } = cmp;
+
+  const diffStr = comparable ? maxAbsDiff.toExponential(3) : "n/a";
+  let verdictText;
+  let verdictClass;
+  if (!comparable) {
+    verdictText = "outputs not comparable (shape/length differ)";
+    verdictClass = "cmp-warn";
+  } else if (equivalent) {
+    verdictText = `equivalent — max |Δ| = ${diffStr} ≤ ${tolerance}`;
+    verdictClass = "cmp-ok";
+  } else {
+    verdictText = `differs — max |Δ| = ${diffStr} > ${tolerance}`;
+    verdictClass = "cmp-bad";
+  }
+
+  const speedStr =
+    speedup != null
+      ? `${speedup.toFixed(2)}× ${speedup >= 1 ? "faster" : "slower"}`
+      : "—";
+  const dimsStr = `[${(before.dims || []).join(", ")}]${
+    dimsMatch ? "" : ` vs [${(after.dims || []).join(", ")}]`
+  }`;
+
+  const macsBefore = modelMacs(originalBytes);
+  const macsAfter = modelMacs(convertedBytes);
+  const macsCell =
+    macsBefore != null && macsAfter != null
+      ? `${humanNum(macsBefore)} → ${humanNum(macsAfter)}` +
+        (macsBefore > 0
+          ? ` (${(((macsBefore - macsAfter) / macsBefore) * 100).toFixed(1)}% fewer)`
+          : "")
+      : "annotate model info to compare";
+
+  const rows = [
+    ["Outputs", verdictText, verdictClass],
+    ["Output dims", `${dimsStr}${dimsMatch ? " (match)" : " (differ)"}`, ""],
+    [
+      "Latency",
+      `before ${before.avgMs.toFixed(2)} ms, after ${after.avgMs.toFixed(2)} ms → ${speedStr}`,
+      "",
+    ],
+    ["MACs", macsCell, ""],
+  ];
+  container.innerHTML =
+    `<table class="macs-table cmp-table"><tbody>` +
+    rows
+      .map(
+        ([k, v, cls]) =>
+          `<tr><th>${k}</th><td class="${cls}">${v}</td></tr>`,
+      )
+      .join("") +
+    `</tbody></table>` +
+    `<p class="macs-note">Both models run on the <b>same</b> deterministic input ` +
+    `(dynamic axes sized from the batch control); a small max |Δ| means the ` +
+    `conversion preserved the model's numerics. Speedup = before ÷ after average ` +
+    `<code>session.run</code> latency on '${after.ep}'.</p>`;
+
+  log("── comparison (before vs after conversion) ──");
+  log(`outputs: ${verdictText}`);
+  log(`output dims: ${dimsStr}${dimsMatch ? " (match)" : " (differ)"}`);
+  log(
+    `speed: before ${before.avgMs.toFixed(2)} ms/iter, after ` +
+      `${after.avgMs.toFixed(2)} ms/iter → ${speedStr}`,
+  );
+  if (macsBefore != null && macsAfter != null) {
+    log(`MACs: ${macsCell}`);
+  }
+}
+
 export function initInferencePanel() {
   const btn = document.getElementById("run-inference");
   const out = document.getElementById("inference-output");
@@ -336,22 +502,56 @@ export function initInferencePanel() {
     if (macsContainer) macsContainer.innerHTML = "";
     try {
       const source = sourceSelect ? sourceSelect.value : "original";
-      const { bytes, label } = await resolveModelBytes(source, fileInput);
       const iterations = Math.max(1, parseInt(itersInput.value, 10) || 5);
       const batch = Math.max(1, parseInt(batchInput ? batchInput.value : "1", 10) || 1);
       const epValue = epSelect.value;
       const { providers, needWebnn } = providersForEp(epValue);
       const profile = !profileChk || profileChk.checked;
-      log(`running ${label}`);
-      // Static MACs/FLOPs from the model's onnxsim metadata_props (PR #527),
-      // shown before the run so they appear even if inference fails.
-      renderMacs(macsContainer, log, bytes, null);
+
       if (isWebnnEp(epValue)) {
         log(
           "WebNN is experimental; falling back to WASM if the WebNN device " +
             "or an operator is unsupported.",
         );
       }
+
+      // "compare (before vs after)" runs both the original and converted models
+      // on one shared input and reports how far their outputs diverge plus the
+      // speed difference — the verification the rest of the panel can't give
+      // from a single model.
+      if (source === "compare") {
+        const original = await resolveModelBytes("original", fileInput);
+        const converted = await resolveModelBytes("converted", fileInput);
+        const tolerance = 1e-3;
+        log(`comparing ${original.label} vs ${converted.label}`);
+        log(`loading onnxruntime-web ${ORT_VERSION}…`);
+        const cmp = await runCompare(
+          original.bytes,
+          converted.bytes,
+          { iterations, batch, providers, needWebnn, profile },
+          log,
+        );
+        log(
+          `PASS: ran both models ${cmp.after.iterations} iterations on ` +
+            `'${cmp.after.ep}'`,
+        );
+        if (macsContainer) {
+          renderCompare(macsContainer, log, original.bytes, converted.bytes, cmp, tolerance);
+        }
+        if (profile && cmp.after.trace && traceContainer) {
+          renderTrace(traceContainer, cmp.after.trace, {
+            title: `onnxruntime-web ${cmp.after.ep} inference (converted)`,
+            filename: `onnxruntime-web.${cmp.after.ep}.converted.trace.json`,
+          });
+        }
+        return;
+      }
+
+      const { bytes, label } = await resolveModelBytes(source, fileInput);
+      log(`running ${label}`);
+      // Static MACs/FLOPs from the model's onnxsim metadata_props (PR #527),
+      // shown before the run so they appear even if inference fails.
+      renderMacs(macsContainer, log, bytes, null);
       log(`loading onnxruntime-web ${ORT_VERSION}…`);
       const res = await runOnModel(
         bytes,

--- a/scripts/convertmodel/inference_core.mjs
+++ b/scripts/convertmodel/inference_core.mjs
@@ -152,3 +152,87 @@ export async function runInference(ort, {
   }
   return result;
 }
+
+// Compare two runInference() results computed from the SAME input: how far the
+// outputs diverge and how their speed relates. Pure (no ort), so the Node test
+// drives the exact numeric logic the page shows. Returns
+// { maxAbsDiff, dimsMatch, comparable, equivalent, speedup }:
+//   - maxAbsDiff: largest |a - b| over the flat outputs, or null when the two
+//     outputs can't be compared elementwise (missing or different length).
+//   - dimsMatch:  the reported output dims are identical.
+//   - comparable: both outputs were present and the same length.
+//   - equivalent: comparable, dims match, and maxAbsDiff <= tolerance — i.e. the
+//     graph change preserved the numerics.
+//   - speedup:    a.avgMs / b.avgMs (>1 means b — the "after" model — is
+//     faster), or null if a latency is non-positive.
+export function compareOutputs(a, b, tolerance = 1e-3) {
+  const dimsMatch = !!(
+    a &&
+    b &&
+    Array.isArray(a.dims) &&
+    Array.isArray(b.dims) &&
+    a.dims.length === b.dims.length &&
+    a.dims.every((d, i) => d === b.dims[i])
+  );
+  const comparable = !!(
+    a &&
+    b &&
+    a.output &&
+    b.output &&
+    a.output.length === b.output.length
+  );
+  const maxDiff = comparable ? maxAbsDiff(a.output, b.output) : null;
+  const equivalent =
+    comparable && dimsMatch && maxDiff != null && maxDiff <= tolerance;
+  const speedup =
+    a && b && a.avgMs > 0 && b.avgMs > 0 ? a.avgMs / b.avgMs : null;
+  return { maxAbsDiff: maxDiff, dimsMatch, comparable, equivalent, speedup };
+}
+
+// Run two models on the SAME input tensor and compare their outputs — the
+// before/after check for a graph conversion (simplify/optimize). Feeding
+// identical inputs isolates the effect of the graph change: a small maxAbsDiff
+// means the conversion preserved the model's numerics, while the two avgMs let
+// the caller report the speed difference.
+//
+// `before`/`after` are { model, label? }. Returns
+// { before, after, ...compareOutputs(before, after) } where before/after are the
+// full runInference results (so the caller can still read timings, trace, etc.).
+export async function compareInference(ort, {
+  before,
+  after,
+  inputName,
+  input,
+  outputName,
+  providers,
+  iterations = 5,
+  tolerance = 1e-3,
+  profile = false,
+  onLog = () => {},
+}) {
+  const beforeLabel = before.label || "before";
+  const afterLabel = after.label || "after";
+  onLog(`running ${beforeLabel} (before conversion)…`);
+  const a = await runInference(ort, {
+    model: before.model,
+    inputName,
+    input,
+    outputName,
+    providers,
+    iterations,
+    profile,
+    onLog,
+  });
+  onLog(`running ${afterLabel} (after conversion)…`);
+  const b = await runInference(ort, {
+    model: after.model,
+    inputName,
+    input,
+    outputName,
+    providers,
+    iterations,
+    profile,
+    onLog,
+  });
+  return { before: a, after: b, ...compareOutputs(a, b, tolerance) };
+}

--- a/scripts/convertmodel/package.json
+++ b/scripts/convertmodel/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "test:inference": "node test/inference.test.mjs",
+    "test:compare": "node test/compare.test.mjs",
     "test:netron": "node test/netron.test.mjs",
     "test:trace": "node test/trace.test.mjs",
     "test:macs": "node test/macs.test.mjs",
@@ -13,7 +14,7 @@
     "test:xet": "node test/xet_cache.test.mjs",
     "test:issue": "node test/issue_report.test.mjs",
     "test:webnn": "node test/webnn.test.mjs",
-    "test:all": "npm run test:netron && npm run test:trace && npm run test:macs && npm run test:hf && npm run test:xet && npm run test:issue && npm run test:webnn && npm run test:inference",
+    "test:all": "npm run test:netron && npm run test:trace && npm run test:macs && npm run test:hf && npm run test:xet && npm run test:issue && npm run test:webnn && npm run test:inference && npm run test:compare",
     "coverage": "c8 npm run test:all"
   },
   "dependencies": {

--- a/scripts/convertmodel/test/README.md
+++ b/scripts/convertmodel/test/README.md
@@ -17,6 +17,7 @@ npm run test:inference          # wasm EP, 5 iterations, batch 1
 ORT_ITERS=20 npm run test:inference
 ORT_BATCH=64 npm run test:inference    # feed 64 input rows
 ORT_EP=webgpu npm run test:inference   # only where a WebGPU runtime exists
+npm run test:compare            # before/after comparison path (wasm EP)
 npm run test:netron             # Netron embedding helpers unit test (no GPU/ORT needed)
 npm run test:trace              # trace-assembler unit test (no GPU/ORT needed)
 ```
@@ -57,6 +58,27 @@ into *both* outputs of a conversion: the converted result and — via the WASM
 throughput for either **model** source, so the original and converted models can
 be compared on inference speed. Annotation only adds `metadata_props`, so the
 annotated bytes execute identically to the upload.
+
+## Before/after comparison
+
+`npm run test:compare` drives `compareInference()` / `compareOutputs()` in
+`inference_core.mjs`, the code behind the inference panel's **compare (before vs
+after conversion)** mode. That mode feeds one shared, deterministic input to
+*both* the original upload and the simplify/optimize result and reports how far
+their outputs diverge (max |Δ|) plus the speed difference, so a conversion that
+was meant to be numerics-preserving can be verified as such right in the browser.
+
+The test runs the fixture model against itself (a conversion is free to be a
+no-op) and asserts the outputs are byte-for-byte identical (max |Δ| == 0), the
+dims match, and the verdict is *equivalent* within tolerance. It also unit-tests
+`compareOutputs()` directly — no onnxruntime — across the divergent,
+within-tolerance, and not-comparable (mismatched output length) branches the
+panel renders:
+
+```bash
+npm run test:compare
+ORT_EP=webgpu npm run test:compare   # only where a WebGPU runtime exists
+```
 
 ## Report-an-issue URL
 

--- a/scripts/convertmodel/test/compare.test.mjs
+++ b/scripts/convertmodel/test/compare.test.mjs
@@ -1,0 +1,134 @@
+// Before/after comparison test for the model converter's "Run inference"
+// panel.
+//
+// The panel's "compare (before vs after conversion)" mode feeds one shared input
+// to two models — the original upload and the simplify/optimize result — and
+// reports how far their outputs diverge (max |Δ|) plus the speed difference. It
+// drives compareInference()/compareOutputs() in inference_core.mjs, the same
+// code the browser page calls, so a green run here means that comparison path
+// works end to end.
+//
+// Two checks:
+//   1. compareInference() with the fixture model as BOTH sides (a conversion is
+//      free to be a no-op) must report the outputs as identical (max |Δ| == 0),
+//      dims matching, and equivalent within tolerance — the "conversion
+//      preserved the numerics" verdict.
+//   2. compareOutputs() alone (pure, no onnxruntime) reports the divergent and
+//      not-comparable branches the way the panel renders them.
+//
+// Usage:
+//   node test/compare.test.mjs            # wasm EP, 5 iterations
+//   ORT_EP=webgpu node test/compare.test.mjs
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import assert from "node:assert/strict";
+import * as ort from "onnxruntime-web";
+import { compareInference, compareOutputs } from "../inference_core.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DIST = join(HERE, "..", "node_modules", "onnxruntime-web", "dist") + "/";
+
+const EP = process.env.ORT_EP || "wasm";
+const ITERS = Number(process.env.ORT_ITERS || "5");
+const TOL = 1e-3;
+
+// Same offline, single-threaded onnxruntime-web config as inference.test.mjs.
+ort.env.wasm.wasmPaths = DIST;
+ort.env.wasm.numThreads = 1;
+ort.env.wasm.proxy = false;
+
+async function testEndToEnd() {
+  const model = new Uint8Array(readFileSync(join(HERE, "model.onnx")));
+  const io = JSON.parse(readFileSync(join(HERE, "io.json"), "utf8"));
+
+  const input = new ort.Tensor(
+    "float32",
+    Float32Array.from(io.input.data),
+    io.input.dims,
+  );
+
+  // Compare the fixture model against itself: a conversion that changed nothing
+  // is the strongest "must be equivalent" case, and it exercises the full
+  // two-run + diff path without needing a second fixture.
+  const cmp = await compareInference(ort, {
+    before: { model, label: "original" },
+    after: { model, label: "converted" },
+    inputName: io.input.name,
+    outputName: io.output.name,
+    input,
+    providers: [EP],
+    iterations: ITERS,
+    tolerance: TOL,
+    onLog: (m) => console.log("  " + m),
+  });
+
+  assert.equal(cmp.comparable, true, "outputs should be comparable");
+  assert.equal(cmp.dimsMatch, true, "output dims should match");
+  assert.equal(cmp.maxAbsDiff, 0, "identical models must diverge by exactly 0");
+  assert.equal(cmp.equivalent, true, "identical models must be equivalent");
+  assert.ok(cmp.speedup > 0, "speedup should be a positive ratio");
+  // Both runs must also match the reference row baked into io.json.
+  const ref = Float32Array.from(io.output.data);
+  const firstAfter = Array.from(cmp.after.output);
+  let maxRefDiff = 0;
+  for (let i = 0; i < ref.length; i++) {
+    maxRefDiff = Math.max(maxRefDiff, Math.abs(firstAfter[i] - ref[i]));
+  }
+  assert.ok(maxRefDiff <= 1e-4, `output within ${1e-4} of reference (got ${maxRefDiff})`);
+
+  console.log(
+    `PASS end-to-end: both models ran ${cmp.after.iterations} iterations on ` +
+      `'${cmp.after.ep}', max |Δ| = ${cmp.maxAbsDiff}, ` +
+      `speedup ${cmp.speedup.toFixed(2)}×`,
+  );
+}
+
+function testCompareOutputs() {
+  // Divergent outputs beyond tolerance -> comparable but not equivalent.
+  const differ = compareOutputs(
+    { output: new Float32Array([0, 0, 0]), dims: [1, 3], avgMs: 2 },
+    { output: new Float32Array([0, 0.5, 0]), dims: [1, 3], avgMs: 1 },
+    TOL,
+  );
+  assert.equal(differ.comparable, true);
+  assert.equal(differ.dimsMatch, true);
+  assert.ok(Math.abs(differ.maxAbsDiff - 0.5) < 1e-9);
+  assert.equal(differ.equivalent, false, "0.5 diff exceeds tolerance");
+  assert.ok(Math.abs(differ.speedup - 2) < 1e-9, "2ms -> 1ms is a 2x speedup");
+
+  // Within tolerance -> equivalent.
+  const same = compareOutputs(
+    { output: new Float32Array([1, 2, 3]), dims: [1, 3], avgMs: 1 },
+    { output: new Float32Array([1, 2, 3 + 1e-6]), dims: [1, 3], avgMs: 1 },
+    TOL,
+  );
+  assert.equal(same.equivalent, true, "tiny diff is within tolerance");
+
+  // Mismatched output lengths -> not comparable, maxAbsDiff null.
+  const uncomparable = compareOutputs(
+    { output: new Float32Array([0, 0]), dims: [1, 2], avgMs: 1 },
+    { output: new Float32Array([0, 0, 0]), dims: [1, 3], avgMs: 1 },
+    TOL,
+  );
+  assert.equal(uncomparable.comparable, false);
+  assert.equal(uncomparable.maxAbsDiff, null);
+  assert.equal(uncomparable.dimsMatch, false);
+  assert.equal(uncomparable.equivalent, false);
+
+  console.log("PASS compareOutputs: differ / equivalent / not-comparable branches");
+}
+
+async function main() {
+  console.log(
+    `onnxruntime-web ${ort.env.versions.web ?? "?"}, EP=${EP}, iterations=${ITERS}`,
+  );
+  testCompareOutputs();
+  await testEndToEnd();
+}
+
+main().catch((e) => {
+  console.error("FAIL:", e.stack ?? String(e));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a "compare (before vs after conversion)" mode to the inference panel that runs both the original and converted models on the same deterministic input and reports how far their outputs diverge (max |Δ|) plus the speed difference. This lets users verify that a simplify/optimize conversion preserved the model's numerics and see the performance improvement.

## Key Changes

- **New comparison functions in `inference_core.mjs`**:
  - `compareOutputs()`: Pure function that compares two inference results and computes max absolute difference, dims matching, and speedup ratio
  - `compareInference()`: Runs two models on the same input tensor and returns detailed comparison results

- **Enhanced input generation in `inference_browser.mjs`**:
  - `fillPseudoRandom()`: Fills float arrays with deterministic pseudo-random values (seeded xorshift32) in [-1, 1) range, used for comparison mode to exercise the graph with varied inputs rather than all-zeros
  - `prepareInputs()`: Extracted common input preparation logic shared by single-model and compare paths, supporting both "zero" and "random" fill modes
  - `runCompare()`: New function that orchestrates the before/after comparison workflow

- **UI updates in `inference_browser.mjs`**:
  - `renderCompare()`: Renders comparison summary table showing output equivalence verdict, dims matching, latency comparison, speedup, and MAC reduction (when both models are annotated)
  - Updated inference panel logic to support "compare" as a model source option, with appropriate logging and result rendering

- **Test coverage in `test/compare.test.mjs`**:
  - End-to-end test running a fixture model against itself via `compareInference()` and verifying outputs are identical (max |Δ| == 0)
  - Unit tests for `compareOutputs()` covering divergent, within-tolerance, and not-comparable output branches

- **Documentation updates**:
  - Updated `index.html` with CSS styling for comparison verdict colors (ok/bad/warn)
  - Updated help text explaining the new compare mode
  - Updated `test/README.md` with before/after comparison test documentation

## Implementation Details

- The comparison uses a **shared, deterministic input** fed to both models, isolating the effect of the graph change
- Deterministic pseudo-random values (rather than zeros) are used because many ops map 0 → 0, which could mask divergences introduced by graph changes
- Integer/bool inputs remain zero (safe default for index-like tensors in Gather, etc.)
- The comparison verdict indicates whether outputs are equivalent within a tolerance (1e-3), with clear visual feedback for pass/fail/warning states
- Speedup is computed as before_latency / after_latency (>1 means the converted model is faster)

https://claude.ai/code/session_018Hfm1zYJffPa8kpbgHTYDY