### PR TITLE
Add "Copy shareable link" button to model converter UI

### DIFF
--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -355,6 +355,18 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                 <code>target_opset</code>/<code>opset</code>,
                 <code>backend</code> (prefills the backend-test URL). Setting an
                 input updates this URL so it stays shareable (uploads excepted).
+                <div style="margin-top: 0.35em;">
+                    <button id="share-link-button" type="button">Copy shareable link</button>
+                    <span id="share-link-status" style="color: #0a7d24; font-size: 0.85em; margin-left: 0.4em;"></span>
+                    <div style="margin-top: 0.2em;">
+                        Builds a link that reproduces the <b>current</b> input and
+                        <i>all</i> the conversion options below (processor, constant
+                        fold, shape inference, tensor size threshold, target opset)
+                        and copies it to your clipboard. Uploaded local files have no
+                        URL, so share a Hugging Face model / URL, a backend test case,
+                        or a pasted text graph.
+                    </div>
+                </div>
             </div>
             <div style="margin-top: 0.25em;">
                 <input type="checkbox" id="hf-use-xet" checked>
@@ -508,6 +520,7 @@ agraph (float[N] X) =&gt; (float[N] Y) {
         </div>
         <script type="module" src="./netron_view.mjs"></script>
         <script type="module" src="./hf_load.mjs"></script>
+        <script type="module" src="./share_url.mjs"></script>
 
         <h2>Console outputs:</h2>
         <textarea id="log-output" readonly rows="20" style="width: 100%; box-sizing: border-box;"></textarea>

--- a/scripts/convertmodel/query_params.mjs
+++ b/scripts/convertmodel/query_params.mjs
@@ -142,6 +142,51 @@ export function syncInputUrl(kind, value) {
   }
 }
 
+// The converter option controls' default state, matching index.html. An option
+// left at its default is omitted from a shared link (parseInputParams falls back
+// to the same defaults), so a typical "Share link" URL stays compact — it only
+// spells out what the user actually changed.
+const OPTION_DEFAULTS = {
+  constantFold: true, // #id_simplify_constant_fold checked
+  shapeInference: true, // #id_simplify_shape_inference checked
+  tensorSizeThreshold: 1000000000, // #id_simplify_tensor_size_threshold
+  targetOpset: 0, // #id_simplify_target_opset (0 = keep current opset)
+};
+
+// Build a complete shareable query string from the current converter state.
+// `search` is the live query string (already carrying the input key, kept in
+// sync by syncInputUrl); this overlays every conversion option at its current
+// control value so the link reproduces the *whole* configuration — not just the
+// input and processor that get synced live. `doc` is the document, injected for
+// testability. Options at their default are dropped to keep the URL short. Pure.
+export function buildShareSearch(search, doc) {
+  let s = search || "";
+  // Processor / mode radio (canonical key `optimizer`).
+  const checked = doc.querySelector && doc.querySelector('input[name="optimizer"]:checked');
+  if (checked && checked.value) s = setUrlParam(s, "optimizer", checked.value);
+  // Boolean toggles: emit "1"/"0" only when flipped away from the default.
+  const setBool = (id, key, dflt) => {
+    const el = doc.getElementById(id);
+    if (!el) return;
+    s = setUrlParam(s, key, el.checked === dflt ? "" : el.checked ? "1" : "0");
+  };
+  setBool("id_simplify_constant_fold", "cf", OPTION_DEFAULTS.constantFold);
+  setBool("id_simplify_shape_inference", "si", OPTION_DEFAULTS.shapeInference);
+  // Numeric options: emit only when meaningful (present and non-default).
+  const tst = doc.getElementById("id_simplify_tensor_size_threshold");
+  if (tst) {
+    const v = String(tst.value).trim();
+    const drop = v === "" || Number(v) === OPTION_DEFAULTS.tensorSizeThreshold;
+    s = setUrlParam(s, "tst", drop ? "" : v);
+  }
+  const opset = doc.getElementById("id_simplify_target_opset");
+  if (opset) {
+    const v = parseInt(opset.value, 10);
+    s = setUrlParam(s, "opset", Number.isFinite(v) && v > 0 ? String(v) : "");
+  }
+  return s;
+}
+
 // Prefill the converter's option controls from a parsed config, so both an
 // auto-run and a later manual run honor the link's options. `doc` is the
 // document (injected for testability); only set fields are touched. Returns the

--- a/scripts/convertmodel/share_url.mjs
+++ b/scripts/convertmodel/share_url.mjs
@@ -1,0 +1,84 @@
+// "Share link" button: build a URL that reproduces the current converter
+// configuration and copy it to the clipboard.
+//
+// The input source (model / graph / backend) and the processor already get
+// reflected into the address bar live (syncInputUrl / syncUrlParam in
+// query_params.mjs), but the other conversion options — constant fold, shape
+// inference, tensor size threshold, target opset — are only *read* from the URL
+// on load, not written back when the user changes a control. buildShareSearch
+// closes that gap: it overlays every option's current value onto the live query
+// string, so the copied link carries the whole configuration.
+//
+// Clicking Share also updates the address bar (history.replaceState) to the same
+// full URL, so a manual copy of the location bar matches what was copied.
+
+import { buildShareSearch } from "./query_params.mjs";
+
+const btn = document.getElementById("share-link-button");
+const statusEl = document.getElementById("share-link-status");
+
+// The absolute, shareable URL for the current configuration. Built from the page
+// URL (minus any existing query/hash) plus the freshly composed query string,
+// preserving the fragment. Works for file:// as well as served pages.
+function currentShareUrl() {
+  const search = buildShareSearch(window.location.search, document);
+  const base = window.location.href.split(/[?#]/)[0];
+  return base + search + window.location.hash;
+}
+
+// Copy `text` to the clipboard, preferring the async Clipboard API and falling
+// back to a hidden-textarea + execCommand for older / insecure-context browsers.
+// Returns whether the copy is believed to have succeeded.
+async function copyText(text) {
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to the legacy path
+  }
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    // Keep it off-screen and non-disruptive while still selectable.
+    ta.style.position = "fixed";
+    ta.style.top = "-1000px";
+    ta.style.opacity = "0";
+    ta.setAttribute("readonly", "");
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+let clearTimer = null;
+function flash(msg) {
+  if (!statusEl) return;
+  statusEl.textContent = msg;
+  if (clearTimer) clearTimeout(clearTimer);
+  clearTimer = setTimeout(() => {
+    statusEl.textContent = "";
+    clearTimer = null;
+  }, 4000);
+}
+
+if (btn) {
+  btn.addEventListener("click", async () => {
+    const url = currentShareUrl();
+    // Reflect the full configuration in the address bar too, so copying the
+    // location bar by hand yields the same link. Best-effort.
+    try {
+      window.history.replaceState(null, "", url);
+    } catch {
+      // ignore — a failed URL update must not break the copy.
+    }
+    const ok = await copyText(url);
+    flash(ok ? "link copied to clipboard ✓" : "copy failed — select the address bar and copy it");
+  });
+}

--- a/scripts/convertmodel/test/README.md
+++ b/scripts/convertmodel/test/README.md
@@ -138,9 +138,13 @@ Keys (aliases in parentheses): `model` (`hf`/`url`/`input`), `optimizer`,
 Conversely, **setting** an input model updates the address bar (via
 `history.replaceState`) to the matching `?model=` / `?backend=` link, so the
 current input is always shareable — except an uploaded local file, which has no
-URL. `npm run test:query` unit-tests the pure `query_params.mjs` parser, the
-option-prefiller (against a fake DOM), and the `setInputParam` URL builder; no
-DOM/network:
+URL. The **Copy shareable link** button (wired in `share_url.mjs`) goes further:
+it calls `buildShareSearch` to overlay *every* conversion option's current value
+onto that link — the processor plus `cf` / `si` / `tst` / `opset`, dropping any
+left at its default to keep the URL short — and copies the result to the
+clipboard (updating the address bar to match). `npm run test:query` unit-tests
+the pure `query_params.mjs` parser, the option-prefiller (against a fake DOM),
+the `setInputParam` URL builder, and `buildShareSearch`; no DOM/network:
 
 ```bash
 npm run test:query

--- a/scripts/convertmodel/test/query_params.test.mjs
+++ b/scripts/convertmodel/test/query_params.test.mjs
@@ -11,6 +11,7 @@ import {
   applyOptionParams,
   setInputParam,
   setUrlParam,
+  buildShareSearch,
 } from "../query_params.mjs";
 
 let passed = 0;
@@ -157,6 +158,74 @@ check("setUrlParam sets/deletes one param, preserving inputs", () => {
   assert.equal(new URLSearchParams(setUrlParam("?model=x", "optimizer", "optimize")).get("model"), "x");
   // Empty value deletes the key.
   assert.equal(new URLSearchParams(setUrlParam("?model=x&optimizer=optimize", "optimizer", "")).get("optimizer"), null);
+});
+
+// A document stand-in for buildShareSearch: the option controls addressed by id
+// plus a querySelector that resolves the single supported selector, the checked
+// optimizer radio. `opts` overrides the defaults (all at their index.html state).
+function shareDoc(opts = {}) {
+  const optimizer = opts.optimizer || "simplify";
+  const els = {
+    id_simplify_constant_fold: { checked: opts.constantFold ?? true },
+    id_simplify_shape_inference: { checked: opts.shapeInference ?? true },
+    id_simplify_tensor_size_threshold: { value: String(opts.tst ?? 1000000000) },
+    id_simplify_target_opset: { value: String(opts.opset ?? 0) },
+  };
+  return {
+    getElementById: (id) => els[id] || null,
+    querySelector: (sel) =>
+      sel === 'input[name="optimizer"]:checked' ? { value: optimizer } : null,
+  };
+}
+
+check("buildShareSearch keeps a compact URL when all options are default", () => {
+  const s = buildShareSearch("?model=owner/repo", shareDoc());
+  const p = new URLSearchParams(s);
+  assert.equal(p.get("model"), "owner/repo"); // input preserved
+  assert.equal(p.get("optimizer"), "simplify"); // processor always spelled out
+  // Defaults are dropped to keep the link short.
+  assert.equal(p.get("cf"), null);
+  assert.equal(p.get("si"), null);
+  assert.equal(p.get("tst"), null);
+  assert.equal(p.get("opset"), null);
+});
+
+check("buildShareSearch encodes every changed option", () => {
+  const doc = shareDoc({
+    optimizer: "optimize",
+    constantFold: false,
+    shapeInference: false,
+    tst: 500000,
+    opset: 18,
+  });
+  const s = buildShareSearch("?model=owner/repo", doc);
+  const p = new URLSearchParams(s);
+  assert.equal(p.get("model"), "owner/repo");
+  assert.equal(p.get("optimizer"), "optimize");
+  assert.equal(p.get("cf"), "0");
+  assert.equal(p.get("si"), "0");
+  assert.equal(p.get("tst"), "500000");
+  assert.equal(p.get("opset"), "18");
+});
+
+check("buildShareSearch round-trips through parseInputParams", () => {
+  const doc = shareDoc({ optimizer: "optimize", constantFold: false, opset: 17 });
+  const s = buildShareSearch("?backend=https://x/tree/y", doc);
+  const c = parseInputParams(s);
+  assert.equal(c.backend, "https://x/tree/y");
+  assert.equal(c.optimizer, "optimize");
+  assert.equal(c.constantFold, false);
+  assert.equal(c.shapeInference, null); // left at default → absent → default on load
+  assert.equal(c.targetOpset, 17);
+});
+
+check("buildShareSearch overwrites a stale option already in the query", () => {
+  // A previously shared cf=0 must be cleared once the control is back to default.
+  const s = buildShareSearch("?model=x&cf=0&opset=18", shareDoc({ opset: 0 }));
+  const p = new URLSearchParams(s);
+  assert.equal(p.get("cf"), null); // re-checked → default → dropped
+  assert.equal(p.get("opset"), null); // back to 0 (keep) → dropped
+  assert.equal(p.get("model"), "x");
 });
 
 console.log(`PASS: ${passed} checks`);


### PR DESCRIPTION
## Summary
Adds a "Copy shareable link" button to the ONNX model converter UI that captures the complete converter configuration (input source, processor, and all conversion options) into a shareable URL and copies it to the clipboard.

## Changes
- **New module `share_url.mjs`**: Implements the share link functionality
  - `currentShareUrl()`: Builds the complete shareable URL by overlaying all current option values onto the live query string
  - `copyText()`: Copies text to clipboard with fallback from modern Clipboard API to legacy `execCommand` for older browsers
  - `flash()`: Displays transient status messages to the user
  - Click handler that updates the address bar and copies the link

- **Updated `query_params.mjs`**: Adds `buildShareSearch()` export
  - Reads current state from DOM controls (processor radio, boolean toggles, numeric inputs)
  - Overlays option values onto the existing query string
  - Drops options at their defaults to keep URLs compact
  - Handles all conversion options: `optimizer`, `cf` (constant fold), `si` (shape inference), `tst` (tensor size threshold), `opset` (target opset)

- **Updated `index.html`**: Adds UI for the share button
  - Button with id `share-link-button` and status display element
  - Explanatory text describing the feature and its limitations (e.g., uploaded files have no URL)

- **Updated `query_params.test.mjs`**: Adds comprehensive test coverage
  - Tests that defaults are omitted from URLs to keep them short
  - Tests that changed options are properly encoded
  - Tests round-trip compatibility with `parseInputParams`
  - Tests that stale options in existing queries are cleared when controls return to defaults

## Implementation Details
- The feature complements the existing live URL sync (`syncInputUrl`/`syncUrlParam`) which only captures the input source and processor
- Options are only included in the shared URL if they differ from their defaults, matching the behavior of `parseInputParams` which falls back to defaults for missing parameters
- The address bar is updated via `history.replaceState` when sharing, so manual copying of the location bar yields the same result
- Graceful fallback for clipboard operations: if copying fails, the user is prompted to manually copy from the address bar

https://claude.ai/code/session_01R6jNmEAuovcJtG2s1boakK