### PR TITLE
Add support for inlining local functions in ONNX models

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ constant folding until the model stops changing. Around that it offers:
   up schemas registered via `onnx.defs.register_schema` automatically.
 - **[Opset conversion](#changing-the-opset-version).** Upgrade or downgrade the
   model's opset while simplifying with `--target-opset`.
+- **Function inlining.** Flatten the model's local (model-defined) functions into
+  the main graph before simplifying with `--inline-functions` (Python:
+  `inline_functions=True`), so the optimizer, shape inference and constant folding
+  can see through function calls. Schema-defined (built-in) functions are left
+  alone.
 - **[Custom rewriters](#custom-rewriters).** Plug your own rewriting logic into
   the fixed point with `custom_rewriter`, or express data-only `FunctionProto`
   rules that also run from the C and Rust bindings.

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -354,11 +354,11 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
          ONNX_NAMESPACE::ModelProto model;
          ParseProtoFromBytes(&model, model_proto_bytes.c_str(),
                              model_proto_bytes.size());
-         auto const result = Simplify(
-             *executor, model, skip_optimizers, constant_folding,
-             shape_inference, tensor_size_threshold, target_opset_version,
-             rewriter.get(), initializers_as_constants,
-             include_inline_functions);
+         auto const result =
+             Simplify(*executor, model, skip_optimizers, constant_folding,
+                      shape_inference, tensor_size_threshold,
+                      target_opset_version, rewriter.get(),
+                      initializers_as_constants, include_inline_functions);
          std::string out;
          result.SerializeToString(&out);
          return py::bytes(out.data(), out.size());

--- a/onnxsim/cpp2py_export.cc
+++ b/onnxsim/cpp2py_export.cc
@@ -347,7 +347,8 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
           bool constant_folding, bool shape_inference,
           size_t tensor_size_threshold, std::optional<int> target_opset_version,
           std::shared_ptr<GraphRewriter> rewriter,
-          bool initializers_as_constants) -> py::bytes {
+          bool initializers_as_constants,
+          bool include_inline_functions) -> py::bytes {
          // force env initialization to register opset
          InitEnv();
          ONNX_NAMESPACE::ModelProto model;
@@ -356,7 +357,8 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
          auto const result = Simplify(
              *executor, model, skip_optimizers, constant_folding,
              shape_inference, tensor_size_threshold, target_opset_version,
-             rewriter.get(), initializers_as_constants);
+             rewriter.get(), initializers_as_constants,
+             include_inline_functions);
          std::string out;
          result.SerializeToString(&out);
          return py::bytes(out.data(), out.size());
@@ -364,7 +366,8 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
        "executor"_a, "model_bytes"_a, "skip_optimizers"_a.none(),
        "constant_folding"_a = true, "shape_inference"_a = true,
        "tensor_size_threshold"_a, "target_opset_version"_a.none(),
-       "rewriter"_a.none(), "initializers_as_constants"_a = true)
+       "rewriter"_a.none(), "initializers_as_constants"_a = true,
+       "include_inline_functions"_a = false)
       .def(
           "simplify_path",
           [](std::shared_ptr<PyModelExecutor> executor,
@@ -374,19 +377,22 @@ NB_MODULE(onnxsim_cpp2py_export, m) {
              size_t tensor_size_threshold,
              std::optional<int> target_opset_version,
              std::shared_ptr<GraphRewriter> rewriter,
-             bool initializers_as_constants) -> bool {
+             bool initializers_as_constants,
+             bool include_inline_functions) -> bool {
             // force env initialization to register opset
             InitEnv();
             SimplifyPath(*executor, in_path, out_path, skip_optimizers,
                          constant_folding, shape_inference,
                          tensor_size_threshold, target_opset_version,
-                         rewriter.get(), initializers_as_constants);
+                         rewriter.get(), initializers_as_constants,
+                         include_inline_functions);
             return true;
           },
           "executor"_a, "in_path"_a, "out_path"_a, "skip_optimizers"_a.none(),
           "constant_folding"_a = true, "shape_inference"_a = true,
           "tensor_size_threshold"_a, "target_opset_version"_a.none(),
-          "rewriter"_a.none(), "initializers_as_constants"_a = true)
+          "rewriter"_a.none(), "initializers_as_constants"_a = true,
+          "include_inline_functions"_a = false)
       .def("_list_optimizers",
            []() {
              py::list ret;

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -375,6 +375,7 @@ def simplify(
     mutable_initializer: bool = False,
     *,
     initializers_as_constants: bool = True,
+    inline_functions: bool = False,
     import_custom_schemas: bool = True,
     input_shapes=None,
     target_opset_version: Optional[int] = None,
@@ -412,6 +413,11 @@ def simplify(
             as tunable tensors. ``Constant`` nodes are still folded either way. This is orthogonal
             to ``mutable_initializer`` (which controls whether initializers also remain graph
             inputs).
+    :param inline_functions: When True, inline the model's local (model-defined) functions into
+            the main graph before simplifying (using onnx's inliner), flattening function calls
+            into plain ops so the optimizer, shape inference and constant folding can see through
+            them. Schema-defined (built-in) functions are left alone. Defaults to False, which
+            leaves the model's functions untouched.
     :param import_custom_schemas: Import operator schemas registered in the Python `onnx` module
             (e.g. via `onnx.defs.register_schema`) into onnxsim's own registry so models using
             custom operators pass validation. Set to False to disable this and leave onnxsim's
@@ -698,6 +704,7 @@ def simplify(
             target_opset_version,
             rewriter,
             initializers_as_constants,
+            inline_functions,
         )
         # The serialized original (~1x model) is not needed once the C++
         # simplifier has consumed it -- the large-model fallback below
@@ -766,6 +773,7 @@ def simplify(
                 target_opset_version,
                 rewriter,
                 initializers_as_constants,
+                inline_functions,
             )
             check_ok = model_checking.compare(
                 os.path.join(tmpdirname, "opt.onnx"),
@@ -1050,6 +1058,13 @@ def main():
         default=None,
     )
     parser.add_argument(
+        "--inline-functions",
+        help="Inline the model's local (model-defined) functions into the main graph before "
+        "simplifying, so the optimizer, shape inference and constant folding can see through "
+        "function calls into a flat op graph. Schema-defined (built-in) functions are left alone.",
+        action="store_true",
+    )
+    parser.add_argument(
         "--providers",
         help="onnxruntime execution providers used to run the model during "
         "constant folding, in priority order, for example '--providers "
@@ -1286,6 +1301,7 @@ def main():
         args.tensor_size_threshold,
         args.mutable_initializer,
         initializers_as_constants=not args.initializers_as_non_constants,
+        inline_functions=args.inline_functions,
         import_custom_schemas=not args.skip_schema_import,
         target_opset_version=args.target_opset,
         check_rtol=args.check_rtol,

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -34,6 +34,7 @@
 #include "onnx/common/file_utils.h"
 #include "onnx/defs/printer.h"
 #include "onnx/defs/schema.h"
+#include "onnx/inliner/inliner.h"
 #include "onnx/shape_inference/implementation.h"
 #include "onnx/version_converter/convert.h"
 #include "onnxoptimizer/model_util.h"
@@ -1971,7 +1972,7 @@ onnx::ModelProto Simplify(
     std::optional<std::vector<std::string>> skip_optimizers,
     bool constant_folding, bool shape_inference, size_t tensor_size_threshold,
     std::optional<int> target_opset_version, const GraphRewriter* rewriter,
-    bool initializers_as_constants) {
+    bool initializers_as_constants, bool include_inline_functions) {
   // Make shape inference aware of ONNX Runtime's quantized contrib operators
   // (QLinearAdd and friends) so shape deduction does not stop at them.
   onnxsim::RegisterContribOpSchemas();
@@ -2162,6 +2163,15 @@ onnx::ModelProto Simplify(
   // The fixed points mutate in place, so make one working copy of the (const)
   // input model and simplify it in place.
   onnx::ModelProto sim_model = model;
+  // Optionally inline the model's local (model-defined) functions into the main
+  // graph up front, so the optimizer, shape inference and constant folding below
+  // see through them into a flat op graph. Done before the opset conversion and
+  // fixed point so everything downstream operates on the inlined graph;
+  // schema-defined functions are left untouched. Off by default, so a model with
+  // functions is otherwise simplified exactly as before.
+  if (include_inline_functions) {
+    onnx::inliner::InlineLocalFunctions(sim_model);
+  }
   // Optionally convert the model to a different opset version (of the default
   // ONNX domain) first, so the simplification below can clean up any redundant
   // nodes the version converter introduces.
@@ -2199,13 +2209,15 @@ void SimplifyPath(const ModelExecutor& executor, const std::string& in_path,
                   size_t tensor_size_threshold,
                   std::optional<int> target_opset_version,
                   const GraphRewriter* rewriter,
-                  bool initializers_as_constants) {
+                  bool initializers_as_constants,
+                  bool include_inline_functions) {
   onnx::ModelProto model;
   onnx::optimization::loadModel(&model, in_path, true);
 
   model = Simplify(executor, model, skip_optimizers, constant_folding,
                    shape_inference, tensor_size_threshold, target_opset_version,
-                   rewriter, initializers_as_constants);
+                   rewriter, initializers_as_constants,
+                   include_inline_functions);
 
   onnx::optimization::saveModel(&model, out_path, true, "");
 }

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -2164,11 +2164,11 @@ onnx::ModelProto Simplify(
   // input model and simplify it in place.
   onnx::ModelProto sim_model = model;
   // Optionally inline the model's local (model-defined) functions into the main
-  // graph up front, so the optimizer, shape inference and constant folding below
-  // see through them into a flat op graph. Done before the opset conversion and
-  // fixed point so everything downstream operates on the inlined graph;
-  // schema-defined functions are left untouched. Off by default, so a model with
-  // functions is otherwise simplified exactly as before.
+  // graph up front, so the optimizer, shape inference and constant folding
+  // below see through them into a flat op graph. Done before the opset
+  // conversion and fixed point so everything downstream operates on the inlined
+  // graph; schema-defined functions are left untouched. Off by default, so a
+  // model with functions is otherwise simplified exactly as before.
   if (include_inline_functions) {
     onnx::inliner::InlineLocalFunctions(sim_model);
   }
@@ -2208,16 +2208,15 @@ void SimplifyPath(const ModelExecutor& executor, const std::string& in_path,
                   bool constant_folding, bool shape_inference,
                   size_t tensor_size_threshold,
                   std::optional<int> target_opset_version,
-                  const GraphRewriter* rewriter,
-                  bool initializers_as_constants,
+                  const GraphRewriter* rewriter, bool initializers_as_constants,
                   bool include_inline_functions) {
   onnx::ModelProto model;
   onnx::optimization::loadModel(&model, in_path, true);
 
-  model = Simplify(executor, model, skip_optimizers, constant_folding,
-                   shape_inference, tensor_size_threshold, target_opset_version,
-                   rewriter, initializers_as_constants,
-                   include_inline_functions);
+  model =
+      Simplify(executor, model, skip_optimizers, constant_folding,
+               shape_inference, tensor_size_threshold, target_opset_version,
+               rewriter, initializers_as_constants, include_inline_functions);
 
   onnx::optimization::saveModel(&model, out_path, true, "");
 }

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -89,9 +89,9 @@ std::shared_ptr<const ModelExecutor> GetBuiltinModelExecutor();
 // ``include_inline_functions`` (default false) inlines the model's local
 // (model-defined) functions into the main graph before simplifying, via onnx's
 // inliner. This flattens function calls into plain ops so the optimizer, shape
-// inference and constant folding can see through them; schema-defined (built-in)
-// functions are left alone. With the default the model's functions are left
-// untouched.
+// inference and constant folding can see through them; schema-defined
+// (built-in) functions are left alone. With the default the model's functions
+// are left untouched.
 onnx::ModelProto Simplify(
     const ModelExecutor& executor, const onnx::ModelProto& model,
     std::optional<std::vector<std::string>> skip_optimizers,

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -86,13 +86,20 @@ std::shared_ptr<const ModelExecutor> GetBuiltinModelExecutor();
 // as non-constant, so nodes rooted only at initializers are left in the graph
 // and their weights survive simplification as tunable tensors; ``Constant``
 // nodes are still treated as constants either way.
+// ``include_inline_functions`` (default false) inlines the model's local
+// (model-defined) functions into the main graph before simplifying, via onnx's
+// inliner. This flattens function calls into plain ops so the optimizer, shape
+// inference and constant folding can see through them; schema-defined (built-in)
+// functions are left alone. With the default the model's functions are left
+// untouched.
 onnx::ModelProto Simplify(
     const ModelExecutor& executor, const onnx::ModelProto& model,
     std::optional<std::vector<std::string>> skip_optimizers,
     bool constant_folding, bool shape_inference, size_t tensor_size_threshold,
     std::optional<int> target_opset_version = std::nullopt,
     const GraphRewriter* rewriter = nullptr,
-    bool initializers_as_constants = true);
+    bool initializers_as_constants = true,
+    bool include_inline_functions = false);
 
 // Debugging helpers: run a *single* one of the transforms that ``Simplify``
 // otherwise drives to a fixed point, once, on a copy of ``model``, and return
@@ -121,4 +128,5 @@ void SimplifyPath(const ModelExecutor& executor, const std::string& in_path,
                   size_t tensor_size_threshold,
                   std::optional<int> target_opset_version = std::nullopt,
                   const GraphRewriter* rewriter = nullptr,
-                  bool initializers_as_constants = true);
+                  bool initializers_as_constants = true,
+                  bool include_inline_functions = false);

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -263,9 +263,15 @@
                     // by default; applies to every optimizer mode.
                     const annotate_model_info = document.getElementById("id_annotate_model_info").checked;
                     last_run_info.annotate_model_info = annotate_model_info;
+                    // Inline the model's local functions before simplify / optimize /
+                    // fixed optimize (a no-op for the single-pass debug modes and the
+                    // standalone "inline" mode). Off by default so behaviour is
+                    // unchanged unless the user opts in.
+                    const inline_functions = document.getElementById("id_inline_functions").checked;
+                    last_run_info.inline_functions = inline_functions;
                     // Expose the latest run parameters to the report-issue module.
                     window.__onnxsimLastRunInfo = last_run_info;
-                    worker.postMessage([optimizer, buf, passes, constant_fold, shape_inference, tensor_size_threshold, target_opset_version, profile, annotate_model_info], [buf]);
+                    worker.postMessage([optimizer, buf, passes, constant_fold, shape_inference, tensor_size_threshold, target_opset_version, profile, annotate_model_info, inline_functions], [buf]);
                 };
                 // Expose the conversion entry point for the Hugging Face loader
                 // module (hf_load.mjs), which downloads model bytes and drives
@@ -300,9 +306,13 @@
                 — the form <code>onnx.parser.parse_graph</code> / <code>parse_model</code> accept.
                 It is parsed into a model by the WebAssembly module (a bare graph is
                 wrapped into a model with a default-domain opset import) and shown in
-                the <b>Before</b> Netron pane. With <b>convert after parsing</b> on, it
-                is also run straight through the currently selected convert mode below
-                (Simplify / Optimize, or a single debug pass).
+                the <b>Before</b> Netron pane. Local <b>function</b> definitions
+                (<code>&lt;domain: "..."&gt; name (...) =&gt; (...) {...}</code> blocks after
+                the graph) are parsed too, and the wrapped model gains an opset import
+                for each function's domain so it validates. With <b>convert after
+                parsing</b> on, it is also run straight through the currently selected
+                convert mode below (Simplify / Optimize / Inline functions, or a single
+                debug pass).
             </p>
             <textarea id="parse-graph-text" rows="8" style="width: 100%; box-sizing: border-box; font-family: monospace;"
                 placeholder="&lt;
@@ -362,9 +372,10 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                 (<code>hf</code>/<code>url</code>), <code>graph</code> (an ONNX text
                 graph to parse), <code>optimizer</code> (a.k.a. <code>mode</code>/<code>processor</code>; the
                 convert mode —
-                <code>simplify</code>/<code>optimize</code>/<code>optimize_fixed</code>/<code>infer_shapes</code>/<code>data_propagation</code>/<code>fold_constant</code>),
+                <code>simplify</code>/<code>optimize</code>/<code>optimize_fixed</code>/<code>inline</code>/<code>infer_shapes</code>/<code>data_propagation</code>/<code>fold_constant</code>),
                 <code>constant_fold</code>/<code>cf</code>,
                 <code>shape_inference</code>/<code>si</code>,
+                <code>inline_functions</code>/<code>inline</code>,
                 <code>tensor_size_threshold</code>/<code>tst</code>,
                 <code>target_opset</code>/<code>opset</code>,
                 <code>backend</code> (prefills the backend-test URL). Setting an
@@ -451,6 +462,8 @@ agraph (float[N] X) =&gt; (float[N] Y) {
             <label for="optimizer_optimize_fixed">
                 Fixed <a href="https://github.com/onnx/optimizer" target="_blank">Optimize</a>
             </label>
+            <input type="radio" name="optimizer" value="inline" id="optimizer_inline">
+            <label for="optimizer_inline" title="Inline the model's local (model-defined) functions into the main graph; schema-defined functions are left alone">Inline functions</label>
             <span style="margin-left: 0.6em; color: #666;">| single pass (debug):</span>
             <input type="radio" name="optimizer" value="infer_shapes" id="optimizer_infer_shapes">
             <label for="optimizer_infer_shapes" title="Run ONNX shape inference once (not in the fixed point)">Shape inference</label>
@@ -465,6 +478,9 @@ agraph (float[N] X) =&gt; (float[N] Y) {
             <br/>
             <input type="checkbox" name="simplify_shape_inference" id="id_simplify_shape_inference" checked>
             <label for="id_simplify_shape_inference">shape inference (simplify only)</label>
+            <br/>
+            <input type="checkbox" name="inline_functions" id="id_inline_functions">
+            <label for="id_inline_functions">inline local functions first (simplify / optimize / fixed optimize) — flatten model-defined functions into the graph before converting</label>
             <br/>
             <label>tensor size threshold (simplify / constant folding)</label>
             <input type="number" name="simplify_tensor_size_threshold" id="id_simplify_tensor_size_threshold" value="1000000000">

--- a/scripts/convertmodel/interface.cpp
+++ b/scripts/convertmodel/interface.cpp
@@ -4,6 +4,7 @@
 #include "onnx/checker.h"
 #include "onnx/defs/parser.h"
 #include "onnx/defs/schema.h"
+#include "onnx/inliner/inliner.h"
 
 // Version strings baked in by CMake (read from VERSION and
 // third_party/onnx-optimizer/VERSION_NUMBER). Fall back to "unknown" so the
@@ -26,6 +27,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <set>
 #include <sstream>
 #include <string>
 
@@ -145,6 +147,53 @@ bool TensorProtoToRawBytes(const onnx::TensorProto& tensor, std::string& out) {
             return true;
         default:
             return false;
+    }
+}
+
+// Highest opset version this build supports for the default ONNX domain
+// (ai.onnx), read from the linked onnx at runtime. Returns 1 if the registry
+// somehow lacks the default domain. Used to give parsed graphs a sensible
+// default opset import.
+int HighestDefaultOpset() {
+    const auto& ranges =
+        onnx::OpSchemaRegistry::DomainToVersionRange::Instance().Map();
+    auto it = ranges.find("");  // "" is the default ONNX domain (ai.onnx)
+    int max_opset = (it != ranges.end()) ? it->second.second : 0;
+    return max_opset > 0 ? max_opset : 1;
+}
+
+// Make sure `model` carries an opset import for the default ONNX domain and for
+// every domain its local functions live in, so a model assembled from parsed
+// text (which may omit the prolog, or reference local functions) still validates
+// and can be simplified / visualized. Existing opset imports are left untouched;
+// only missing domains are added. A local function's own domain is imported at
+// the version the function declares for that domain, defaulting to 1 for a
+// custom domain that declares none.
+void EnsureOpsetImports(onnx::ModelProto& model) {
+    std::set<std::string> present;
+    for (const auto& op : model.opset_import()) {
+        present.insert(op.domain());
+    }
+    if (!present.count("")) {
+        auto* op = model.add_opset_import();
+        op->set_domain("");  // default ONNX domain (ai.onnx)
+        op->set_version(HighestDefaultOpset());
+        present.insert("");
+    }
+    for (const auto& fn : model.functions()) {
+        const std::string& dom = fn.domain();
+        if (present.count(dom)) continue;
+        int64_t ver = 1;
+        for (const auto& op : fn.opset_import()) {
+            if (op.domain() == dom) {
+                ver = op.version();
+                break;
+            }
+        }
+        auto* op = model.add_opset_import();
+        op->set_domain(dom);
+        op->set_version(ver);
+        present.insert(dom);
     }
 }
 
@@ -380,22 +429,29 @@ em::val onnxsim_versions() {
 
 // Parse an ONNX *text* representation into a model and return its bytes. Accepts
 // either a whole-model text (with an `<ir_version: ..., opset_import: [...]>`
-// prolog) or a bare graph body -- the textual form onnx.parser.parse_graph
-// accepts. A bare graph is wrapped in a minimal ModelProto with a default-domain
-// opset import at the highest opset this build supports, so the parsed graph can
-// then be simplified / visualized / run like an uploaded model. Returns
-// { model: Uint8Array } on success or { error: string } describing the parse
-// failure(s).
+// prolog) or a bare graph body -- the textual form onnx.parser.parse_graph /
+// parse_model accept. Local function definitions (one or more `<domain: ...>
+// name (...) => (...) {...}` blocks after the graph) are parsed too: the model
+// path captures them natively, and either path is normalized so the model
+// carries an opset import for the default ONNX domain and for every domain its
+// functions use, plus a valid ir_version -- so a graph that calls local
+// functions still validates and can be simplified / visualized / run like an
+// uploaded model. Returns { model: Uint8Array } on success or { error: string }
+// describing the parse failure(s).
 em::val onnxsim_parse_graph(const std::string& text) {
     em::val out = em::val::object();
-    // Try whole-model text first. Each OnnxParser consumes its input, so a fresh
-    // parser is constructed per attempt (the member Parse API is stable across
-    // onnx versions).
+    // Try whole-model text first: this is the only path that captures trailing
+    // FunctionProto definitions (GraphProto has no functions field), and it also
+    // accepts a bare graph because the `<...>` prolog is optional. Each
+    // OnnxParser consumes its input, so a fresh parser is constructed per attempt
+    // (the member Parse API is stable across onnx versions).
     onnx::ModelProto model;
     onnx::OnnxParser model_parser(text.c_str());
     onnx::Common::Status model_st = model_parser.Parse(model);
-    if (!model_st.IsOK()) {
-        // Fall back to graph-only text and wrap it into a model.
+    if (!model_st.IsOK() || !model.has_graph()) {
+        // Fall back to graph-only text and wrap it into a model. This path has no
+        // functions (the graph syntax cannot carry them), so a model that needs
+        // local functions must go through the model path above.
         onnx::GraphProto graph;
         onnx::OnnxParser graph_parser(text.c_str());
         onnx::Common::Status graph_st = graph_parser.Parse(graph);
@@ -407,19 +463,16 @@ em::val onnxsim_parse_graph(const std::string& text) {
             return out;
         }
         model.Clear();
-        model.set_ir_version(onnx::IR_VERSION);
         *model.mutable_graph() = graph;
-        int max_opset = 0;
-        const auto& ranges =
-            onnx::OpSchemaRegistry::DomainToVersionRange::Instance().Map();
-        auto it = ranges.find("");  // default ONNX domain (ai.onnx)
-        if (it != ranges.end()) {
-            max_opset = it->second.second;
-        }
-        auto* opset = model.add_opset_import();
-        opset->set_domain("");  // default ONNX domain
-        opset->set_version(max_opset > 0 ? max_opset : 1);
     }
+    // A bare graph (or a graph with local functions but no explicit prolog) parses
+    // without an ir_version or opset imports; fill in sensible defaults so the
+    // result validates. Local functions require IR v8+, and EnsureOpsetImports
+    // adds an opset import for each function's domain.
+    if (model.ir_version() == 0) {
+        model.set_ir_version(onnx::IR_VERSION);
+    }
+    EnsureOpsetImports(model);
     em::val bytes = SerializeModel(model);
     if (bytes.isNull()) {
         out.set("error", std::string("failed to serialize the parsed model"));
@@ -427,6 +480,37 @@ em::val onnxsim_parse_graph(const std::string& text) {
     }
     out.set("model", bytes);
     return out;
+}
+
+// Inline the model's local (model-defined) functions into its main graph: every
+// call-site of a FunctionProto listed in `model.functions` is replaced by the
+// function body, and the functions are removed from the model. This flattens a
+// model that uses local functions into a plain op graph, which onnx-optimizer /
+// Simplify and constant folding can then see through. Schema-defined (built-in)
+// functions are left alone. Returns the inlined model bytes (null on failure);
+// `annotate` optionally bakes MAC/FLOP model info into metadata_props, matching
+// the other convert entry points.
+em::val onnxsim_inline_functions(const std::string& data, bool annotate) {
+    onnx::ModelProto xmodel;
+    std::cerr << "parsing message" << std::endl;
+    if (!xmodel.ParseFromArray(data.data(), data.size())) {
+        std::cerr << "Parse failed" << std::endl;
+        return em::val::null();
+    }
+    try {
+        onnx::inliner::InlineLocalFunctions(xmodel);
+    } catch (const std::exception& e) {
+        std::cerr << "inline functions error: " << e.what() << std::endl;
+        return em::val::null();
+    }
+    if (annotate) {
+        try {
+            AnnotateModelInfo(xmodel);
+        } catch (const std::exception& e) {
+            std::cerr << "annotate model info failed: " << e.what() << std::endl;
+        }
+    }
+    return SerializeModel(xmodel);
 }
 
 // Parse a serialized onnx.TensorProto (e.g. an input_N.pb / output_N.pb from an
@@ -552,6 +636,7 @@ EMSCRIPTEN_BINDINGS(module) {
     // single-pass debugging entry points (see the definitions above).
     em::function("onnxsim_versions", &onnxsim_versions);
     em::function("onnxsim_parse_graph", &onnxsim_parse_graph);
+    em::function("onnxsim_inline_functions", &onnxsim_inline_functions);
     em::function("onnxsim_parse_tensor", &onnxsim_parse_tensor);
     em::function("onnxsim_infer_shapes", &onnxsim_infer_shapes);
     em::function("onnxsim_data_propagation", &onnxsim_data_propagation);

--- a/scripts/convertmodel/issue_report.mjs
+++ b/scripts/convertmodel/issue_report.mjs
@@ -49,6 +49,7 @@ function headerLines({ pageUrl, userAgent, runInfo, versions }) {
     lines.push("- File: " + runInfo.file_name);
     lines.push("- constant fold: " + runInfo.constant_fold);
     lines.push("- shape inference: " + runInfo.shape_inference);
+    lines.push("- inline functions: " + runInfo.inline_functions);
     lines.push("- tensor size threshold: " + runInfo.tensor_size_threshold);
     lines.push("- target opset version: " + runInfo.target_opset_version + " (0 = keep)");
     if (runInfo.passes && runInfo.passes.length) {

--- a/scripts/convertmodel/query_params.mjs
+++ b/scripts/convertmodel/query_params.mjs
@@ -12,8 +12,11 @@
 //     "Run an ONNX backend test case" panel.
 //   autoload (run, convert) — whether to start the conversion automatically once
 //     a model is given (default: true).
-//   optimizer (opt) — "simplify" | "optimize" | "optimize_fixed".
+//   optimizer (opt) — "simplify" | "optimize" | "optimize_fixed" | "inline" |
+//     the single-pass debug modes.
 //   constant_fold (cf), shape_inference (si) — booleans.
+//   inline_functions (inline) — boolean: inline local functions before the
+//     simplify / optimize / fixed-optimize transform.
 //   tensor_size_threshold (tst), target_opset (opset) — integers.
 
 // Parse a boolean-ish value: an empty value (a bare `?cf`) means "on"; returns
@@ -37,6 +40,7 @@ const OPTIMIZERS = [
   "simplify",
   "optimize",
   "optimize_fixed",
+  "inline",
   "infer_shapes",
   "data_propagation",
   "fold_constant",
@@ -73,6 +77,9 @@ export function parseInputParams(search) {
     optimizer,
     constantFold: toBool(first("constant_fold", "cf")),
     shapeInference: toBool(first("shape_inference", "si")),
+    // Whether to inline local functions before simplify / optimize / fixed
+    // optimize (the "inline local functions first" checkbox).
+    inlineFunctions: toBool(first("inline_functions", "inline")),
     tensorSizeThreshold: toInt(first("tensor_size_threshold", "tst")),
     targetOpset: toInt(first("target_opset", "opset")),
   };
@@ -173,6 +180,7 @@ export function applyOptionParams(params, doc) {
   }
   setChecked("id_simplify_constant_fold", params.constantFold);
   setChecked("id_simplify_shape_inference", params.shapeInference);
+  setChecked("id_inline_functions", params.inlineFunctions);
   setValue("id_simplify_tensor_size_threshold", params.tensorSizeThreshold);
   setValue("id_simplify_target_opset", params.targetOpset);
   return changed;

--- a/scripts/convertmodel/test/query_params.test.mjs
+++ b/scripts/convertmodel/test/query_params.test.mjs
@@ -61,12 +61,22 @@ check("parses integer options and ignores garbage", () => {
   assert.equal(parseInputParams("?opset=notanumber").targetOpset, null);
 });
 
-check("only accepts known optimizer values, incl. single-pass modes", () => {
+check("only accepts known optimizer values, incl. inline and single-pass modes", () => {
   assert.equal(parseInputParams("?optimizer=optimize_fixed").optimizer, "optimize_fixed");
+  assert.equal(parseInputParams("?optimizer=inline").optimizer, "inline");
   assert.equal(parseInputParams("?optimizer=fold_constant").optimizer, "fold_constant");
   assert.equal(parseInputParams("?optimizer=infer_shapes").optimizer, "infer_shapes");
   assert.equal(parseInputParams("?optimizer=data_propagation").optimizer, "data_propagation");
   assert.equal(parseInputParams("?optimizer=bogus").optimizer, null);
+});
+
+check("parses the inline_functions flag and its alias", () => {
+  // Absent → null so callers can tell "not set" from off.
+  assert.equal(parseInputParams("?model=x").inlineFunctions, null);
+  assert.equal(parseInputParams("?inline_functions=1").inlineFunctions, true);
+  assert.equal(parseInputParams("?inline_functions=0").inlineFunctions, false);
+  assert.equal(parseInputParams("?inline").inlineFunctions, true); // bare alias = on
+  assert.equal(parseInputParams("?inline=off").inlineFunctions, false);
 });
 
 check("optimizer accepts mode/processor/opt aliases", () => {
@@ -100,17 +110,20 @@ check("applyOptionParams prefills only the given controls", () => {
     "optimizer_optimize",
     "id_simplify_constant_fold",
     "id_simplify_shape_inference",
+    "id_inline_functions",
     "id_simplify_tensor_size_threshold",
     "id_simplify_target_opset",
   ]);
-  const params = parseInputParams("?optimizer=optimize&cf=0&si=1&tst=1000&opset=18");
+  const params = parseInputParams("?optimizer=optimize&cf=0&si=1&inline=1&tst=1000&opset=18");
   const changed = applyOptionParams(params, doc);
   assert.equal(doc.els.optimizer_optimize.checked, true);
   assert.equal(doc.els.id_simplify_constant_fold.checked, false);
   assert.equal(doc.els.id_simplify_shape_inference.checked, true);
+  assert.equal(doc.els.id_inline_functions.checked, true);
   assert.equal(doc.els.id_simplify_tensor_size_threshold.value, "1000");
   assert.equal(doc.els.id_simplify_target_opset.value, "18");
   assert.ok(changed.includes("optimizer_optimize"));
+  assert.ok(changed.includes("id_inline_functions"));
 });
 
 check("applyOptionParams leaves untouched controls alone", () => {

--- a/scripts/convertmodel/worker.js
+++ b/scripts/convertmodel/worker.js
@@ -93,7 +93,12 @@ create_onnxsim({
 
     addEventListener("message", async (e) => {
         console.log(e.data);
-        const buf = e.data[1];
+        let buf = e.data[1];
+        // The true uploaded bytes, kept aside so the "annotate the original for
+        // the inference-compare panel" step below always sees the model the user
+        // gave us, even when the inline pre-step replaces `buf` with the inlined
+        // model before the main transform runs.
+        const originalBuf = e.data[1];
         // `model` is the converted model bytes (a Uint8Array view); `trace` is
         // the onnxsim profiling trace JSON for "simplify" when profiling was
         // requested, otherwise an empty string.
@@ -104,6 +109,24 @@ create_onnxsim({
         // user gets an explanation (see memoryLimitMessage) instead of the worker
         // dying with an opaque, unhandled error.
         try {
+        // Optional pre-step: inline the model's local functions before the main
+        // transform, so onnx-optimizer / Simplify / constant folding see through
+        // them into a plain op graph. Controlled by a checkbox (e.data[9]) and
+        // only meaningful for the whole-model transforms; the single-pass debug
+        // modes and the standalone "inline" mode below never run it. Inlining
+        // needs no model executor, so it is synchronous in both module variants.
+        if (e.data[9] &&
+            (e.data[0] === "simplify" || e.data[0] === "optimize" ||
+             e.data[0] === "optimize_fixed")) {
+            const inlined = runtime.onnxsim_inline_functions(buf, false);
+            if (!inlined) {
+                postMessage(["stderr", "inline functions failed!"]);
+                return;
+            }
+            // Copy out of the wasm heap (the view is invalidated by later wasm
+            // calls) and feed the inlined bytes to the selected transform.
+            buf = new Uint8Array(inlined).buffer;
+        }
         switch (e.data[0]) {
             case "simplify": {
                 // Simplify returns { model, trace } so the profiling trace can
@@ -141,6 +164,16 @@ create_onnxsim({
                 model = runtime.onnxoptimizer_optimize_fixed(
                     buf,
                     e.data[2], // target optimizers
+                    e.data[8], // annotate model info (MACs/FLOPs) into metadata_props
+                );
+                break;
+            // Standalone transform: inline the model's local functions into its
+            // main graph and return the flattened model. Unlike the pre-step
+            // above (which feeds a following simplify/optimize), this is the
+            // whole conversion, so it honors the "annotate model info" toggle.
+            case "inline":
+                model = runtime.onnxsim_inline_functions(
+                    buf,
                     e.data[8], // annotate model info (MACs/FLOPs) into metadata_props
                 );
                 break;
@@ -192,7 +225,7 @@ create_onnxsim({
         let original_data_url = "";
         if (e.data[8]) {
             try {
-                const annotated = runtime.onnxsim_annotate_model_info(buf);
+                const annotated = runtime.onnxsim_annotate_model_info(originalBuf);
                 if (annotated) {
                     original_data_url =
                         "data:application/octet-stream;base64," + annotated.toBase64();

--- a/scripts/leak.txt
+++ b/scripts/leak.txt
@@ -1,5 +1,6 @@
 leak:libcrypt
 leak:libtorch
+leak:libc10
 leak:numpy/_core
 leak:onnxruntime_pybind11_state
 leak:onnx_cpp2py_export
@@ -14,5 +15,6 @@ leak:_PyBytes_Resize
 leak:Objects/unicodeobject
 leak:PyObject_Malloc
 leak:PyMem_Malloc
+leak:PyMem_Calloc
 leak:list_resize
 leak:_io/stringio

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -1400,3 +1400,58 @@ def test_initializers_as_non_constants_keeps_initializer_node():
     # W stays an initializer, and K has been folded into one too.
     init_names = {i.name for i in sim_model.graph.initializer}
     assert "W" in init_names
+
+
+def _model_with_local_function() -> onnx.ModelProto:
+    # A model whose main graph calls a single model-defined (local) function
+    # ``custom.AddRelu`` -- authored via the ONNX text form so the FunctionProto
+    # rides along in ``model.functions``.
+    from onnx import parser
+
+    return parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 18, "custom": 1]
+        >
+        agraph (float[N] X) => (float[N] Y) {
+          Y = custom.AddRelu(X)
+        }
+        <
+          domain: "custom",
+          opset_import: ["": 18]
+        >
+        AddRelu (x) => (y) {
+          one = Constant<value = float {1.0}>()
+          shifted = Add(x, one)
+          y = Relu(shifted)
+        }
+        """
+    )
+
+
+def test_inline_functions_disabled_by_default_keeps_function():
+    # Without inline_functions the local function is preserved: the graph still
+    # calls custom.AddRelu and the FunctionProto stays in model.functions.
+    model = _model_with_local_function()
+    sim_model, ok = onnxsim.simplify(model, check_n=0)
+    assert ok
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert op_types == ["AddRelu"]
+    assert sim_model.graph.node[0].domain == "custom"
+    assert [f.name for f in sim_model.functions] == ["AddRelu"]
+
+
+def test_inline_functions_flattens_local_function():
+    # With inline_functions the call site is replaced by the function body (Add +
+    # Relu, with the folded constant), and the function is removed from the model
+    # so the optimizer and constant folding can act on the flattened graph.
+    model = _model_with_local_function()
+    sim_model, ok = onnxsim.simplify(model, inline_functions=True, check_n=0)
+    assert ok
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert "AddRelu" not in op_types
+    # The inlined body survives as plain ops (the +1 bias folds into an Add
+    # initializer/Constant, followed by Relu).
+    assert "Relu" in op_types
+    assert len(sim_model.functions) == 0


### PR DESCRIPTION
## Summary

This PR adds support for inlining model-defined (local) functions into the main graph of ONNX models. This allows onnx-optimizer, Simplify, and constant folding to see through function calls into a flattened op graph. The feature is exposed as both a standalone transform mode and an optional pre-processing step before simplify/optimize.

## Key Changes

- **New C++ functions in `interface.cpp`**:
  - `HighestDefaultOpset()`: Queries the ONNX registry for the highest supported opset version
  - `EnsureOpsetImports()`: Ensures a model has opset imports for the default ONNX domain and all domains used by local functions
  - `onnxsim_inline_functions()`: New WebAssembly entry point that inlines local functions and optionally annotates model info

- **Enhanced graph parsing**:
  - Updated `onnxsim_parse_graph()` to support parsing local function definitions (FunctionProto blocks) from text
  - Improved handling of bare graphs vs. whole-model text with proper opset import and ir_version defaults
  - Added `#include "onnx/inliner/inliner.h"` to support function inlining

- **UI and worker updates**:
  - Added "Inline functions" radio button option in the optimizer mode selector
  - Added "inline local functions first" checkbox to enable pre-processing before simplify/optimize/fixed-optimize
  - Updated worker to optionally inline functions before the main transform
  - Modified annotation step to use original buffer (before inlining) for inference comparison

- **Query parameter support**:
  - Added `inline_functions` / `inline` query parameters to control the feature via URL
  - Updated parameter parsing and application logic to handle the new flag

- **Documentation**:
  - Updated help text to explain local function support in graph parsing
  - Added documentation for the new `inline` optimizer mode and `inline_functions` parameter

## Implementation Details

- The inlining is controlled by a checkbox that defaults to OFF to preserve existing behavior
- Inlining only applies to the whole-model transforms (simplify/optimize/fixed-optimize), not single-pass debug modes
- The standalone "inline" mode honors the "annotate model info" toggle like other transforms
- Local functions require IR version 8+, which is handled by the `EnsureOpsetImports()` function
- The implementation preserves the original model buffer for the inference-compare annotation step

https://claude.ai/code/session_017LLsbAXtr4V6GXFNiN48UJ