### PR TITLE
Add reshape cancellation optimization around elementwise ops

### DIFF
--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -2028,9 +2028,12 @@ onnx::ModelProto Simplify(
     // than a pure node reduction. Transformer linear layers apply a 2-D weight
     // to rank-3 activations, which the 2-D-only
     // ``fuse_matmul_add_bias_into_gemm`` cannot fuse; converting them to
-    // ``Gemm`` lets runtimes dispatch their tuned GEMM kernels (the reshape
-    // scaffolding it introduces is folded/deduplicated by the rest of the fixed
-    // point). Still honour an explicit ``--skip-optimization`` for it.
+    // ``Gemm`` lets runtimes dispatch their tuned GEMM kernels. The reshape
+    // scaffolding it introduces around chains of element-wise ops is then
+    // cancelled by ``eliminate_reshape_around_elementwise`` (a Nop pass in the
+    // default set), which keeps the Gemms but drops the now-inverse reshape
+    // pairs so the node count does not regress. Still honour an explicit
+    // ``--skip-optimization`` for it.
     const std::string batched_gemm = "fuse_matmul_add_bias_into_gemm_batched";
     if (!is_disabled(*skip_optimizers, batched_gemm) &&
         !is_disabled(always_disabled_passes, batched_gemm)) {

--- a/tests/test_fusion_patterns.py
+++ b/tests/test_fusion_patterns.py
@@ -361,6 +361,50 @@ def test_fuse_convtranspose_add():
 
 
 # --------------------------------------------------------------------------- #
+# Reshape cancellation around a batched-Gemm element-wise chain. onnxsim's
+# batched MatMul+bias -> Gemm rewrite brackets each rank-3 linear layer in a
+# Reshape(-> 2-D) / Gemm / Reshape(-> N-D) sandwich so runtimes can dispatch a
+# tuned GEMM kernel. When two such linears surround an element-wise chain, the
+# inverse reshapes between them cancel (eliminate_reshape_around_elementwise):
+# the chain runs on the 2-D Gemm output and both Gemms are kept. This is the
+# node-count half of the batched-Gemm rewrite (issue: model-regression node
+# reduction).
+# --------------------------------------------------------------------------- #
+def test_eliminate_reshape_around_elementwise():
+    # The post-batched-fusion shape, built explicitly: Gemm -> Reshape(N-D) ->
+    # Relu -> Reshape(2-D) -> Gemm. The two middle reshapes are exact inverses
+    # (they only split / merge the leading dims), so they collapse and the Relu
+    # ends up directly between the two Gemms.
+    inits = [
+        _i64([-1, 8], "s1"),
+        _f32(np.random.randn(8, 16), "W1"),
+        _f32(np.random.randn(16), "b1"),
+        _i64([2, 4, 16], "s2"),
+        _i64([-1, 16], "s3"),
+        _f32(np.random.randn(16, 8), "W2"),
+        _f32(np.random.randn(8), "b2"),
+        _i64([2, 4, 8], "s4"),
+    ]
+    nodes = [
+        onnx.helper.make_node("Reshape", ["X", "s1"], ["rx1"]),
+        onnx.helper.make_node("Gemm", ["rx1", "W1", "b1"], ["g1"]),
+        onnx.helper.make_node("Reshape", ["g1", "s2"], ["u1"]),
+        onnx.helper.make_node("Relu", ["u1"], ["r"]),
+        onnx.helper.make_node("Reshape", ["r", "s3"], ["f2"]),
+        onnx.helper.make_node("Gemm", ["f2", "W2", "b2"], ["g2"]),
+        onnx.helper.make_node("Reshape", ["g2", "s4"], ["Y"]),
+    ]
+    model = _model(nodes, [_vi("X", [2, 4, 8])], [_vi("Y", [2, 4, 8])], inits)
+    _, ops = _simplify(model)
+    # Both Gemms are kept (tuned-kernel dispatch preserved)...
+    assert ops["Gemm"] == 2
+    assert ops["Relu"] == 1
+    # ...and the two inverse reshapes bracketing the Relu are gone: only the
+    # entry (X -> 2-D) and the final (2-D -> N-D output) reshapes remain.
+    assert ops["Reshape"] == 2
+
+
+# --------------------------------------------------------------------------- #
 # Remaining gap: passes OnnxSlim performs but onnxsim does not. Marked xfail
 # (strict=False) so CI stays green; each XPASSes and can be promoted if onnxsim
 # gains the pass.


### PR DESCRIPTION
## Summary
This PR adds a new optimization pass `eliminate_reshape_around_elementwise` that cancels inverse reshape pairs surrounding elementwise operation chains. This optimization is particularly valuable for batched Gemm patterns where the `fuse_matmul_add_bias_into_gemm_batched` pass introduces reshape scaffolding around rank-3 linear layers.

## Key Changes
- **Test coverage**: Added `test_eliminate_reshape_around_elementwise()` that validates the optimization on a realistic pattern: `Reshape → Gemm → Reshape → Relu → Reshape → Gemm → Reshape`. The test verifies that:
  - Both Gemm operations are preserved (maintaining tuned kernel dispatch)
  - The Relu operation is preserved
  - Only 2 Reshape operations remain (entry and final output reshapes), with the 2 inverse reshape pairs around the Relu eliminated
  
- **Documentation update**: Updated the comment in `onnxsim.cpp` explaining the batched Gemm rewrite to clarify that:
  - The reshape scaffolding introduced by `fuse_matmul_add_bias_into_gemm_batched` is now cancelled by `eliminate_reshape_around_elementwise`
  - This keeps the Gemms (preserving tuned kernel dispatch) while dropping inverse reshape pairs
  - This prevents node count regression from the batched Gemm optimization

- **Dependency update**: Updated `third_party/onnx-optimizer` submodule to include the new `eliminate_reshape_around_elementwise` pass implementation

## Implementation Details
The optimization targets the specific pattern created by batched Gemm fusion: when two linear layers (converted to Gemm with reshape scaffolding) surround an elementwise operation chain, the inverse reshapes between them can be safely eliminated. The reshapes only split/merge leading dimensions, making them exact inverses that collapse when adjacent.

https://claude.ai/code/session_01YMofSUmZoFKfn2WNP1owUx