### PR TITLE
Centralize CDN dependencies into single source of truth

### DIFF
--- a/.github/workflows/convertmodel-inference.yml
+++ b/.github/workflows/convertmodel-inference.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Run query-parameter unit test
         working-directory: scripts/convertmodel
         run: npm run test:query
+      - name: Run CDN source-of-truth unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:cdn
       - name: Run inference smoke test (wasm EP)
         working-directory: scripts/convertmodel
         run: npm run test:inference

--- a/scripts/convertmodel/backend_test.mjs
+++ b/scripts/convertmodel/backend_test.mjs
@@ -17,9 +17,7 @@
 
 import { downloadText } from "./download.mjs";
 import { syncInputUrl } from "./query_params.mjs";
-
-const ORT_VERSION = "1.27.0";
-const ORT_BASE = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ORT_VERSION}/dist/`;
+import { ORT_VERSION, ORT_BASE } from "./cdn.mjs";
 
 // A curated set of common ONNX backend *node* test cases for the picker, like
 // the Hugging Face model dropdown. Each entry's value is the GitHub tree URL of

--- a/scripts/convertmodel/cdn.mjs
+++ b/scripts/convertmodel/cdn.mjs
@@ -1,0 +1,47 @@
+// Single source of truth for every third-party CDN the converter page loads
+// *executable code* (or an embeddable app) from at runtime.
+//
+// The page's external runtime dependencies used to be declared inline in each
+// consumer — the onnxruntime-web URL alone was copied into three files
+// (inference_browser.mjs, backend_test.mjs, worker.js) with "keep in sync"
+// comments, so a version bump in one and not the others would silently mismatch
+// the JS glue against the .wasm binaries. Centralizing them here means the UI's
+// external dependencies live in one auditable place: one file to see what the
+// page trusts, one constant to bump a version, one file to self-host from.
+//
+// Only executable / embedded dependencies belong here. Everything else the page
+// fetches over the network is *data* (models, backend test cases, model lists)
+// pulled from Hugging Face / GitHub per feature; that stays with its feature.
+//
+//   * onnxruntime-web  (cdn.jsdelivr.net)  — inference + the ORT-web build's
+//                                            constant folding
+//   * @huggingface/hub (esm.sh)            — experimental Xet download (lazy)
+//   * Perfetto UI      (ui.perfetto.dev)   — optional embedded trace viewer
+//
+// Pure constants only (no window/document access) so the Node tests can import
+// and assert on them.
+
+// --- onnxruntime-web -------------------------------------------------------
+// The JS bundles and the matching wasm binaries are pulled from the same
+// versioned dist/ directory (see ORT_BASE), so the glue and the .wasm can never
+// disagree. Bump this one constant to move the whole page to a new
+// onnxruntime-web.
+export const ORT_VERSION = "1.27.0";
+
+// Base URL of that version's dist/ directory. Callers append the bundle name
+// (e.g. `${ORT_BASE}ort.min.mjs`) and point `ort.env.wasm.wasmPaths` at it so
+// the wasm artifacts come from the same directory as the glue.
+export const ORT_BASE = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ORT_VERSION}/dist/`;
+
+// --- @huggingface/hub ------------------------------------------------------
+// Pinned build for the experimental Xet download path, loaded lazily (only when
+// the Xet toggle is used) via dynamic import.
+export const HF_HUB_VERSION = "2.14.4";
+export const HF_HUB_ESM = `https://esm.sh/@huggingface/hub@${HF_HUB_VERSION}`;
+
+// --- Perfetto UI -----------------------------------------------------------
+// The trace viewer can embed the full Perfetto UI (or open it in a new tab) for
+// deep analysis, driven over Perfetto's postMessage embedding protocol.
+export const PERFETTO_ORIGIN = "https://ui.perfetto.dev";
+// `mode=embedded` hides Perfetto's sidebar for a clean in-page view.
+export const PERFETTO_EMBED_SRC = `${PERFETTO_ORIGIN}/#!/?mode=embedded`;

--- a/scripts/convertmodel/hf_models.mjs
+++ b/scripts/convertmodel/hf_models.mjs
@@ -10,6 +10,8 @@
 // This module is pure data/networking: it returns model bytes, and index.html
 // feeds them into the same conversion path an uploaded file takes.
 
+import { HF_HUB_ESM } from "./cdn.mjs";
+
 const HF = "https://huggingface.co";
 // Default org for bare names, matching scripts/regression/model_zoo.py.
 const ORG = "onnxmodelzoo";
@@ -269,10 +271,10 @@ export async function fetchModelBytes(ref, onLog = () => {}, onProgress = () => 
   return { bytes, name, repo: parsed.repo };
 }
 
-// Pinned @huggingface/hub build for the experimental Xet download path. Loaded
-// lazily (only when the Xet toggle is used) from a CDN, mirroring how the
-// inference panel lazy-loads onnxruntime-web.
-const HF_HUB_ESM = "https://esm.sh/@huggingface/hub@2.14.4";
+// The pinned @huggingface/hub build for the experimental Xet download path
+// (HF_HUB_ESM) is declared in cdn.mjs. It is loaded lazily (only when the Xet
+// toggle is used) from a CDN, mirroring how the inference panel lazy-loads
+// onnxruntime-web.
 
 // Read a Blob (e.g. the XetBlob returned by downloadFile) to a Uint8Array,
 // reporting streaming progress against its known size.

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -120,7 +120,7 @@
             let last_run_info = null;
 
             window.onload = () => {
-                const worker = new Worker("worker.js");
+                const worker = new Worker(window.__onnxsimWorkerUrl || "worker.js");
                 const log_output = document.getElementById("log-output");
                 const input = document.getElementById("file-input");
                 const dl_btn = document.getElementById("download-button");
@@ -289,6 +289,16 @@
                     startConversion(file.name, buf);
                 });
             };
+        </script>
+        <!-- Build the conversion worker's URL from the single CDN source of
+             truth (cdn.mjs). worker.js is a classic worker and can't import the
+             ES module, so the onnxruntime-web base — which only the module's
+             ORT-web build needs — rides in on the worker URL's query string.
+             The window.onload handler above reads __onnxsimWorkerUrl; module
+             scripts run before the load event, so it is set in time. -->
+        <script type="module">
+            import { ORT_BASE } from "./cdn.mjs";
+            window.__onnxsimWorkerUrl = "worker.js?ortBase=" + encodeURIComponent(ORT_BASE);
         </script>
     </head>
     <body>

--- a/scripts/convertmodel/inference_browser.mjs
+++ b/scripts/convertmodel/inference_browser.mjs
@@ -16,6 +16,7 @@ import { summarizeOrtTrace } from "./trace_build.mjs";
 import { renderTrace } from "./trace_viewer.mjs";
 import { downloadText } from "./download.mjs";
 import { providersForEp, isWebnnEp, detectWebnn, formatWebnnStatus } from "./webnn.mjs";
+import { ORT_VERSION, ORT_BASE } from "./cdn.mjs";
 import {
   readAnnotations,
   perOpSummary,
@@ -26,9 +27,6 @@ import {
   evalMetric,
   isSymbolicStr,
 } from "./macs.mjs";
-
-const ORT_VERSION = "1.27.0";
-const ORT_BASE = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ORT_VERSION}/dist/`;
 
 // onnxruntime-web ships several EP bundles. The default (`ort.min.mjs`) carries
 // WASM + WebGPU; WebNN lives only in the "all" bundle (`ort.all.min.mjs`). Both

--- a/scripts/convertmodel/package.json
+++ b/scripts/convertmodel/package.json
@@ -18,7 +18,8 @@
     "test:backend": "node test/backend_test.test.mjs",
     "test:query": "node test/query_params.test.mjs",
     "test:webnn": "node test/webnn.test.mjs",
-    "test:all": "npm run test:netron && npm run test:trace && npm run test:macs && npm run test:shapes && npm run test:hf && npm run test:xet && npm run test:issue && npm run test:versions && npm run test:backend && npm run test:query && npm run test:webnn && npm run test:inference && npm run test:compare",
+    "test:cdn": "node test/cdn.test.mjs",
+    "test:all": "npm run test:netron && npm run test:trace && npm run test:macs && npm run test:shapes && npm run test:hf && npm run test:xet && npm run test:issue && npm run test:versions && npm run test:backend && npm run test:query && npm run test:webnn && npm run test:cdn && npm run test:inference && npm run test:compare",
     "coverage": "c8 npm run test:all"
   },
   "dependencies": {

--- a/scripts/convertmodel/test/cdn.test.mjs
+++ b/scripts/convertmodel/test/cdn.test.mjs
@@ -1,0 +1,62 @@
+// Unit tests for cdn.mjs — the single source of truth for the converter page's
+// external CDN runtime dependencies. These guard the invariants that made the
+// old triplicated constants risky: the wasm binaries and JS glue must share one
+// versioned onnxruntime-web directory, and every declared endpoint must be an
+// https URL on the expected origin.
+//
+// Usage:
+//   node test/cdn.test.mjs
+
+import assert from "node:assert/strict";
+import {
+  ORT_VERSION,
+  ORT_BASE,
+  HF_HUB_VERSION,
+  HF_HUB_ESM,
+  PERFETTO_ORIGIN,
+  PERFETTO_EMBED_SRC,
+} from "../cdn.mjs";
+
+let passed = 0;
+function check(name, fn) {
+  fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+
+check("ORT_BASE points at the pinned onnxruntime-web version's dist/", () => {
+  assert.equal(
+    ORT_BASE,
+    `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ORT_VERSION}/dist/`,
+  );
+  // The glue and the .wasm are pulled from this same directory, so the version
+  // must appear in the base — the drift the old copies risked.
+  assert.ok(ORT_BASE.includes(ORT_VERSION));
+  assert.ok(ORT_BASE.endsWith("/dist/"));
+});
+
+check("HF_HUB_ESM points at the pinned @huggingface/hub version", () => {
+  assert.equal(HF_HUB_ESM, `https://esm.sh/@huggingface/hub@${HF_HUB_VERSION}`);
+  assert.ok(HF_HUB_ESM.includes(HF_HUB_VERSION));
+});
+
+check("PERFETTO_EMBED_SRC is the embedded-mode URL on PERFETTO_ORIGIN", () => {
+  assert.ok(PERFETTO_EMBED_SRC.startsWith(PERFETTO_ORIGIN + "/"));
+  assert.ok(PERFETTO_EMBED_SRC.includes("mode=embedded"));
+});
+
+check("every declared endpoint is an https URL on its expected origin", () => {
+  const expect = [
+    [ORT_BASE, "cdn.jsdelivr.net"],
+    [HF_HUB_ESM, "esm.sh"],
+    [PERFETTO_ORIGIN, "ui.perfetto.dev"],
+    [PERFETTO_EMBED_SRC, "ui.perfetto.dev"],
+  ];
+  for (const [value, host] of expect) {
+    const url = new URL(value);
+    assert.equal(url.protocol, "https:", `${value} must be https`);
+    assert.equal(url.host, host, `${value} must be on ${host}`);
+  }
+});
+
+console.log(`PASS: ${passed} checks`);

--- a/scripts/convertmodel/trace_viewer.mjs
+++ b/scripts/convertmodel/trace_viewer.mjs
@@ -21,9 +21,8 @@
 // (ui.perfetto.dev/#!/?mode=embedded) and against the full UI opened in a new
 // tab (window.open on ui.perfetto.dev).
 
-const PERFETTO_ORIGIN = "https://ui.perfetto.dev";
-// `mode=embedded` hides Perfetto's sidebar for a clean in-page view.
-const PERFETTO_EMBED_SRC = "https://ui.perfetto.dev/#!/?mode=embedded";
+import { PERFETTO_ORIGIN, PERFETTO_EMBED_SRC } from "./cdn.mjs";
+
 const ROW_H = 18; // px per stacked span row
 const TRACK_PAD = 6; // px above each track label
 const LABEL_H = 16; // px for a track's name row

--- a/scripts/convertmodel/worker.js
+++ b/scripts/convertmodel/worker.js
@@ -1,9 +1,15 @@
 importScripts("./onnxsim.js");
 
-// onnxruntime-web CDN location, kept in sync with inference_browser.mjs. Only
-// used by the ORT-web build of the module (see below).
-const ORT_VERSION = "1.27.0";
-const ORT_BASE = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ORT_VERSION}/dist/`;
+// onnxruntime-web CDN location. Only used by the ORT-web build of the module
+// (see setupOrtWebIfNeeded below); the default built-in-ORT build never reads
+// it. This classic worker can't import the ES-module single source of truth
+// (cdn.mjs), so index.html — which does import it — passes the base in via the
+// worker URL's `?ortBase=` query param (new Worker("worker.js?ortBase=…")). The
+// literal below is only a defensive fallback for a worker started without it;
+// the live value always comes from cdn.mjs through the page.
+const ORT_BASE =
+    new URLSearchParams(self.location.search).get("ortBase") ||
+    "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.27.0/dist/";
 
 // Turn a low-level WASM out-of-memory abort into an actionable explanation.
 // When a model needs more heap than the module can address, Emscripten aborts


### PR DESCRIPTION
## Summary

Consolidates all third-party CDN dependencies (onnxruntime-web, @huggingface/hub, Perfetto UI) into a single `cdn.mjs` module to eliminate version drift and improve auditability. Previously, the onnxruntime-web URL was duplicated across three files with "keep in sync" comments, creating a maintenance risk.

## Key Changes

- **New `cdn.mjs` module**: Single source of truth for all executable/embedded CDN dependencies with clear documentation of what each dependency is used for
- **New `test/cdn.test.mjs`**: Unit tests that guard invariants:
  - onnxruntime-web version appears in the base URL (preventing JS/WASM mismatch)
  - All endpoints are HTTPS URLs on expected origins
  - Pinned versions are consistent across declarations
- **Updated `inference_browser.mjs`**: Imports `ORT_VERSION` and `ORT_BASE` from `cdn.mjs` instead of declaring them locally
- **Updated `backend_test.mjs`**: Imports `ORT_VERSION` and `ORT_BASE` from `cdn.mjs`
- **Updated `hf_models.mjs`**: Imports `HF_HUB_ESM` from `cdn.mjs` with clarifying comments
- **Updated `trace_viewer.mjs`**: Imports `PERFETTO_ORIGIN` and `PERFETTO_EMBED_SRC` from `cdn.mjs`
- **Updated `worker.js`**: Receives `ORT_BASE` via query parameter from `index.html` (since classic workers can't import ES modules), with a defensive fallback to the hardcoded value
- **Updated `index.html`**: Builds worker URL with `ORT_BASE` from `cdn.mjs` via query string parameter
- **Updated `package.json`**: Added `test:cdn` script and integrated it into `test:all`

## Implementation Details

The worker.js integration uses a query parameter approach (`worker.js?ortBase=...`) because classic workers cannot import ES modules. The page's module script sets `window.__onnxsimWorkerUrl` before the load event, ensuring the worker receives the correct CDN base URL from the centralized source.

All constants are pure (no window/document access) to enable Node.js test imports and assertions.

https://claude.ai/code/session_018jspwqhS7tPj8YXKdsZYSv