### PR TITLE
Add warmup parameter to inference benchmarking

### DIFF
--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -654,7 +654,11 @@ agraph (float[N] X) =&gt; (float[N] Y) {
             just the <b>converted</b> result or the <b>original</b> upload on
             their own. The <b>batch</b> control sizes the model's dynamic batch
             (first) axis; it has no effect on inputs whose first dimension is
-            fixed. WebGPU falls back to WebAssembly when unavailable.
+            fixed. The <b>warmup</b> control runs that many untimed passes before
+            the timed iterations, so one-time costs (kernel/program compilation,
+            buffer allocation) don't add noise to the reported latency; set it to
+            0 to time every run. WebGPU falls back to WebAssembly when
+            unavailable.
         </p>
         <p>
             The execution-provider picker also offers
@@ -695,6 +699,9 @@ agraph (float[N] X) =&gt; (float[N] Y) {
             </select>
             <label for="inference-iters">iterations</label>
             <input type="number" id="inference-iters" value="5" min="1" style="width: 4em;">
+            <label for="inference-warmup">warmup</label>
+            <input type="number" id="inference-warmup" value="1" min="0" style="width: 4em;"
+                   title="Untimed warm-up runs done before the timed iterations, so one-time costs (kernel/program compilation, buffer allocation) don't skew the measured latency. 0 times every iteration.">
             <label for="inference-batch">batch</label>
             <input type="number" id="inference-batch" value="1" min="1" style="width: 4em;"
                    title="Size for the model's dynamic batch (first) axis; ignored on fixed-shape inputs.">

--- a/scripts/convertmodel/inference_browser.mjs
+++ b/scripts/convertmodel/inference_browser.mjs
@@ -145,7 +145,7 @@ async function prepareInputs(ort, modelBytes, batch, fill, log) {
   return { feeds, inputName, leadMeta, leadingDynamic };
 }
 
-async function runOnModel(modelBytes, { iterations, batch, providers, needWebnn, profile }, log) {
+async function runOnModel(modelBytes, { iterations, warmup, batch, providers, needWebnn, profile }, log) {
   const ort = await loadOrt(needWebnn ? "all" : "default");
 
   const { feeds, inputName, leadingDynamic } = await prepareInputs(
@@ -167,6 +167,7 @@ async function runOnModel(modelBytes, { iterations, batch, providers, needWebnn,
     feeds,
     providers,
     iterations,
+    warmup,
     profile,
     onLog: log,
   });
@@ -185,7 +186,7 @@ async function runOnModel(modelBytes, { iterations, batch, providers, needWebnn,
 async function runCompare(
   originalBytes,
   convertedBytes,
-  { iterations, batch, providers, needWebnn, profile },
+  { iterations, warmup, batch, providers, needWebnn, profile },
   log,
 ) {
   const ort = await loadOrt(needWebnn ? "all" : "default");
@@ -211,6 +212,7 @@ async function runCompare(
     feeds,
     providers,
     iterations,
+    warmup,
     profile,
     onLog: log,
   });
@@ -458,6 +460,7 @@ export function initInferencePanel() {
   const out = document.getElementById("inference-output");
   const fileInput = document.getElementById("file-input");
   const itersInput = document.getElementById("inference-iters");
+  const warmupInput = document.getElementById("inference-warmup");
   const batchInput = document.getElementById("inference-batch");
   const epSelect = document.getElementById("inference-ep");
   const sourceSelect = document.getElementById("inference-source");
@@ -509,6 +512,10 @@ export function initInferencePanel() {
     try {
       const source = sourceSelect ? sourceSelect.value : "original";
       const iterations = Math.max(1, parseInt(itersInput.value, 10) || 5);
+      // Warm-up passes run before the timed loop and are excluded from the
+      // measured latency, so the reported speed isn't skewed by one-time
+      // compilation/allocation costs. 0 keeps every iteration timed.
+      const warmup = Math.max(0, parseInt(warmupInput ? warmupInput.value : "1", 10) || 0);
       const batch = Math.max(1, parseInt(batchInput ? batchInput.value : "1", 10) || 1);
       const epValue = epSelect.value;
       const { providers, needWebnn } = providersForEp(epValue);
@@ -534,7 +541,7 @@ export function initInferencePanel() {
         const cmp = await runCompare(
           original.bytes,
           converted.bytes,
-          { iterations, batch, providers, needWebnn, profile },
+          { iterations, warmup, batch, providers, needWebnn, profile },
           log,
         );
         log(
@@ -561,7 +568,7 @@ export function initInferencePanel() {
       log(`loading onnxruntime-web ${ORT_VERSION}…`);
       const res = await runOnModel(
         bytes,
-        { iterations, batch, providers, needWebnn, profile },
+        { iterations, warmup, batch, providers, needWebnn, profile },
         log,
       );
       log(

--- a/scripts/convertmodel/inference_core.mjs
+++ b/scripts/convertmodel/inference_core.mjs
@@ -75,6 +75,13 @@ function startWebGpuProfiling(ort) {
 // equal the first) and, if `reference` is given, correctness within `tolerance`.
 // Returns { ep, iterations, timings, avgMs, output, dims, trace? }.
 //
+// `warmup` untimed passes run first (default 1) and are excluded from the
+// reported timings, average, and profiling trace. The first `session.run` pays
+// one-time costs — kernel/program compilation, buffer allocation, JIT warm-up —
+// that don't recur, so counting it would inflate the measured latency; a warm-up
+// pass absorbs that cost and leaves the timed loop measuring steady state. Pass
+// `warmup: 0` to time every iteration (the old behaviour).
+//
 // With `profile: true`, `trace` is a Chrome Trace Event object built from the
 // per-iteration wall timings and (on WebGPU) the per-kernel GPU records.
 export async function runInference(ort, {
@@ -85,6 +92,7 @@ export async function runInference(ort, {
   outputName,
   providers,
   iterations = 5,
+  warmup = 1,
   reference = null,
   tolerance = 1e-4,
   profile = false,
@@ -120,7 +128,17 @@ export async function runInference(ort, {
   let lastDims = null;
   const timings = [];
   const runs = [];
+  const warmupRuns = Math.max(0, warmup | 0);
   try {
+    // Warm-up passes: run but don't time. These absorb the one-time
+    // compilation/allocation costs so they don't skew the measured latency.
+    for (let w = 0; w < warmupRuns; w++) {
+      await session.run(runFeeds);
+      onLog(`warmup ${w}: discarded (not timed)`);
+    }
+    // Drop any kernel spans the warm-up passes emitted so the profiling trace
+    // reflects only the timed iterations.
+    if (gpu) gpu.kernels.length = 0;
     for (let i = 0; i < iterations; i++) {
       const t0 = performance.now();
       const results = await session.run(runFeeds);
@@ -216,6 +234,7 @@ export async function compareInference(ort, {
   outputName,
   providers,
   iterations = 5,
+  warmup = 1,
   tolerance = 1e-3,
   profile = false,
   onLog = () => {},
@@ -231,6 +250,7 @@ export async function compareInference(ort, {
     outputName,
     providers,
     iterations,
+    warmup,
     profile,
     onLog,
   });
@@ -243,6 +263,7 @@ export async function compareInference(ort, {
     outputName,
     providers,
     iterations,
+    warmup,
     profile,
     onLog,
   });


### PR DESCRIPTION
## Summary
Adds a configurable `warmup` parameter to inference benchmarking to exclude one-time initialization costs (kernel compilation, buffer allocation, JIT warm-up) from latency measurements, providing more accurate steady-state performance metrics.

## Changes
- **inference_core.mjs**: 
  - Added `warmup` parameter (default 1) to `runInference()` and `compareInference()` functions
  - Implemented warmup loop that runs untimed passes before the timed iterations
  - Clears GPU kernel records after warmup to exclude them from profiling traces
  - Updated JSDoc to explain warmup behavior and how it improves measurement accuracy

- **inference_browser.mjs**:
  - Threaded `warmup` parameter through `runOnModel()` and `runCompare()` functions
  - Updated UI initialization to read warmup value from input field with sensible defaults

- **index.html**:
  - Added warmup input control (number field, min 0, default 1)
  - Updated help text to explain warmup's purpose and how to disable it (set to 0)
  - Added tooltip describing the feature

## Implementation Details
- Warmup passes are coerced to non-negative integers via `Math.max(0, warmup | 0)`
- GPU kernel spans emitted during warmup are cleared before timed iterations to keep profiling traces clean
- Setting `warmup: 0` preserves the old behavior of timing every iteration
- The feature is transparent to callers; existing code continues to work with the new default of 1 warmup pass

https://claude.ai/code/session_016NGXDNytNEUZrGmf6b8cP4