### PR TITLE
Add input_fill parameter to control test input generation

### DIFF
--- a/.github/workflows/convertmodel-inference.yml
+++ b/.github/workflows/convertmodel-inference.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Run CDN source-of-truth unit test
         working-directory: scripts/convertmodel
         run: npm run test:cdn
+      - name: Run input-fill helper unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:fill
       - name: Run inference smoke test (wasm EP)
         working-directory: scripts/convertmodel
         run: npm run test:inference

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ constant folding until the model stops changing. Around that it offers:
   partial shape evaluation via ONNX data propagation — to unlock more folding.
 - **Correctness checking.** Optionally validates the simplified model against the
   original on `N` random inputs (the positional `check_n` argument, with
-  configurable `--check-rtol`/`--check-atol`).
+  configurable `--check-rtol`/`--check-atol`). Choose how the generated inputs are
+  filled with `--input-fill` (Python: `input_fill=`): `random` (uniform `[0, 1)`,
+  the default), `ones`, `zeros` or `arange`.
 - **Fixed and dynamic input shapes.** Pin a dynamic model's shapes for
   simplification/checking with `--overwrite-input-shape` and `--test-input-shape`.
 - **[Custom operators](#custom-operators).** Keeps custom ops (TensorRT plugins,

--- a/onnxsim/model_checking.py
+++ b/onnxsim/model_checking.py
@@ -11,6 +11,35 @@ Tensors = Dict[str, np.ndarray]
 TensorShape = List[int]
 TensorShapes = Dict[Optional[str], TensorShape]
 
+# How the values of the random test inputs are generated when the user does not
+# supply their own ``input_data``. See ``compare``'s ``input_fill`` parameter.
+INPUT_FILL_CHOICES = ("random", "ones", "zeros", "arange")
+
+
+def _fill_array(shape: TensorShape, np_type: type, input_fill: str) -> np.ndarray:
+    """Create an array of ``shape`` / ``np_type`` filled according to ``input_fill``.
+
+    ``random`` draws from a uniform ``[0, 1)`` distribution (the historical
+    default), ``ones``/``zeros`` fill with the constant, and ``arange`` fills with
+    ``0, 1, 2, ...`` in row-major order, which is handy for reproducible,
+    easy-to-eyeball checks.
+    """
+    if input_fill == "random":
+        values = np.random.rand(*shape)
+    elif input_fill == "ones":
+        values = np.ones(shape)
+    elif input_fill == "zeros":
+        values = np.zeros(shape)
+    elif input_fill == "arange":
+        values = np.arange(int(np.prod(shape, dtype=np.int64))).reshape(shape)
+    else:
+        raise ValueError(
+            'Unknown input_fill "{}", expected one of {}.'.format(
+                input_fill, ", ".join(INPUT_FILL_CHOICES)
+            )
+        )
+    return np.array(values, dtype=np_type)
+
 
 def _iter_graph_nodes(graph: onnx.GraphProto) -> Iterable[onnx.NodeProto]:
     """Yield every node in ``graph``, recursing into subgraph attributes."""
@@ -56,6 +85,7 @@ def compare(
     verbose=True,
     rtol: float = 1e-4,
     atol: float = 1e-5,
+    input_fill: str = "random",
 ) -> bool:
     """
     :param model_opt: The simplified ONNX model
@@ -69,7 +99,17 @@ def compare(
         (correct) op reordering accumulates floating-point error beyond the
         default -- see the RF-DETR XLarge case in ``scripts/rfdetr``.
     :param atol: Absolute tolerance for ``numpy.allclose`` (see ``rtol``).
+    :param input_fill: How to fill the generated test inputs when ``input_data``
+        is not given. One of ``"random"`` (uniform ``[0, 1)``, the default),
+        ``"ones"``, ``"zeros"`` or ``"arange"`` (``0, 1, 2, ...`` in row-major
+        order).
     """
+    if input_fill not in INPUT_FILL_CHOICES:
+        raise ValueError(
+            'Unknown input_fill "{}", expected one of {}.'.format(
+                input_fill, ", ".join(INPUT_FILL_CHOICES)
+            )
+        )
 
     def get_shape_from_value_info_proto(v: onnx.ValueInfoProto) -> List[int]:
         return [dim.dim_value for dim in v.type.tensor_type.shape.dim]
@@ -164,9 +204,10 @@ def compare(
                 shape[0] = 1
 
         inputs = {
-            ipt: np.array(
-                np.random.rand(*full_input_shapes[ipt]),
-                dtype=get_np_type_from_elem_type(get_elem_type(model, ipt)),
+            ipt: _fill_array(
+                full_input_shapes[ipt],
+                get_np_type_from_elem_type(get_elem_type(model, ipt)),
+                input_fill,
             )
             for ipt in input_names
         }

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -383,6 +383,7 @@ def simplify(
     function_rewrite_rules: Optional[Sequence[FunctionRewriteRule]] = None,
     check_rtol: float = 1e-4,
     check_atol: float = 1e-5,
+    input_fill: str = "random",
     providers: Optional[Sequence[backend.Provider]] = None,
     profile: Optional[str] = None,
     ort_profile: Optional[str] = None,
@@ -451,6 +452,11 @@ def simplify(
             enough to accumulate a larger-but-benign difference (e.g. RF-DETR's XLarge segmentation
             variants -- see ``scripts/rfdetr/FAILURE_ANALYSIS.md``). Ignored when ``check_n == 0``.
     :param check_atol: Absolute tolerance counterpart of ``check_rtol``.
+    :param input_fill: How to fill the random inputs generated for the ``check_n``
+            verification when ``input_data`` is not supplied. One of ``"random"``
+            (uniform ``[0, 1)``, the default), ``"ones"``, ``"zeros"`` or ``"arange"``
+            (``0, 1, 2, ...`` in row-major order). Ignored when ``check_n == 0`` or
+            when ``input_data`` is given.
     :param providers: onnxruntime execution providers used to run the model
             during constant folding, in priority order, for example
             ``["CUDAExecutionProvider", "CPUExecutionProvider"]`` to fold on an
@@ -735,6 +741,7 @@ def simplify(
             custom_lib,
             rtol=check_rtol,
             atol=check_atol,
+            input_fill=input_fill,
         )
     except (EncodeError, ValueError, onnx.onnx_cpp2py_export.checker.ValidationError):
         if model is None:
@@ -784,6 +791,7 @@ def simplify(
                 custom_lib,
                 rtol=check_rtol,
                 atol=check_atol,
+                input_fill=input_fill,
             )
             model_opt = onnx.load(os.path.join(tmpdirname, "opt.onnx"))
     finally:
@@ -1003,6 +1011,15 @@ def main():
         help='input data, The value should be "input_name1:xxx1.bin"  "input_name2:xxx2.bin ...", input data should be a binary data file.',
         type=str,
         nargs="+",
+    )
+    parser.add_argument(
+        "--input-fill",
+        help="How to fill the random inputs generated for checking (check_n). "
+        "'random' (uniform [0, 1), the default), 'ones', 'zeros' or 'arange' "
+        "(0, 1, 2, ... in row-major order). Ignored when --input-data-path is given.",
+        type=str,
+        choices=model_checking.INPUT_FILL_CHOICES,
+        default="random",
     )
     parser.add_argument(
         "--custom-lib", help="Deprecated. Not needed any more.", type=str
@@ -1306,6 +1323,7 @@ def main():
         target_opset_version=args.target_opset,
         check_rtol=args.check_rtol,
         check_atol=args.check_atol,
+        input_fill=args.input_fill,
         providers=providers,
         profile=args.profile,
         ort_profile=args.ort_profile,

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -698,6 +698,14 @@ agraph (float[N] X) =&gt; (float[N] Y) {
             <label for="inference-batch">batch</label>
             <input type="number" id="inference-batch" value="1" min="1" style="width: 4em;"
                    title="Size for the model's dynamic batch (first) axis; ignored on fixed-shape inputs.">
+            <label for="inference-fill">input fill</label>
+            <select id="inference-fill"
+                    title="How the auto-generated float inputs are valued (integer/bool inputs stay zero). 'random' varies the input so the before/after compare actually exercises the graph; 'zeros' can mask a divergence. Mirrors the CLI's --input-fill.">
+                <option value="random">random (deterministic)</option>
+                <option value="ones">ones</option>
+                <option value="zeros">zeros</option>
+                <option value="arange">arange (0, 1, 2, …)</option>
+            </select>
             <input type="checkbox" id="inference-profile" checked>
             <label for="inference-profile">profile (Chrome trace)</label>
             <button id="run-inference">Run inference</button>

--- a/scripts/convertmodel/inference_browser.mjs
+++ b/scripts/convertmodel/inference_browser.mjs
@@ -12,6 +12,7 @@
 // finishes); "original" reads the file input directly.
 
 import { runInference, compareInference } from "./inference_core.mjs";
+import { fillInput, INPUT_FILL_MODES } from "./input_fill.mjs";
 import { summarizeOrtTrace } from "./trace_build.mjs";
 import { renderTrace } from "./trace_viewer.mjs";
 import { downloadText } from "./download.mjs";
@@ -79,30 +80,10 @@ function concreteShape(shape, batch = 1) {
   });
 }
 
-// Fill a float typed-array in place with small deterministic pseudo-random
-// values in [-1, 1) (a seeded xorshift32, so every call produces the same
-// sequence). Used by the before/after comparison: all-zero inputs can mask a
-// divergence introduced by a graph change (many ops map 0 -> 0), whereas varied
-// inputs actually exercise the graph. Integer/bool inputs are left at zero,
-// which is the safe default for index-like tensors (Gather, etc.) where an
-// arbitrary value could go out of bounds. Determinism matters because
-// runInference() re-feeds the same tensor every iteration and asserts the output
-// never changes.
-function fillPseudoRandom(arr, type) {
-  if (type !== "float32" && type !== "float64") return; // zeros for ints/bool
-  let s = 0x2545f491; // fixed non-zero seed
-  for (let i = 0; i < arr.length; i++) {
-    // xorshift32 (bitwise ops keep `s` a 32-bit signed int throughout).
-    s ^= s << 13;
-    s ^= s >>> 17;
-    s ^= s << 5;
-    arr[i] = s / 0x80000000; // 32-bit signed / 2^31 -> [-1, 1)
-  }
-}
-
-// Build a feeds object for every model input. `fill` is "zero" (the default,
-// matching a plain single-model run) or "random" (deterministic non-zero float
-// values, used by the compare path so the before/after diff is meaningful).
+// Build a feeds object for every model input. `fill` selects how the float
+// inputs are valued (see input_fill.mjs): "zero" (a plain single-model run),
+// "random" (deterministic non-zero values, the compare path's default so the
+// before/after diff is meaningful), or the user-chosen "ones"/"zeros"/"arange".
 function makeDummyInputs(ort, session, batch = 1, fill = "zero") {
   const feeds = {};
   for (const meta of session.inputMetadata) {
@@ -113,8 +94,7 @@ function makeDummyInputs(ort, session, batch = 1, fill = "zero") {
     const count = dims.reduce((a, b) => a * b, 1);
     const Ctor = TYPED_ARRAY[meta.type];
     if (!Ctor) throw new Error(`unsupported input type '${meta.type}'`);
-    const buf = new Ctor(count);
-    if (fill === "random") fillPseudoRandom(buf, meta.type);
+    const buf = fillInput(new Ctor(count), meta.type, fill);
     feeds[meta.name] = new ort.Tensor(meta.type, buf, dims);
   }
   return feeds;
@@ -145,17 +125,21 @@ async function prepareInputs(ort, modelBytes, batch, fill, log) {
   return { feeds, inputName, leadMeta, leadingDynamic };
 }
 
-async function runOnModel(modelBytes, { iterations, batch, providers, needWebnn, profile }, log) {
+async function runOnModel(
+  modelBytes,
+  { iterations, batch, providers, needWebnn, profile, fill = "zero" },
+  log,
+) {
   const ort = await loadOrt(needWebnn ? "all" : "default");
 
   const { feeds, inputName, leadingDynamic } = await prepareInputs(
     ort,
     modelBytes,
     batch,
-    "zero",
+    fill,
     log,
   );
-  log(`input '${inputName}' dims [${feeds[inputName].dims.join(", ")}]`);
+  log(`input '${inputName}' dims [${feeds[inputName].dims.join(", ")}] (fill=${fill})`);
 
   const res = await runInference(ort, {
     model: modelBytes,
@@ -185,7 +169,7 @@ async function runOnModel(modelBytes, { iterations, batch, providers, needWebnn,
 async function runCompare(
   originalBytes,
   convertedBytes,
-  { iterations, batch, providers, needWebnn, profile },
+  { iterations, batch, providers, needWebnn, profile, fill = "random" },
   log,
 ) {
   const ort = await loadOrt(needWebnn ? "all" : "default");
@@ -194,11 +178,14 @@ async function runCompare(
     ort,
     originalBytes,
     batch,
-    "random",
+    fill,
     log,
   );
   const input = feeds[inputName];
-  log(`shared input '${inputName}' dims [${input.dims.join(", ")}] (deterministic)`);
+  log(
+    `shared input '${inputName}' dims [${input.dims.join(", ")}] ` +
+      `(deterministic, fill=${fill})`,
+  );
 
   const cmp = await compareInference(ort, {
     before: { model: originalBytes, label: "original" },
@@ -461,6 +448,7 @@ export function initInferencePanel() {
   const batchInput = document.getElementById("inference-batch");
   const epSelect = document.getElementById("inference-ep");
   const sourceSelect = document.getElementById("inference-source");
+  const fillSelect = document.getElementById("inference-fill");
   const profileChk = document.getElementById("inference-profile");
   const traceContainer = document.getElementById("inference-trace");
   const macsContainer = document.getElementById("inference-macs");
@@ -513,6 +501,11 @@ export function initInferencePanel() {
       const epValue = epSelect.value;
       const { providers, needWebnn } = providersForEp(epValue);
       const profile = !profileChk || profileChk.checked;
+      // How the auto-generated float inputs are valued (input_fill.mjs). Guard
+      // against an unexpected value so a stale/edited DOM can't feed a bad mode
+      // into the fill routine.
+      const fillValue = fillSelect ? fillSelect.value : "random";
+      const fill = INPUT_FILL_MODES.includes(fillValue) ? fillValue : "random";
 
       if (isWebnnEp(epValue)) {
         log(
@@ -534,7 +527,7 @@ export function initInferencePanel() {
         const cmp = await runCompare(
           original.bytes,
           converted.bytes,
-          { iterations, batch, providers, needWebnn, profile },
+          { iterations, batch, providers, needWebnn, profile, fill },
           log,
         );
         log(
@@ -561,7 +554,7 @@ export function initInferencePanel() {
       log(`loading onnxruntime-web ${ORT_VERSION}…`);
       const res = await runOnModel(
         bytes,
-        { iterations, batch, providers, needWebnn, profile },
+        { iterations, batch, providers, needWebnn, profile, fill },
         log,
       );
       log(

--- a/scripts/convertmodel/input_fill.mjs
+++ b/scripts/convertmodel/input_fill.mjs
@@ -1,0 +1,48 @@
+// Fill modes for the dummy inputs the "Run inference" panel auto-generates.
+//
+// Mirrors the Python CLI's `--input-fill` option (see
+// onnxsim.model_checking.INPUT_FILL_CHOICES): the same names produce analogous
+// values so the in-browser check and the command-line check agree on what they
+// feed a model. The before/after comparison uses this to build ONE shared input
+// and run it through both models, so the fill choice decides how hard the graph
+// change is exercised — all-zero inputs can mask a divergence (many ops map
+// 0 -> 0), whereas varied inputs (random/ones/arange) actually stress it.
+//
+// Only float inputs receive the requested values; integer/bool inputs are left
+// at zero, the safe default for index-like tensors (Gather, etc.) where an
+// arbitrary value could index out of bounds. "random" is a seeded xorshift32,
+// so every call yields the identical sequence: runInference() re-feeds the same
+// tensor each iteration and asserts the output never changes.
+
+// The selectable fill modes, in the order shown in the UI dropdown. Kept in
+// sync with the Python side's INPUT_FILL_CHOICES.
+export const INPUT_FILL_MODES = ["random", "ones", "zeros", "arange"];
+
+// Fill `arr` (a typed array) in place according to `fill`, for an input of the
+// given onnxruntime element `type` ("float32", "int64", ...). Returns `arr`.
+// "zero"/"zeros" and any integer/bool input are left untouched (already zeroed
+// by the typed-array constructor). Throws on an unknown mode.
+export function fillInput(arr, type, fill) {
+  const isFloat = type === "float32" || type === "float64";
+  // Integer/bool tensors always stay zero-filled (see file header); "zero" and
+  // "zeros" are an explicit request for an all-zero float tensor.
+  if (!isFloat || fill === "zero" || fill === "zeros") return arr;
+  if (fill === "ones") {
+    arr.fill(1);
+  } else if (fill === "arange") {
+    // 0, 1, 2, ... in row-major order, matching numpy's np.arange fill.
+    for (let i = 0; i < arr.length; i++) arr[i] = i;
+  } else if (fill === "random") {
+    let s = 0x2545f491; // fixed non-zero seed
+    for (let i = 0; i < arr.length; i++) {
+      // xorshift32 (bitwise ops keep `s` a 32-bit signed int throughout).
+      s ^= s << 13;
+      s ^= s >>> 17;
+      s ^= s << 5;
+      arr[i] = s / 0x80000000; // 32-bit signed / 2^31 -> [-1, 1)
+    }
+  } else {
+    throw new Error(`unknown input fill '${fill}'`);
+  }
+  return arr;
+}

--- a/scripts/convertmodel/package.json
+++ b/scripts/convertmodel/package.json
@@ -19,7 +19,8 @@
     "test:query": "node test/query_params.test.mjs",
     "test:webnn": "node test/webnn.test.mjs",
     "test:cdn": "node test/cdn.test.mjs",
-    "test:all": "npm run test:netron && npm run test:trace && npm run test:macs && npm run test:shapes && npm run test:hf && npm run test:xet && npm run test:issue && npm run test:versions && npm run test:backend && npm run test:query && npm run test:webnn && npm run test:cdn && npm run test:inference && npm run test:compare",
+    "test:fill": "node test/input_fill.test.mjs",
+    "test:all": "npm run test:netron && npm run test:trace && npm run test:macs && npm run test:shapes && npm run test:hf && npm run test:xet && npm run test:issue && npm run test:versions && npm run test:backend && npm run test:query && npm run test:webnn && npm run test:cdn && npm run test:fill && npm run test:inference && npm run test:compare",
     "coverage": "c8 npm run test:all"
   },
   "dependencies": {

--- a/scripts/convertmodel/test/input_fill.test.mjs
+++ b/scripts/convertmodel/test/input_fill.test.mjs
@@ -1,0 +1,99 @@
+// Unit test for the "Run inference" panel's input-fill helper (input_fill.mjs).
+//
+// The panel auto-generates dummy inputs for the before/after comparison and for
+// single-model runs; `fillInput` decides how the float inputs are valued. This
+// checks each selectable mode (random/ones/zeros/arange), the safe zero default
+// for integer/bool inputs, random determinism (the panel re-feeds the same
+// tensor every iteration and asserts a stable output), and the unknown-mode
+// guard.
+//
+// Pure JS, no onnxruntime — runs anywhere node does.
+//
+// Usage:
+//   node test/input_fill.test.mjs
+
+import assert from "node:assert/strict";
+import { fillInput, INPUT_FILL_MODES } from "../input_fill.mjs";
+
+function testModes() {
+  // ones fills every float slot with 1.
+  assert.deepEqual(
+    Array.from(fillInput(new Float32Array(4), "float32", "ones")),
+    [1, 1, 1, 1],
+  );
+  // arange is 0, 1, 2, ... in row-major order.
+  assert.deepEqual(
+    Array.from(fillInput(new Float32Array(4), "float32", "arange")),
+    [0, 1, 2, 3],
+  );
+  // zeros / zero leave the (already zeroed) buffer untouched.
+  for (const mode of ["zeros", "zero"]) {
+    assert.deepEqual(
+      Array.from(fillInput(new Float32Array(3), "float32", mode)),
+      [0, 0, 0],
+      `${mode} stays all-zero`,
+    );
+  }
+  // float64 is treated as a float too.
+  assert.deepEqual(
+    Array.from(fillInput(new Float64Array(2), "float64", "ones")),
+    [1, 1],
+  );
+  console.log("PASS modes: ones / arange / zeros produce the expected values");
+}
+
+function testRandom() {
+  const a = fillInput(new Float32Array(8), "float32", "random");
+  const b = fillInput(new Float32Array(8), "float32", "random");
+  // Seeded xorshift32: identical across calls (determinism the panel relies on).
+  assert.deepEqual(Array.from(a), Array.from(b), "random is deterministic");
+  // Non-trivial: not all zero, and within [-1, 1).
+  assert.ok(
+    Array.from(a).some((v) => v !== 0),
+    "random produces non-zero values",
+  );
+  assert.ok(
+    Array.from(a).every((v) => v >= -1 && v < 1),
+    "random values fall in [-1, 1)",
+  );
+  console.log("PASS random: deterministic, non-zero, in [-1, 1)");
+}
+
+function testIntegerAndBoolStayZero() {
+  // Integer/bool inputs are always left at zero regardless of the mode, the
+  // safe default for index-like tensors (Gather, etc.).
+  for (const [type, Ctor] of [
+    ["int64", BigInt64Array],
+    ["int32", Int32Array],
+    ["bool", Uint8Array],
+  ]) {
+    for (const mode of INPUT_FILL_MODES) {
+      const out = fillInput(new Ctor(4), type, mode);
+      assert.ok(
+        Array.from(out).every((v) => v == 0),
+        `${type} stays zero under '${mode}'`,
+      );
+    }
+  }
+  console.log("PASS integer/bool: left at zero for every fill mode");
+}
+
+function testUnknownModeThrows() {
+  assert.throws(
+    () => fillInput(new Float32Array(2), "float32", "bogus"),
+    /unknown input fill/,
+    "an unknown mode is rejected",
+  );
+  console.log("PASS guard: unknown fill mode throws");
+}
+
+function main() {
+  assert.deepEqual(INPUT_FILL_MODES, ["random", "ones", "zeros", "arange"]);
+  testModes();
+  testRandom();
+  testIntegerAndBoolStayZero();
+  testUnknownModeThrows();
+  console.log("PASS input_fill: all checks");
+}
+
+main();

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -1330,6 +1330,57 @@ def test_compare_respects_check_tolerance():
     )
 
 
+def test_compare_input_fill_modes():
+    # The random test inputs can be filled several ways. Capture what compare()
+    # actually feeds the model by intercepting the backend run.
+    from onnxsim import backend, model_checking
+
+    model = _add_const_model(0.0)
+    captured = {}
+
+    def fake_run_model(m, inputs, custom_lib=None):
+        captured["inputs"] = inputs
+        return {"y": inputs["x"]}
+
+    for fill, expected in (
+        ("ones", np.ones((1, 4), dtype=np.float32)),
+        ("zeros", np.zeros((1, 4), dtype=np.float32)),
+        ("arange", np.arange(4, dtype=np.float32).reshape(1, 4)),
+    ):
+        import unittest.mock
+
+        with unittest.mock.patch.object(backend, "run_model", fake_run_model):
+            assert model_checking.compare(
+                model, model, n_times=1, verbose=False, input_fill=fill
+            )
+        np.testing.assert_array_equal(captured["inputs"]["x"], expected)
+
+
+def test_compare_rejects_unknown_input_fill():
+    from onnxsim import model_checking
+
+    with pytest.raises(ValueError):
+        model_checking.compare(
+            _add_const_model(0.0), _add_const_model(0.0), n_times=1, input_fill="bogus"
+        )
+
+
+def test_simplify_threads_input_fill(monkeypatch):
+    # simplify() must forward input_fill into model_checking.compare.
+    from onnxsim import model_checking
+
+    captured = {}
+
+    def fake_compare(model_opt, model_ori, n_times, *args, **kwargs):
+        captured["input_fill"] = kwargs.get("input_fill")
+        return True
+
+    monkeypatch.setattr(model_checking, "compare", fake_compare)
+
+    onnxsim.simplify(_add_const_model(0.0), check_n=1, input_fill="arange")
+    assert captured == {"input_fill": "arange"}
+
+
 def test_simplify_threads_check_tolerance(monkeypatch):
     # simplify() must forward check_rtol/check_atol into model_checking.compare.
     from onnxsim import model_checking


### PR DESCRIPTION
## Summary
Adds a new `input_fill` parameter to control how random test inputs are generated during model correctness checking. This allows users to choose between random values, ones, zeros, or sequential arange values for more reproducible and debuggable testing.

## Key Changes
- **New `_fill_array()` helper function** in `model_checking.py` that generates arrays according to the specified fill mode (`random`, `ones`, `zeros`, or `arange`)
- **`input_fill` parameter added to `compare()`** function with validation against allowed choices
- **`input_fill` parameter added to `simplify()`** function and properly threaded through to `compare()` calls
- **CLI support** via new `--input-fill` argument in the command-line interface
- **Documentation updates** in README.md explaining the new parameter and its options
- **Comprehensive test coverage** including:
  - Test verifying each fill mode produces expected arrays
  - Test ensuring invalid fill modes are rejected
  - Test confirming `simplify()` properly forwards the parameter to `compare()`

## Implementation Details
- The `arange` fill mode is particularly useful for reproducible, easy-to-eyeball checks as it fills with sequential values `0, 1, 2, ...` in row-major order
- Default behavior remains `random` (uniform `[0, 1)` distribution) for backward compatibility
- Parameter is properly ignored when `input_data` is explicitly provided by the user
- Validation occurs early in `compare()` to catch invalid choices immediately

https://claude.ai/code/session_01SPqhFo9x4bcy8sJhZVdRZw