### PR TITLE
Add auto-run inference option after model conversion

### DIFF
--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -388,6 +388,8 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                 <code>inline_functions</code>/<code>inline</code>,
                 <code>tensor_size_threshold</code>/<code>tst</code>,
                 <code>target_opset</code>/<code>opset</code>,
+                <code>autorun</code>/<code>autoinfer</code> (auto-run inference
+                after each conversion),
                 <code>backend</code> (prefills the backend-test URL). Setting an
                 input updates this URL so it stays shareable (uploads excepted).
                 <div style="margin-top: 0.35em;">
@@ -654,7 +656,10 @@ agraph (float[N] X) =&gt; (float[N] Y) {
             just the <b>converted</b> result or the <b>original</b> upload on
             their own. The <b>batch</b> control sizes the model's dynamic batch
             (first) axis; it has no effect on inputs whose first dimension is
-            fixed. WebGPU falls back to WebAssembly when unavailable.
+            fixed. WebGPU falls back to WebAssembly when unavailable. Tick
+            <b>auto-run after each conversion</b> to run this panel automatically
+            whenever a conversion finishes (with the options selected here),
+            instead of clicking <b>Run inference</b> each time.
         </p>
         <p>
             The execution-provider picker also offers
@@ -700,6 +705,8 @@ agraph (float[N] X) =&gt; (float[N] Y) {
                    title="Size for the model's dynamic batch (first) axis; ignored on fixed-shape inputs.">
             <input type="checkbox" id="inference-profile" checked>
             <label for="inference-profile">profile (Chrome trace)</label>
+            <input type="checkbox" id="inference-autorun">
+            <label for="inference-autorun" title="Run this inference panel automatically each time a conversion finishes, using the model / execution provider / iterations / batch selected here. Off by default; a run downloads onnxruntime-web and executes the model.">auto-run after each conversion</label>
             <button id="run-inference">Run inference</button>
             <button id="download-inference-log-button" type="button">Download log</button>
         </div>

--- a/scripts/convertmodel/inference_browser.mjs
+++ b/scripts/convertmodel/inference_browser.mjs
@@ -462,6 +462,7 @@ export function initInferencePanel() {
   const epSelect = document.getElementById("inference-ep");
   const sourceSelect = document.getElementById("inference-source");
   const profileChk = document.getElementById("inference-profile");
+  const autoRunChk = document.getElementById("inference-autorun");
   const traceContainer = document.getElementById("inference-trace");
   const macsContainer = document.getElementById("inference-macs");
   const dlLogBtn = document.getElementById("download-inference-log-button");
@@ -501,7 +502,12 @@ export function initInferencePanel() {
     });
   }
 
-  btn.addEventListener("click", async () => {
+  // Run the inference panel once, honoring the currently-selected controls.
+  // Shared by the "Run inference" button and the "auto-run after each
+  // conversion" option below; the button's disabled state doubles as a simple
+  // re-entrancy guard so overlapping runs can't interleave.
+  const runOnce = async () => {
+    if (btn.disabled) return;
     btn.disabled = true;
     out.value = "";
     if (traceContainer) traceContainer.innerHTML = "";
@@ -591,7 +597,25 @@ export function initInferencePanel() {
     } finally {
       btn.disabled = false;
     }
-  });
+  };
+
+  btn.addEventListener("click", runOnce);
+
+  // "auto-run after each conversion": when enabled, run this panel
+  // automatically every time a conversion finishes, using the options selected
+  // here. index.html dispatches `onnxsim:converted` on window once the worker
+  // returns — and, right after (synchronously), `onnxsim:original-annotated`.
+  // Defer to a macrotask so the whole convert-done handler finishes first,
+  // ensuring both the converted and MAC-annotated-original bytes are published
+  // before a "compare (before vs after)" run reads them.
+  if (autoRunChk) {
+    window.addEventListener("onnxsim:converted", () => {
+      if (!autoRunChk.checked || btn.disabled) return;
+      setTimeout(() => {
+        if (autoRunChk.checked && !btn.disabled) runOnce();
+      }, 0);
+    });
+  }
 }
 
 initInferencePanel();

--- a/scripts/convertmodel/query_params.mjs
+++ b/scripts/convertmodel/query_params.mjs
@@ -18,6 +18,8 @@
 //   inline_functions (inline) — boolean: inline local functions before the
 //     simplify / optimize / fixed-optimize transform.
 //   tensor_size_threshold (tst), target_opset (opset) — integers.
+//   autorun (autoinfer, autorun_inference) — boolean: auto-run the "Run
+//     inference" panel each time a conversion finishes.
 
 // Parse a boolean-ish value: an empty value (a bare `?cf`) means "on"; returns
 // null for absent or unrecognized so callers can tell "not set" from false.
@@ -82,6 +84,9 @@ export function parseInputParams(search) {
     inlineFunctions: toBool(first("inline_functions", "inline")),
     tensorSizeThreshold: toInt(first("tensor_size_threshold", "tst")),
     targetOpset: toInt(first("target_opset", "opset")),
+    // Whether to auto-run the "Run inference" panel after each conversion
+    // (the "auto-run after each conversion" checkbox).
+    autoRunInference: toBool(first("autorun", "autoinfer", "autorun_inference")),
   };
 }
 
@@ -158,6 +163,7 @@ const OPTION_DEFAULTS = {
   shapeInference: true, // #id_simplify_shape_inference checked
   tensorSizeThreshold: 1000000000, // #id_simplify_tensor_size_threshold
   targetOpset: 0, // #id_simplify_target_opset (0 = keep current opset)
+  autoRunInference: false, // #inference-autorun unchecked
 };
 
 // Build a complete shareable query string from the current converter state.
@@ -179,6 +185,7 @@ export function buildShareSearch(search, doc) {
   };
   setBool("id_simplify_constant_fold", "cf", OPTION_DEFAULTS.constantFold);
   setBool("id_simplify_shape_inference", "si", OPTION_DEFAULTS.shapeInference);
+  setBool("inference-autorun", "autorun", OPTION_DEFAULTS.autoRunInference);
   // Numeric options: emit only when meaningful (present and non-default).
   const tst = doc.getElementById("id_simplify_tensor_size_threshold");
   if (tst) {
@@ -226,6 +233,7 @@ export function applyOptionParams(params, doc) {
   setChecked("id_simplify_constant_fold", params.constantFold);
   setChecked("id_simplify_shape_inference", params.shapeInference);
   setChecked("id_inline_functions", params.inlineFunctions);
+  setChecked("inference-autorun", params.autoRunInference);
   setValue("id_simplify_tensor_size_threshold", params.tensorSizeThreshold);
   setValue("id_simplify_target_opset", params.targetOpset);
   return changed;

--- a/scripts/convertmodel/test/query_params.test.mjs
+++ b/scripts/convertmodel/test/query_params.test.mjs
@@ -80,6 +80,16 @@ check("parses the inline_functions flag and its alias", () => {
   assert.equal(parseInputParams("?inline=off").inlineFunctions, false);
 });
 
+check("parses the autorun (auto-run inference) flag and its aliases", () => {
+  // Absent → null so callers can tell "not set" from off.
+  assert.equal(parseInputParams("?model=x").autoRunInference, null);
+  assert.equal(parseInputParams("?autorun=1").autoRunInference, true);
+  assert.equal(parseInputParams("?autorun").autoRunInference, true); // bare flag = on
+  assert.equal(parseInputParams("?autorun=0").autoRunInference, false);
+  assert.equal(parseInputParams("?autoinfer=on").autoRunInference, true);
+  assert.equal(parseInputParams("?autorun_inference=false").autoRunInference, false);
+});
+
 check("optimizer accepts mode/processor/opt aliases", () => {
   assert.equal(parseInputParams("?mode=simplify").optimizer, "simplify");
   assert.equal(parseInputParams("?processor=fold_constant").optimizer, "fold_constant");
@@ -114,8 +124,9 @@ check("applyOptionParams prefills only the given controls", () => {
     "id_inline_functions",
     "id_simplify_tensor_size_threshold",
     "id_simplify_target_opset",
+    "inference-autorun",
   ]);
-  const params = parseInputParams("?optimizer=optimize&cf=0&si=1&inline=1&tst=1000&opset=18");
+  const params = parseInputParams("?optimizer=optimize&cf=0&si=1&inline=1&tst=1000&opset=18&autorun=1");
   const changed = applyOptionParams(params, doc);
   assert.equal(doc.els.optimizer_optimize.checked, true);
   assert.equal(doc.els.id_simplify_constant_fold.checked, false);
@@ -123,8 +134,10 @@ check("applyOptionParams prefills only the given controls", () => {
   assert.equal(doc.els.id_inline_functions.checked, true);
   assert.equal(doc.els.id_simplify_tensor_size_threshold.value, "1000");
   assert.equal(doc.els.id_simplify_target_opset.value, "18");
+  assert.equal(doc.els["inference-autorun"].checked, true);
   assert.ok(changed.includes("optimizer_optimize"));
   assert.ok(changed.includes("id_inline_functions"));
+  assert.ok(changed.includes("inference-autorun"));
 });
 
 check("applyOptionParams leaves untouched controls alone", () => {
@@ -183,6 +196,7 @@ function shareDoc(opts = {}) {
     id_simplify_shape_inference: { checked: opts.shapeInference ?? true },
     id_simplify_tensor_size_threshold: { value: String(opts.tst ?? 1000000000) },
     id_simplify_target_opset: { value: String(opts.opset ?? 0) },
+    "inference-autorun": { checked: opts.autoRunInference ?? false },
   };
   return {
     getElementById: (id) => els[id] || null,
@@ -201,6 +215,7 @@ check("buildShareSearch keeps a compact URL when all options are default", () =>
   assert.equal(p.get("si"), null);
   assert.equal(p.get("tst"), null);
   assert.equal(p.get("opset"), null);
+  assert.equal(p.get("autorun"), null); // unchecked (default) → dropped
 });
 
 check("buildShareSearch encodes every changed option", () => {
@@ -210,6 +225,7 @@ check("buildShareSearch encodes every changed option", () => {
     shapeInference: false,
     tst: 500000,
     opset: 18,
+    autoRunInference: true,
   });
   const s = buildShareSearch("?model=owner/repo", doc);
   const p = new URLSearchParams(s);
@@ -219,6 +235,7 @@ check("buildShareSearch encodes every changed option", () => {
   assert.equal(p.get("si"), "0");
   assert.equal(p.get("tst"), "500000");
   assert.equal(p.get("opset"), "18");
+  assert.equal(p.get("autorun"), "1"); // checked → emitted
 });
 
 check("buildShareSearch round-trips through parseInputParams", () => {


### PR DESCRIPTION
## Summary
Adds an "auto-run after each conversion" checkbox to the inference panel that automatically runs inference whenever a model conversion completes, using the currently-selected inference options.

## Key Changes
- **inference_browser.mjs**: Refactored the inference run logic into a reusable `runOnce()` function that can be called both by the "Run inference" button and automatically after conversions. Added an event listener for the `onnxsim:converted` event that triggers inference when the auto-run checkbox is enabled.
- **index.html**: Added the "auto-run after each conversion" checkbox (`inference-autorun`) to the inference panel UI with explanatory tooltip and help text.
- **query_params.mjs**: Extended query parameter parsing and URL building to support the `autorun`/`autoinfer`/`autorun_inference` flags, allowing users to share URLs with auto-run pre-enabled. Added `autoRunInference` to the option defaults and parameter handling.
- **query_params.test.mjs**: Added comprehensive test coverage for parsing the autorun flag, applying it to UI controls, and round-tripping through the shareable URL builder.

## Implementation Details
- The auto-run uses a macrotask (`setTimeout(..., 0)`) to defer execution until after the conversion handler completes, ensuring both the converted model bytes and MAC-annotated original are available before inference runs.
- The button's disabled state serves as a simple re-entrancy guard to prevent overlapping inference runs.
- The feature is disabled by default and can be enabled via checkbox or query parameter, making it shareable via URL.

https://claude.ai/code/session_01XP5XAsb8GQioM6XX3JNxrH