### PR TITLE
Surface WebNN device probe errors to console and report

### DIFF
--- a/docs/webnn.md
+++ b/docs/webnn.md
@@ -38,7 +38,11 @@ in `test/webnn.test.mjs`):
 - **`detectWebnn(navigator)`** probes `navigator.ml` at page load, attempting to
   create an `MLContext` for each device type (`gpu`, `npu`, `cpu`). The panel
   renders the result as a live **WebNN status** line under the inference
-  controls, so a visitor can see whether WebNN will run before selecting it.
+  controls, so a visitor can see whether WebNN will run before selecting it. When
+  a device type can't be created, the underlying WebNN error is **logged to the
+  browser console** (and captured in the report so the status line's tooltip
+  shows the reason), so a failure the one-line status can only summarize is
+  debuggable in DevTools.
 - **`providersForEp(value)`** maps each EP dropdown choice to an ordered
   onnxruntime-web provider list. The WebNN choices are:
 

--- a/docs/webnn.md
+++ b/docs/webnn.md
@@ -57,6 +57,21 @@ in `test/webnn.test.mjs`):
   particular operator — is unsupported. `inference_core.mjs` reports which
   provider actually won (e.g. `webnn:gpu` or the `wasm` fallback).
 
+- **`captureOrtDiagnostics(...)`** (in `ort_log_capture.mjs`, unit-tested in
+  `test/ort_log_capture.test.mjs`) mirrors onnxruntime-web's *own* diagnostics
+  into the panel's on-page log while a run is active. Some ORT messages never
+  reach the panel's `try/catch`, so before this they were visible only in the
+  browser devtools console: EP-assignment notes
+  (`VerifyEachNodeIsAssignedToAnEp …`) are printed straight to
+  `console.warn`/`console.error` from the wasm module, and WebNN backend
+  failures (e.g. `WebNN backend does not support data type: int64`) are thrown
+  on an internal ORT promise that isn't chained to the awaited `session.run()`,
+  so they surface as an *uncaught* promise rejection. The helper wraps
+  `console.warn`/`console.error` and listens for `unhandledrejection` for the
+  duration of the run, forwarding the `onnxruntime`/`webnn` ones to the log
+  (devtools output is preserved). This is why WebNN falls back to `wasm` silently
+  yet the reason now shows up in the panel too.
+
 - The WebNN provider lives only in the "all" onnxruntime-web bundle, so the
   panel loads `ort.all.min.mjs` on demand the first time a WebNN EP is selected,
   and keeps the smaller default bundle for the common WebGPU/WASM path. Both

--- a/scripts/convertmodel/.c8rc.json
+++ b/scripts/convertmodel/.c8rc.json
@@ -14,6 +14,7 @@
     "macs.mjs",
     "shapes.mjs",
     "netron.mjs",
+    "ort_log_capture.mjs",
     "query_params.mjs",
     "trace_build.mjs",
     "versions.mjs",

--- a/scripts/convertmodel/inference_browser.mjs
+++ b/scripts/convertmodel/inference_browser.mjs
@@ -16,6 +16,7 @@ import { summarizeOrtTrace } from "./trace_build.mjs";
 import { renderTrace } from "./trace_viewer.mjs";
 import { downloadText } from "./download.mjs";
 import { providersForEp, isWebnnEp, detectWebnn, formatWebnnStatus } from "./webnn.mjs";
+import { captureOrtDiagnostics } from "./ort_log_capture.mjs";
 import { ORT_VERSION, ORT_BASE } from "./cdn.mjs";
 import {
   readAnnotations,
@@ -517,6 +518,12 @@ export function initInferencePanel() {
     out.value = "";
     if (traceContainer) traceContainer.innerHTML = "";
     if (macsContainer) macsContainer.innerHTML = "";
+    // Mirror onnxruntime-web's own console diagnostics and unhandled WebNN/ORT
+    // promise rejections into this panel's log for the duration of the run —
+    // e.g. "WebNN backend does not support data type: int64", which ORT throws
+    // on an internal promise that bypasses the try/catch below and otherwise
+    // only shows in devtools. restoreOrtLogs() is called in finally.
+    const restoreOrtLogs = captureOrtDiagnostics({ log });
     try {
       const source = sourceSelect ? sourceSelect.value : "original";
       const iterations = Math.max(1, parseInt(itersInput.value, 10) || 5);
@@ -604,6 +611,11 @@ export function initInferencePanel() {
     } catch (e) {
       log("FAIL: " + (e && e.message ? e.message : String(e)));
     } finally {
+      // Give any WebNN/ORT rejection queued during the run a microtask to fire
+      // (unhandledrejection is dispatched asynchronously) so it's still mirrored
+      // before the console/handler hooks are removed.
+      await Promise.resolve();
+      restoreOrtLogs();
       btn.disabled = false;
     }
   });

--- a/scripts/convertmodel/inference_browser.mjs
+++ b/scripts/convertmodel/inference_browser.mjs
@@ -486,9 +486,17 @@ export function initInferencePanel() {
     detectWebnn()
       .then((report) => {
         webnnStatusEl.textContent = formatWebnnStatus(report);
+        // Show per-device availability in the tooltip, appending the failure
+        // reason (captured by detectWebnn) for any device that couldn't be
+        // created — the full errors are also logged to the browser console.
         webnnStatusEl.title = report.apiPresent
           ? `device availability — ${["gpu", "npu", "cpu"]
-              .map((d) => `${d}: ${report.devices[d] ? "yes" : "no"}`)
+              .map((d) => {
+                const err = report.errors && report.errors[d];
+                return `${d}: ${report.devices[d] ? "yes" : "no"}${
+                  err ? ` (${err})` : ""
+                }`;
+              })
               .join(", ")}`
           : "";
       })

--- a/scripts/convertmodel/ort_log_capture.mjs
+++ b/scripts/convertmodel/ort_log_capture.mjs
@@ -1,0 +1,94 @@
+// Mirror onnxruntime-web's own diagnostics into the inference panel's UI log.
+//
+// Some onnxruntime-web errors never reach the panel's try/catch, so they only
+// appear in the browser devtools console — not the on-page "console" textarea:
+//
+//   * EP-assignment notes ("Some nodes were not assigned to the preferred
+//     execution providers …", "VerifyEachNodeIsAssignedToAnEp") are printed
+//     straight to console.error/console.warn from inside the wasm module.
+//   * WebNN backend failures ("WebNN backend does not support data type:
+//     int64") are thrown on an internal ORT promise that isn't chained to the
+//     awaited session.run(), so they surface as an *uncaught* promise rejection
+//     rather than rejecting the run the panel awaits.
+//
+// captureOrtDiagnostics() wraps console.warn/console.error and listens for
+// unhandledrejection while a run is active, forwarding the onnxruntime/WebNN
+// ones to a provided sink (the panel log). The console output is preserved, so
+// devtools still shows everything it did before. The pure pieces take injected
+// console/target so they can be unit-tested under Node.
+
+// onnxruntime-web tags these messages with the library or backend name; match on
+// that so unrelated page logging (or another library's console noise) is not
+// mirrored into the inference log.
+const ORT_DIAGNOSTIC_RE = /onnxruntime|webnn/i;
+
+// True when a flattened message looks like one of onnxruntime-web's own
+// diagnostics we want mirrored into the panel log.
+export function isOrtDiagnostic(text) {
+  return typeof text === "string" && ORT_DIAGNOSTIC_RE.test(text);
+}
+
+// Normalize one console argument / rejection reason to a string. Errors show
+// their message, plain strings pass through, everything else is JSON- (or
+// String-) stringified so objects still contribute something matchable.
+export function valueToText(v) {
+  if (v instanceof Error) return v.message || String(v);
+  if (typeof v === "string") return v;
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+}
+
+// Flatten a console argument list to a single space-joined string.
+export function formatLogArgs(args) {
+  return (args || []).map(valueToText).join(" ");
+}
+
+// Install console.warn/console.error wrappers and an unhandledrejection listener
+// that forward onnxruntime-web's own diagnostics to `log`. Returns a restore()
+// that removes every hook; call it in a finally so the global console/handlers
+// are always put back. `con`/`target` are injectable for testing (default to the
+// page's console and window).
+export function captureOrtDiagnostics({
+  log,
+  con = typeof console !== "undefined" ? console : undefined,
+  target = typeof window !== "undefined" ? window : undefined,
+} = {}) {
+  const restores = [];
+
+  if (con) {
+    for (const level of ["warn", "error"]) {
+      const original = con[level];
+      if (typeof original !== "function") continue;
+      con[level] = (...args) => {
+        // Preserve devtools output unchanged.
+        original.apply(con, args);
+        const text = formatLogArgs(args);
+        if (isOrtDiagnostic(text)) log(`onnxruntime-web ${level}: ${text}`);
+      };
+      restores.push(() => {
+        con[level] = original;
+      });
+    }
+  }
+
+  if (target && typeof target.addEventListener === "function") {
+    const onRejection = (event) => {
+      const text = valueToText(event && event.reason);
+      if (isOrtDiagnostic(text)) {
+        log(`onnxruntime-web unhandled rejection: ${text}`);
+      }
+    };
+    target.addEventListener("unhandledrejection", onRejection);
+    restores.push(() =>
+      target.removeEventListener("unhandledrejection", onRejection),
+    );
+  }
+
+  return () => {
+    for (const restore of restores) restore();
+    restores.length = 0;
+  };
+}

--- a/scripts/convertmodel/package.json
+++ b/scripts/convertmodel/package.json
@@ -18,8 +18,9 @@
     "test:backend": "node test/backend_test.test.mjs",
     "test:query": "node test/query_params.test.mjs",
     "test:webnn": "node test/webnn.test.mjs",
+    "test:ortlog": "node test/ort_log_capture.test.mjs",
     "test:cdn": "node test/cdn.test.mjs",
-    "test:all": "npm run test:netron && npm run test:trace && npm run test:macs && npm run test:shapes && npm run test:hf && npm run test:xet && npm run test:issue && npm run test:versions && npm run test:backend && npm run test:query && npm run test:webnn && npm run test:cdn && npm run test:inference && npm run test:compare",
+    "test:all": "npm run test:netron && npm run test:trace && npm run test:macs && npm run test:shapes && npm run test:hf && npm run test:xet && npm run test:issue && npm run test:versions && npm run test:backend && npm run test:query && npm run test:webnn && npm run test:ortlog && npm run test:cdn && npm run test:inference && npm run test:compare",
     "coverage": "c8 npm run test:all"
   },
   "dependencies": {

--- a/scripts/convertmodel/test/README.md
+++ b/scripts/convertmodel/test/README.md
@@ -228,6 +228,24 @@ all exercised without a real browser. No DOM or network:
 npm run test:webnn
 ```
 
+## ORT diagnostic mirroring
+
+`npm run test:ortlog` unit-tests `ort_log_capture.mjs`, which mirrors
+onnxruntime-web's own diagnostics into the inference panel's on-page log while a
+run is active. Some ORT messages bypass the panel's `try/catch` and so used to
+show up only in the browser devtools console — EP-assignment notes
+(`VerifyEachNodeIsAssignedToAnEp …`, printed to `console.warn`/`console.error`
+from the wasm module) and WebNN backend failures (e.g. `WebNN backend does not
+support data type: int64`, thrown as an *uncaught* promise rejection on an
+internal ORT promise). The helper wraps `console.warn`/`console.error` and
+listens for `unhandledrejection`, forwarding the `onnxruntime`/`webnn` ones to
+the log while preserving the devtools output. Its console/event-target are
+injected, so the test drives the whole thing under Node with no browser:
+
+```bash
+npm run test:ortlog
+```
+
 ## Profiling traces
 
 Both the browser panels can emit a [Chrome Trace Event][cte] JSON that the page

--- a/scripts/convertmodel/test/ort_log_capture.test.mjs
+++ b/scripts/convertmodel/test/ort_log_capture.test.mjs
@@ -1,0 +1,147 @@
+// Unit test for ort_log_capture.mjs — the helper that mirrors onnxruntime-web's
+// own console diagnostics and unhandled WebNN/ORT promise rejections into the
+// inference panel's UI log. The DOM-touching pieces take an injected console and
+// event target, so the whole thing runs under Node with no browser.
+//
+// Usage:
+//   node test/ort_log_capture.test.mjs
+
+import assert from "node:assert/strict";
+import {
+  isOrtDiagnostic,
+  valueToText,
+  formatLogArgs,
+  captureOrtDiagnostics,
+} from "../ort_log_capture.mjs";
+
+let passed = 0;
+function check(name, fn) {
+  fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+
+// A console-shaped stub recording each warn/error call's arguments.
+function fakeConsole() {
+  const calls = { warn: [], error: [] };
+  return {
+    calls,
+    warn: (...a) => calls.warn.push(a),
+    error: (...a) => calls.error.push(a),
+  };
+}
+
+// A minimal EventTarget-shaped stub that can dispatch to registered listeners
+// and report how many are still registered (so restore() can be checked).
+function fakeTarget() {
+  const listeners = {};
+  return {
+    addEventListener(type, fn) {
+      (listeners[type] ||= []).push(fn);
+    },
+    removeEventListener(type, fn) {
+      listeners[type] = (listeners[type] || []).filter((f) => f !== fn);
+    },
+    dispatch(type, event) {
+      (listeners[type] || []).slice().forEach((f) => f(event));
+    },
+    count(type) {
+      return (listeners[type] || []).length;
+    },
+  };
+}
+
+check("isOrtDiagnostic matches onnxruntime/webnn text only", () => {
+  assert.equal(isOrtDiagnostic("WebNN backend does not support data type: int64"), true);
+  assert.equal(
+    isOrtDiagnostic("[W:onnxruntime:, session_state.cc] VerifyEachNodeIsAssignedToAnEp"),
+    true,
+  );
+  assert.equal(isOrtDiagnostic("some unrelated page log"), false);
+  assert.equal(isOrtDiagnostic(""), false);
+  assert.equal(isOrtDiagnostic(undefined), false);
+  assert.equal(isOrtDiagnostic(42), false);
+});
+
+check("valueToText normalizes errors, strings, and objects", () => {
+  assert.equal(valueToText(new Error("boom")), "boom");
+  assert.equal(valueToText("plain"), "plain");
+  assert.equal(valueToText({ a: 1 }), '{"a":1}');
+  // Circular objects can't be JSON-encoded; fall back to String() without throwing.
+  const circular = {};
+  circular.self = circular;
+  assert.equal(valueToText(circular), "[object Object]");
+});
+
+check("formatLogArgs joins mixed args into one matchable string", () => {
+  assert.equal(
+    formatLogArgs(["WebNN backend does not support data type:", new Error("int64")]),
+    "WebNN backend does not support data type: int64",
+  );
+  assert.equal(formatLogArgs([]), "");
+});
+
+check("captureOrtDiagnostics mirrors ORT console diagnostics, not others", () => {
+  const con = fakeConsole();
+  const target = fakeTarget();
+  const logged = [];
+  const restore = captureOrtDiagnostics({ log: (m) => logged.push(m), con, target });
+
+  // An ORT warning is forwarded to the log AND still reaches the real console.
+  con.warn("[W:onnxruntime] VerifyEachNodeIsAssignedToAnEp: nodes unassigned");
+  // An unrelated console.error is left alone (devtools only).
+  con.error("some other library failed");
+
+  assert.equal(con.calls.warn.length, 1); // original still called
+  assert.equal(con.calls.error.length, 1);
+  assert.equal(logged.length, 1);
+  assert.match(logged[0], /^onnxruntime-web warn: /);
+  assert.match(logged[0], /VerifyEachNodeIsAssignedToAnEp/);
+
+  restore();
+});
+
+check("captureOrtDiagnostics mirrors unhandled WebNN rejections", () => {
+  const con = fakeConsole();
+  const target = fakeTarget();
+  const logged = [];
+  const restore = captureOrtDiagnostics({ log: (m) => logged.push(m), con, target });
+
+  assert.equal(target.count("unhandledrejection"), 1);
+
+  // The real-world case: an uncaught promise rejection from ORT's WebNN backend.
+  target.dispatch("unhandledrejection", {
+    reason: new Error("WebNN backend does not support data type: int64"),
+  });
+  // A non-ORT rejection is ignored.
+  target.dispatch("unhandledrejection", { reason: new Error("unrelated") });
+
+  assert.equal(logged.length, 1);
+  assert.match(logged[0], /^onnxruntime-web unhandled rejection: /);
+  assert.match(logged[0], /int64/);
+
+  restore();
+});
+
+check("restore() removes console wrappers and the rejection listener", () => {
+  const con = fakeConsole();
+  const target = fakeTarget();
+  const origWarn = con.warn;
+  const origError = con.error;
+  const logged = [];
+  const restore = captureOrtDiagnostics({ log: (m) => logged.push(m), con, target });
+
+  assert.notEqual(con.warn, origWarn); // wrapped while active
+  restore();
+
+  assert.equal(con.warn, origWarn); // restored
+  assert.equal(con.error, origError);
+  assert.equal(target.count("unhandledrejection"), 0); // listener removed
+
+  // After restore, ORT diagnostics are no longer mirrored.
+  con.warn("[W:onnxruntime] still talking");
+  target.dispatch("unhandledrejection", { reason: new Error("webnn later") });
+  assert.equal(logged.length, 0);
+});
+
+console.log(`\nort_log_capture: ${passed} checks passed`);

--- a/scripts/convertmodel/test/webnn.test.mjs
+++ b/scripts/convertmodel/test/webnn.test.mjs
@@ -91,17 +91,30 @@ await check("isWebnnEp recognizes only the WebNN dropdown values", () => {
   assert.equal(isWebnnEp(undefined), false);
 });
 
-// detectWebnn with no navigator.ml reports the API as absent (never throws).
+// A console-shaped stub that records the arguments of each error() call, so the
+// tests can assert detectWebnn surfaces the underlying WebNN failures without
+// touching the real console.
+function fakeConsole() {
+  const errors = [];
+  return { errors, error: (...args) => errors.push(args) };
+}
+
+// detectWebnn with no navigator.ml reports the API as absent (never throws), and
+// with no device probes there is nothing to log.
 await check("detectWebnn reports absent API", async () => {
-  const report = await detectWebnn({});
+  const con = fakeConsole();
+  const report = await detectWebnn({}, con);
   assert.equal(report.apiPresent, false);
   assert.equal(report.supported, false);
+  assert.deepEqual(report.errors, {});
   assert.match(report.message, /not available/);
+  assert.equal(con.errors.length, 0);
   assert.equal(formatWebnnStatus(report).startsWith("WebNN status: ❌"), true);
 });
 
 // A navigator whose ml.createContext succeeds only for some device types: those
-// become supported, the rest false, and supported reflects "at least one".
+// become supported, the rest false, and supported reflects "at least one". The
+// failing device types' errors are captured in the report and logged to console.
 await check("detectWebnn probes each device type", async () => {
   const calls = [];
   const nav = {
@@ -113,17 +126,23 @@ await check("detectWebnn probes each device type", async () => {
       },
     },
   };
-  const report = await detectWebnn(nav);
+  const con = fakeConsole();
+  const report = await detectWebnn(nav, con);
   assert.deepEqual(calls, WEBNN_DEVICE_TYPES); // probed gpu, npu, cpu
   assert.equal(report.apiPresent, true);
   assert.equal(report.supported, true);
   assert.deepEqual(report.devices, { gpu: true, npu: false, cpu: false });
+  assert.deepEqual(report.errors, { npu: "no npu", cpu: "no cpu" });
+  // Only the two failing device types are logged; the succeeding gpu is not.
+  assert.equal(con.errors.length, 2);
+  assert.match(con.errors[0][0], /deviceType 'npu'/);
+  assert.equal(con.errors[0][1].message, "no npu");
   assert.match(report.message, /gpu/);
   assert.equal(formatWebnnStatus(report).startsWith("WebNN status: ✅"), true);
 });
 
 // navigator.ml present but no device usable → apiPresent true, supported false,
-// warning glyph.
+// warning glyph, every device's error captured and logged.
 await check("detectWebnn handles API present but no usable device", async () => {
   const nav = {
     ml: {
@@ -132,11 +151,34 @@ await check("detectWebnn handles API present but no usable device", async () => 
       },
     },
   };
-  const report = await detectWebnn(nav);
+  const con = fakeConsole();
+  const report = await detectWebnn(nav, con);
   assert.equal(report.apiPresent, true);
   assert.equal(report.supported, false);
   assert.deepEqual(report.devices, { gpu: false, npu: false, cpu: false });
+  assert.deepEqual(report.errors, {
+    gpu: "unsupported",
+    npu: "unsupported",
+    cpu: "unsupported",
+  });
+  assert.equal(con.errors.length, 3);
   assert.equal(formatWebnnStatus(report).startsWith("WebNN status: ⚠️"), true);
+});
+
+// A createContext that rejects with a non-Error value is stringified rather than
+// dropped, so the report and console still carry something useful.
+await check("detectWebnn stringifies non-Error rejections", async () => {
+  const nav = {
+    ml: {
+      async createContext() {
+        throw "boom"; // eslint-disable-line no-throw-literal
+      },
+    },
+  };
+  const con = fakeConsole();
+  const report = await detectWebnn(nav, con);
+  assert.deepEqual(report.errors, { gpu: "boom", npu: "boom", cpu: "boom" });
+  assert.equal(con.errors.length, 3);
 });
 
 console.log(`\nwebnn: ${passed} checks passed`);

--- a/scripts/convertmodel/webnn.mjs
+++ b/scripts/convertmodel/webnn.mjs
@@ -78,13 +78,21 @@ export function isWebnnEp(epValue) {
 }
 
 // Probe the WebNN API on an injected navigator (defaults to the page's).
-// Returns { apiPresent, supported, devices: {gpu,npu,cpu}, message }: apiPresent
-// reflects navigator.ml being exposed at all; `devices[type]` is true when an
-// MLContext for that device type could actually be created; `supported` is true
-// when at least one device type worked. Never throws — any failure is reported
-// as unsupported so a caller can render it directly.
+// Returns { apiPresent, supported, devices: {gpu,npu,cpu}, errors: {…}, message }:
+// apiPresent reflects navigator.ml being exposed at all; `devices[type]` is true
+// when an MLContext for that device type could actually be created; `errors[type]`
+// carries the failure message for a device type that couldn't be created; and
+// `supported` is true when at least one device type worked. Never throws — any
+// failure is reported as unsupported so a caller can render it directly.
+//
+// The per-device MLContext failures are also logged to `con` (defaults to the
+// page's console) so the actual WebNN error — which the one-line panel status
+// can only summarize — is visible in the browser console for debugging. `con` is
+// injectable so the probe stays unit-testable under Node without touching the
+// global console.
 export async function detectWebnn(
   nav = typeof navigator !== "undefined" ? navigator : undefined,
+  con = typeof console !== "undefined" ? console : undefined,
 ) {
   const ml = nav && nav.ml;
   if (!ml || typeof ml.createContext !== "function") {
@@ -92,6 +100,7 @@ export async function detectWebnn(
       apiPresent: false,
       supported: false,
       devices: {},
+      errors: {},
       message:
         "WebNN API (navigator.ml) is not available in this browser. Try a " +
         "recent Chrome/Edge with the WebNN flag enabled " +
@@ -100,6 +109,7 @@ export async function detectWebnn(
   }
 
   const devices = {};
+  const errors = {};
   for (const deviceType of WEBNN_DEVICE_TYPES) {
     try {
       const ctx = await ml.createContext({ deviceType });
@@ -112,8 +122,17 @@ export async function detectWebnn(
           /* ignore */
         }
       }
-    } catch {
+    } catch (err) {
       devices[deviceType] = false;
+      errors[deviceType] = err && err.message ? err.message : String(err);
+      // Surface the real WebNN failure to the console — the panel status only
+      // reports that a device couldn't be created, not why.
+      if (con && typeof con.error === "function") {
+        con.error(
+          `WebNN: could not create an MLContext for deviceType '${deviceType}':`,
+          err,
+        );
+      }
     }
   }
 
@@ -122,6 +141,7 @@ export async function detectWebnn(
     apiPresent: true,
     supported: usable.length > 0,
     devices,
+    errors,
     message: usable.length
       ? `WebNN available — device types: ${usable.join(", ")}.`
       : "navigator.ml exists, but no WebNN device (gpu/npu/cpu) could be " +


### PR DESCRIPTION
## Summary
Enhanced WebNN device probing to capture and surface underlying API failures, making it easier to debug why specific device types (gpu/npu/cpu) are unavailable.

## Key Changes
- **Error capture in `detectWebnn()`**: Device probe failures are now captured in a new `errors` field in the returned report object, storing the failure message for each device type that couldn't be created.
- **Console logging**: WebNN creation failures are logged to the browser console (via an injectable `con` parameter) so developers can see the actual error in DevTools, not just the one-line status summary.
- **Tooltip enhancement**: The WebNN status tooltip now displays failure reasons for unavailable devices, e.g., `gpu: yes, npu: no (unsupported), cpu: no (unsupported)`.
- **Non-Error handling**: Rejections with non-Error values (e.g., thrown strings) are stringified so they're still captured and reported rather than lost.
- **Testability**: Added `fakeConsole()` stub to unit tests so error logging can be verified without touching the real console.

## Implementation Details
- The `detectWebnn()` function now accepts an optional `con` parameter (defaults to global `console`) for dependency injection, enabling unit testing under Node.
- Each device type's failure is logged individually with context: `WebNN: could not create an MLContext for deviceType 'X': [error]`.
- The report structure now includes `errors: { gpu?, npu?, cpu? }` alongside the existing `devices` object.
- Updated documentation in `webnn.md` to explain the new console logging behavior for debugging.

https://claude.ai/code/session_01HCmj4mxcVTg2YEUR3kR4Rz