### PR TITLE
Fix Cloudflare Pages preview gating for fork and Dependabot PRs

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -64,6 +64,11 @@ jobs:
     env:
       CMAKE_GENERATOR: Ninja
       EMSCRIPTEN_VERSION: "5.0.0"
+      # Surfaced so the Cloudflare preview steps can gate on the secret being
+      # present. It is empty for fork PRs and for Dependabot PRs (GitHub does
+      # not share repo secrets with either), so the steps below skip instead of
+      # failing wrangler with "CLOUDFLARE_API_TOKEN is necessary".
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -166,11 +171,13 @@ jobs:
         if: ${{ github.event_name == 'push' }}
 
       # --- Preview: Cloudflare Pages (pull requests only) ---
-      # Secrets are not available to pull requests from forks, so skip the
-      # deploy there instead of failing. Same-repo branches get previews.
+      # Repo secrets are not shared with fork PRs or Dependabot PRs, so
+      # CLOUDFLARE_API_TOKEN is empty there. Gate on it being set so those runs
+      # skip the deploy instead of failing wrangler. Same-repo branches (which
+      # do get the secret) still produce previews.
       - name: Deploy preview to Cloudflare Pages
         id: cf_deploy
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event_name == 'pull_request' && env.CLOUDFLARE_API_TOKEN != '' }}
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -182,7 +189,7 @@ jobs:
             --project-name=onnxsim
             --branch=${{ github.head_ref }}
       - name: Comment preview URL on the PR
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event_name == 'pull_request' && env.CLOUDFLARE_API_TOKEN != '' }}
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary
Updates the GitHub Actions workflow to properly handle Cloudflare Pages preview deployments for fork PRs and Dependabot PRs, which don't have access to repository secrets.

## Changes
- **Surface `CLOUDFLARE_API_TOKEN` as an environment variable** in the job environment so it can be checked in conditional steps. The token is empty for fork PRs and Dependabot PRs (GitHub doesn't share repo secrets with these), allowing steps to skip gracefully.

- **Replace repository check with token presence check** in the deployment conditions:
  - Changed from: `github.event.pull_request.head.repo.full_name == github.repository`
  - Changed to: `env.CLOUDFLARE_API_TOKEN != ''`
  
  This approach is more robust because it directly gates on whether the secret is available, rather than trying to infer it from the PR source.

- **Update both deployment steps** to use the new condition:
  - "Deploy preview to Cloudflare Pages" step
  - "Comment preview URL on the PR" step

## Implementation Details
The previous approach of checking the repository name would fail for Dependabot PRs (which have `head.repo.full_name == null`). By surfacing the secret as an environment variable and checking its presence, we ensure that:
- Same-repo branches with access to secrets still produce previews
- Fork PRs skip deployment gracefully (no secret access)
- Dependabot PRs skip deployment gracefully (no secret access)
- Wrangler doesn't fail with "CLOUDFLARE_API_TOKEN is necessary" errors

https://claude.ai/code/session_01QWgPTyxnLQaEA1t4pSJbwM