### PR TITLE
ci: run the lightweight jobs on ubuntu-slim

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,9 +11,14 @@ on:
 jobs:
   # Format + lint + type-check the Python sources. Tools are pinned so a local
   # run reports exactly what CI does; bump the pins here to upgrade everywhere.
+  #
+  # ubuntu-slim (1 vCPU, 15-minute job limit) is enough: nothing is compiled and
+  # no third-party deps are installed, so this finishes in well under a minute.
+  # setup-python stays -- the slim image's system Python is externally managed
+  # (PEP 668), so `pip install` into it would fail.
   python:
     name: ruff + mypy (Python)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -37,10 +42,11 @@ jobs:
 
   # Check C/C++ formatting. clang-format is installed from the PyPI wheel so its
   # version is pinned and identical across machines (apt/system clang-format
-  # versions differ and would disagree on the output).
+  # versions differ and would disagree on the output). One pip install plus a
+  # formatting check over a handful of files, so ubuntu-slim covers it.
   clang-format:
     name: clang-format (C/C++)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/.github/workflows/model-regression.yml
+++ b/.github/workflows/model-regression.yml
@@ -74,9 +74,11 @@ jobs:
 
   # Emit the shard index list so the shard count is configurable from
   # workflow_dispatch while defaulting to 6.
+  # One `python3 -c` line emitting the shard list -- no checkout, nothing built.
+  # ubuntu-slim's preinstalled Python is all this needs.
   setup:
     name: Plan shards
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     outputs:
       shards: ${{ steps.plan.outputs.shards }}
       num_shards: ${{ steps.plan.outputs.num_shards }}

--- a/.github/workflows/x2paddle-regression.yml
+++ b/.github/workflows/x2paddle-regression.yml
@@ -65,9 +65,11 @@ jobs:
           name: onnxsim-wheel-cp311
           path: ./wheelhouse/*.whl
 
+  # One `python3 -c` line emitting the shard list -- no checkout, nothing built.
+  # ubuntu-slim's preinstalled Python is all this needs.
   setup:
     name: Plan shards
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     outputs:
       shards: ${{ steps.plan.outputs.shards }}
       num_shards: ${{ steps.plan.outputs.num_shards }}


### PR DESCRIPTION
Four CI jobs compile nothing and finish in seconds, so they don't need a full `ubuntu-latest` runner. `ubuntu-slim` (1 vCPU, 5 GB RAM, hard 15-minute job timeout, unprivileged container) covers all of them with room to spare.

## Moved to `ubuntu-slim`

| Job | Work it does |
|---|---|
| `Lint` / ruff + mypy (Python) | checkout + two pip installs; third-party deps and the compiled extension are deliberately not installed |
| `Lint` / clang-format (C/C++) | checkout + `pip install clang-format` + a format check over ~a dozen files |
| `Model Regression` / Plan shards | one `python3 -c` line emitting the shard list; no checkout |
| `X2Paddle Regression` / Plan shards | same |

Both lint jobs keep `actions/setup-python`. The slim image's system Python is externally managed (PEP 668) now that the runner-images pip workaround has been removed, so installing into it would fail.

## Considered and left alone

- `Coverage` / report — `irongut/CodeCoverageSummary` is a Docker container action.
- `Build and Test` / upload_pypi — `pypa/gh-action-pypi-publish` is composite but generates and invokes a Docker container action internally.

Container actions need a Docker daemon, which the unprivileged slim runner cannot provide. Everything else in the repo builds wheels, runs cmake/emscripten, or downloads models, and would blow the 15-minute cap on 1 vCPU.

`Rust wrapper` / fmt + clippy is a plausible future candidate (the workspace has essentially no dependencies and `ONNXSIM_NO_BUILD=1` skips the native build), but the rustup toolchain download plus clippy on 1 vCPU is close enough to the timeout that it's worth measuring first.

## Testing

YAML parses and the per-job runners are as intended. Real validation is this PR's own `Lint` run, which now executes on `ubuntu-slim`; the two Plan shards jobs run on `pull_request` in their respective regression workflows.

---
_Generated by [Claude Code](https://claude.ai/code/session_0136ZiPBMzmCYKRNfe7Vvp6H)_