### PR TITLE
test: run the suite on big endian (s390x) and record what breaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,11 @@ test*.py
 .setuptools-cmake-build/
 onnxsim/version.py
 
+# scripts/cross/ build trees (Windows wheel, s390x big-endian, native control)
+.cross-build/
+.cross-build-s390x/
+.native-build-control/
+
 # Rust
 /rust/target/
 rust/Cargo.lock

--- a/docs/big-endian.md
+++ b/docs/big-endian.md
@@ -1,0 +1,154 @@
+# Big-endian status
+
+onnxsim is **not correct on big-endian hosts today**. Constant folding is
+disabled there and fails quietly, so `simplify()` returns a model that is
+semantically valid but barely simplified. This document records what was
+measured, how to reproduce it, and where the byte-order assumptions live.
+
+## Why byte order matters here
+
+ONNX fixes the byte order of tensor payloads. From `onnx.in.proto`, on
+`TensorProto.raw_data`:
+
+> When this raw_data field is used to store tensor value, elements MUST be
+> stored in as fixed-width, little-endian order.
+
+So `raw_data` is little-endian on *every* host. Code that `memcpy`s or
+`reinterpret_cast`s it into native integers or floats is correct only by
+accident of running on a little-endian CPU.
+
+## How it was measured
+
+s390x, under `qemu-s390x-static` on an x86_64 host, against an **amd64 control**
+running the same commit, the same test suite and the same package versions — so
+byte order is the only variable. See `scripts/cross/README.md` for the
+procedure; both runs go through `scripts/cross/run_s390x_tests.sh`.
+
+Environment for both runs: CPython 3.12.3, numpy 1.26.4, onnx 1.23.0 (the
+vendored version), onnxsim 0.7.0, no onnxruntime (so the reference-evaluator
+fallback is in use).
+
+```
+little endian : 3 failed, 99 passed, 21 skipped, 1 xfailed
+big endian    : 6 failed, 95 passed, 22 skipped, 1 xfailed
+```
+
+The three failures common to both are environmental, not byte-order related
+(`test_simplify_with_unavailable_provider_raises`, `test_fuse_conv_bn_into_conv`
+and `test_fuse_convtranspose_bn` all need onnxruntime).
+
+Failing **only** on big endian:
+
+| Test | Symptom |
+| --- | --- |
+| `test_backend.py::test_simplify_without_onnxruntime` | `assert 2 == 1` — the foldable `Add` is still in the graph |
+| `test_fusion_patterns.py::test_defer_constant_expand_folds_small_consumer` | `assert 1 == 0` — the `Expand` was never folded |
+| `test_fusion_patterns.py::test_defer_constantofshape_folds_small_consumer` | same, for `ConstantOfShape` |
+
+Plus one test that *self-skips* rather than failing:
+`test_profiling.py:134: constant folding did not run the ONNX Runtime executor here`.
+
+Every one of them has the same cause, visible on stderr:
+
+```
+WARNING: failed to run "Add" op (name is ""), skip... dlpack bridge: only little endian is supported
+```
+
+## Finding 1 — constant folding is silently disabled (confirmed)
+
+`onnxsim/dlpack_bridge.h:131`, in `BuildFromProto`:
+
+```cpp
+if constexpr (std::endian::native != std::endian::little) {
+  delete ctx;
+  throw std::invalid_argument("dlpack bridge: only little endian is supported");
+}
+```
+
+Every constant fold goes through this. `RunOps` catches per-op failures, logs a
+warning and moves on, which is the right behaviour for an op the executor cannot
+run — but here it turns a total loss of constant folding into a warning on
+stderr. `simplify()` still returns `check_ok=True`, because the unfolded model
+*is* equivalent to the input. The user gets a model that was not simplified and
+no error.
+
+The damage cascades: once one fold is skipped, later folds reference
+initializers that were never produced, so the log fills with
+`no initializer _v_7`-style follow-on failures and dependent optimizations
+(e.g. folding a `Mul` scale into `Conv` weights) also stop happening.
+
+Reproduced directly — same model, same everything but the CPU:
+
+```
+little endian:  nodes = ['Conv']                                W folded, scaled correctly
+big endian:     nodes = ['Reshape', 'Unsqueeze', 'Mul', 'Conv']  W unscaled, three nodes left over
+```
+
+Worth stating explicitly: this is **not** silent numerical corruption. The
+big-endian output stays mathematically equivalent to the input model, and
+`check_n` (which runs both models and compares) would catch it if it were not.
+The bug is a silent loss of optimization, not wrong numbers.
+
+## Finding 2 — `raw_data` read in host order (by inspection)
+
+`onnxsim/onnxsim.cpp:798`, `IntTensorToSymTensor`, which seeds onnxsim's
+symbolic shape inference from INT64/INT32 initializers:
+
+```cpp
+// Raw data is read little-endian, matching how this
+// file already memcpys raw_data into onnxruntime tensors.
+...
+if (n) std::memcpy(vals.data(), raw.data(), n * sizeof(int64_t));
+```
+
+The comment states the intent, but a `memcpy` into a host `int64_t` reads host
+order — correct only on little-endian machines. The same applies to
+`ToTensorProto` in `dlpack_bridge.h`, which writes native bytes into `raw_data`
+with no endianness guard (unlike `BuildFromProto` on the input side); it is
+currently unreachable on big endian only because the input side throws first.
+
+This one is a defect by inspection: **no test or targeted probe was found where
+it changes onnxsim's output.** Probes over dynamic-shape `Reshape` and `Expand`
+models produced identical inferred shapes on both byte orders, most likely
+because ONNX's own shape inference already resolves those cases before the
+symbolic engine's seeds matter. It is recorded here because the code is wrong as
+written and would surface on models that do depend on the symbolic path — and
+because fixing Finding 1 without fixing this would turn a loud failure into a
+quiet wrong answer.
+
+## Finding 3 — upstream: onnx's C++ `Tensor` (by inspection)
+
+`onnx/common/tensor.h` (vendored, and upstream) reads `raw_data` natively:
+
+```cpp
+inline type* Tensor::data<type>() {
+  if (is_raw_data_) {
+    return reinterpret_cast<type*>(raw_data_.data());
+```
+
+and `ir_pb_converter.cc` copies `raw_data` in verbatim without byte-swapping, so
+the optimizer passes onnxsim and onnx-optimizer build on top of this inherit the
+assumption. Not onnxsim's code to fix, but it bounds how far onnxsim can be made
+big-endian correct on its own.
+
+Note also that **onnx < 1.16 actively corrupts models on big endian**:
+`numpy_helper.to_array()` called `convert_endian(tensor)`, byte-swapping the
+proto *in place*, so merely reading an initializer rewrote its `raw_data` into
+spec-violating big-endian order. Fixed upstream by 1.23 (which byte-swaps into a
+local instead), but relevant to anyone pairing onnxsim with an old onnx.
+
+## What a fix would involve
+
+The honest summary is that supporting big endian is a real piece of work, not a
+one-line change:
+
+1. Byte-swap on both edges of the DLPack bridge (`BuildFromProto` in,
+   `ToTensorProto` out) instead of refusing, which costs a copy on big endian
+   only.
+2. Read `raw_data` little-endian explicitly in `IntTensorToSymTensor`.
+3. Decide what to do about onnx's `Tensor::data<T>()` — either upstream a fix or
+   normalize tensors before handing them to the optimizer.
+
+Until then, the most valuable small change would be making the failure **loud**:
+constant folding collapsing entirely should not be reported to the user as a
+successful simplification.

--- a/scripts/cross/README.md
+++ b/scripts/cross/README.md
@@ -94,3 +94,72 @@ additionally need `xwin` on `PATH`, which downloads the MSVC SDK from Microsoft.
 BACKEND=llvm-mingw PYVER=3.12 ABI3=1 bash scripts/cross/build_windows_wheel.sh
 # -> wheelhouse/onnxsim-<ver>-cp312-abi3-win_amd64.whl
 ```
+
+---
+
+# Cross-building for s390x (big endian)
+
+The second cross-build in this directory targets **s390x Linux**, for a
+different reason than the Windows one: not to ship wheels, but to run onnxsim's
+test suite on a **big-endian** CPU. ONNX defines `TensorProto.raw_data` as
+little-endian on every host, so any code that reinterprets those bytes in host
+order is a latent bug that only x86/ARM's byte order hides. s390x is the only
+mainstream big-endian Linux target a major distro still supports, and Ubuntu
+ships `python3-onnx` / `python3-numpy` / `python3-pytest` for it — which is what
+makes this practical, since PyPI has no s390x wheels.
+
+Everything is compiled by the **host** toolchain (`s390x-linux-gnu-g++`), so the
+build runs at native speed; only the resulting binaries execute under
+`qemu-s390x-static`. An emulated build of the onnx + protobuf stack would take
+hours.
+
+## Procedure
+
+```sh
+# 1. Ubuntu s390x rootfs + binfmt_misc -> qemu-s390x-static  (root; once)
+sudo bash scripts/cross/bootstrap_s390x_rootfs.sh
+
+# 2. Cross-build the extension (host protoc, target abseil/protobuf, onnxsim)
+bash scripts/cross/build_s390x_extension.sh
+
+# 3. Install it into the rootfs and run pytest there, big endian
+sudo bash scripts/cross/run_s390x_tests.sh
+```
+
+## The little-endian control
+
+A big-endian test run on its own is hard to read: a failure may be an
+endianness bug, or just an artifact of this unusual environment (no
+onnxruntime, no torch, an older distro onnx). So build the **same commit** for
+x86_64 and run the **same suite** in an amd64 rootfs with the **same package
+versions**. Then byte order is the only variable and the two failure sets can be
+diffed directly:
+
+```sh
+sudo ARCH=amd64 bash scripts/cross/bootstrap_s390x_rootfs.sh
+bash scripts/cross/build_native_control.sh
+sudo SYSROOT=/rootfs-amd64 BUILD=$PWD/.native-build-control/onnxsim-build \
+     bash scripts/cross/run_s390x_tests.sh
+```
+
+## Notes / gotchas
+
+* **binfmt magic must mask `EI_OSABI`.** glibc's own binaries (notably
+  `ldconfig.real`) are tagged `ELFOSABI_GNU`, so a handler that pins byte 7 to
+  SYSV makes exactly those fail with `Exec format error` part-way through
+  `debootstrap`, corrupting the dpkg status file. The mask also has to accept
+  `ET_DYN` for static-pie binaries.
+* **The host interpreter must match the target CPython's X.Y.** CMake's
+  `FindPython` validates the interpreter against the target headers and refuses
+  a mismatch, even though the interpreter only runs ONNX's codegen.
+* **The distro's `python3-onnx` is too old** for onnxsim's vendored onnx and
+  fails a large part of the suite for reasons unrelated to byte order.
+  `run_s390x_tests.sh` therefore installs the vendored onnx (assembled from the
+  same cross-build) ahead of it on `PYTHONPATH`. protobuf has a pure-Python
+  wheel, so it needs no s390x build; `ml_dtypes` does not, and is compiled once
+  inside the rootfs under emulation by the bootstrap script.
+* onnxruntime, torch and timm have no s390x builds, so the test modules that
+  import them at module scope cannot be collected. onnxsim falls back to onnx's
+  reference evaluator, which is the supported no-onnxruntime path.
+
+See `docs/big-endian.md` for what these runs actually found.

--- a/scripts/cross/bootstrap_s390x_rootfs.sh
+++ b/scripts/cross/bootstrap_s390x_rootfs.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Build an Ubuntu s390x (big endian) rootfs and register qemu-user for it, so
+# onnxsim can be run and tested big-endian on an x86_64 host.
+#
+# s390x is the only mainstream big-endian Linux target a major distro still
+# ships, which makes it the practical way to check onnxsim's byte-order
+# assumptions. Run as root. See README.md for the full procedure.
+set -euo pipefail
+
+# ARCH=amd64 builds the little-endian control rootfs instead (same distro, same
+# package versions), so a big-endian run can be diffed against one that differs
+# only in byte order. Ubuntu keeps s390x on ports.ubuntu.com and amd64 on the
+# main archive.
+ARCH="${ARCH:-s390x}"
+SUITE="${SUITE:-noble}"
+if [[ "${ARCH}" == "amd64" ]]; then
+  SYSROOT="${SYSROOT:-/rootfs-amd64}"
+  MIRROR="${MIRROR:-http://archive.ubuntu.com/ubuntu/}"
+else
+  SYSROOT="${SYSROOT:-/rootfs-s390x}"
+  MIRROR="${MIRROR:-http://ports.ubuntu.com/ubuntu-ports/}"
+fi
+
+command -v debootstrap >/dev/null || {
+  echo "installing debootstrap + qemu-user-static + the s390x cross toolchain"
+  apt-get update -q
+  apt-get install -y -q debootstrap qemu-user-static g++-s390x-linux-gnu
+}
+
+# ---------------------------------------------------------------------------
+# binfmt_misc so s390x binaries (including everything dpkg runs inside the
+# chroot) transparently execute under qemu.
+# ---------------------------------------------------------------------------
+if [[ "${ARCH}" == "s390x" ]]; then
+if [[ ! -e /proc/sys/fs/binfmt_misc/register ]]; then
+  mount -t binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc
+fi
+if [[ -e /proc/sys/fs/binfmt_misc/qemu-s390x ]]; then
+  echo -1 > /proc/sys/fs/binfmt_misc/qemu-s390x
+fi
+# Bytes 0-6 are the ELF ident (64-bit, MSB, v1); 16-17 e_type; 18-19 e_machine
+# (0x0016 = EM_S390). The mask zeroes EI_OSABI/EI_ABIVERSION -- glibc's own
+# binaries (e.g. ldconfig.real) set EI_OSABI=GNU, and a mask that pins them to
+# SYSV makes those, and only those, fail with "Exec format error" mid-install.
+# The 0xfe on byte 17 accepts both ET_EXEC and ET_DYN (static-pie binaries).
+printf ':qemu-s390x:M::\x7fELF\x02\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x16:\xff\xff\xff\xff\xff\xff\xff\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff:/usr/bin/qemu-s390x-static:F' \
+  > /proc/sys/fs/binfmt_misc/register
+fi
+
+# ---------------------------------------------------------------------------
+# The rootfs. python3-onnx/python3-numpy/python3-pytest exist for s390x in
+# Ubuntu, which is what makes this practical -- PyPI has no s390x wheels.
+# The distro onnx is older than the one onnxsim vendors; run_s390x_tests.sh
+# installs the vendored version over it.
+# ---------------------------------------------------------------------------
+if [[ ! -e "${SYSROOT}/etc/os-release" ]]; then
+  debootstrap --arch="${ARCH}" --variant=minbase --components=main,universe \
+    --include=python3,python3-dev,python3-numpy,python3-onnx,python3-pytest,python3-protobuf,python3-pip,libpython3-dev,libprotobuf-dev,protobuf-compiler,ca-certificates,build-essential,cmake,git \
+    "${SUITE}" "${SYSROOT}" "${MIRROR}"
+fi
+
+cat > "${SYSROOT}/etc/apt/sources.list" <<EOF
+deb ${MIRROR} ${SUITE} main universe
+deb ${MIRROR} ${SUITE}-updates main universe
+EOF
+cp /etc/resolv.conf "${SYSROOT}/etc/resolv.conf"
+# Proxied environments hand pip a CA bundle by absolute path; make it resolve
+# inside the chroot too.
+if [[ -f /root/.ccr/ca-bundle.crt ]]; then
+  mkdir -p "${SYSROOT}/root/.ccr"
+  cp /root/.ccr/ca-bundle.crt "${SYSROOT}/root/.ccr/"
+fi
+
+# rich is a runtime dependency of onnxsim and pure Python, so the host's pip can
+# drop it straight in. ml_dtypes is a C extension the vendored onnx needs and
+# has no s390x wheel, so it is compiled in-place under emulation (slow, once).
+python3 -m pip install --quiet --target="${SYSROOT}/usr/lib/python3/dist-packages" rich
+chroot "${SYSROOT}" /bin/sh -c '
+  export PIP_BREAK_SYSTEM_PACKAGES=1
+  python3 -c "import ml_dtypes" 2>/dev/null && exit 0
+  pip3 install -U --ignore-installed setuptools wheel pybind11
+  pip3 install --no-build-isolation --no-deps "ml_dtypes>=0.5.4"
+'
+
+chroot "${SYSROOT}" /usr/bin/python3 -c "
+import sys, numpy
+print('rootfs ready:', sys.byteorder, 'endian | python', sys.version.split()[0],
+      '| numpy', numpy.__version__)
+"

--- a/scripts/cross/build_native_control.sh
+++ b/scripts/cross/build_native_control.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Build the onnxsim extension natively for x86_64 with the SAME CMake settings
+# the s390x cross-build uses, so the two can be compared with byte order as the
+# only difference. Used as the little-endian control for endianness testing.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="${WORK:-${REPO_ROOT}/.cross-build-s390x}"   # reuse the fetched sources
+NATIVE_WORK="${REPO_ROOT}/.native-build-control"
+JOBS="${JOBS:-$(nproc)}"
+PYVER="${PYVER:-3.12}"
+
+HOSTPY="$(command -v "python${PYVER}")"
+NANOBIND_CMAKE_DIR="$(python3 -m nanobind --cmake_dir)"
+BUILD_DIR="${NATIVE_WORK}/onnxsim-build"
+
+cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -G Ninja -Wno-dev -Wdeprecated \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DONNX_BUILD_PYTHON=ON \
+  -DONNX_INSTALL=OFF \
+  -DONNXSIM_PYTHON=ON \
+  -DONNXSIM_BUILTIN_ORT=OFF \
+  -DONNXSIM_TESTS=ON \
+  -DONNX_USE_LITE_PROTO=OFF \
+  -DONNX_USE_PROTOBUF_SHARED_LIBS=OFF \
+  -DCMAKE_PREFIX_PATH="${NANOBIND_CMAKE_DIR}" \
+  -Dnanobind_DIR="${NANOBIND_CMAKE_DIR}" \
+  -DPython_EXECUTABLE="${HOSTPY}" \
+  -DPython3_EXECUTABLE="${HOSTPY}"
+
+cmake --build "${BUILD_DIR}" --target onnxsim_cpp2py_export -j "${JOBS}"
+
+SO="$(find "${BUILD_DIR}" -name 'onnxsim_cpp2py_export*.so' -print -quit)"
+echo "built: ${SO}"
+file "${SO}"

--- a/scripts/cross/build_s390x_extension.sh
+++ b/scripts/cross/build_s390x_extension.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Cross-build the onnxsim CPython extension for s390x (big endian) Linux from an
+# x86_64 host, so the test suite can be run big-endian under qemu-user.
+#
+# Same shape as build_windows_wheel.sh: a host protoc runs ONNX's code
+# generation, abseil + protobuf are cross-built for the target, and the
+# extension links against them. The target sysroot is an Ubuntu s390x rootfs
+# (see scripts/cross/README.md) which also supplies CPython, numpy and onnx for
+# the actual test run.
+#
+# Everything is compiled by the *host* toolchain (s390x-linux-gnu-g++), so the
+# build runs at native speed; only the resulting binaries execute under qemu.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="${WORK:-${REPO_ROOT}/.cross-build-s390x}"
+SYSROOT="${SYSROOT:-/rootfs-s390x}"
+JOBS="${JOBS:-$(nproc)}"
+PYVER="${PYVER:-3.12}"
+
+ONNX_DIR="${REPO_ROOT}/third_party/onnx-optimizer/third_party/onnx"
+SBOM="${ONNX_DIR}/sbom.cdx.json"
+
+sbom_ver() {  # sbom_ver <component-name>
+  python3 - "$SBOM" "$1" <<'PY'
+import json, sys
+sbom, name = sys.argv[1], sys.argv[2]
+data = json.load(open(sbom))
+for c in data.get("components", []):
+    if c.get("name") == name:
+        print(c["version"]); break
+else:
+    sys.exit(f"component {name} not found in SBOM")
+PY
+}
+
+PROTOBUF_VER="${PROTOBUF_VER:-$(sbom_ver protobuf)}"
+ABSL_VER="${ABSL_VER:-$(sbom_ver abseil-cpp)}"
+
+DEPS_HOST="${WORK}/deps-host"      # host protobuf install -> protoc
+DEPS_TARGET="${WORK}/deps-target"  # target (s390x) absl + protobuf install
+DL="${WORK}/dl"
+mkdir -p "${DL}"
+
+fetch() {  # fetch <url> <dest>
+  [[ -s "$2" ]] && return 0
+  echo "-- fetching $1"
+  curl -fsSL --retry 3 -o "$2" "$1"
+}
+
+TOOLCHAIN_ARGS=(
+  -DCMAKE_TOOLCHAIN_FILE="${REPO_ROOT}/scripts/cross/linux-s390x.toolchain.cmake"
+  -DONNXSIM_S390X_SYSROOT="${SYSROOT}"
+)
+
+# ---------------------------------------------------------------------------
+# 1. Host protoc -- ONNX runs this during code generation. A cross-built
+#    s390x protoc could not execute on this host.
+# ---------------------------------------------------------------------------
+HOST_PROTOC="${DEPS_HOST}/bin/protoc"
+if [[ ! -x "${HOST_PROTOC}" ]]; then
+  echo "== [1/3] building host abseil ${ABSL_VER} + protobuf ${PROTOBUF_VER} (for protoc) =="
+  fetch "https://github.com/abseil/abseil-cpp/releases/download/${ABSL_VER}/abseil-cpp-${ABSL_VER}.tar.gz" "${DL}/absl.tar.gz"
+  fetch "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VER}/protobuf-${PROTOBUF_VER}.tar.gz" "${DL}/protobuf.tar.gz"
+
+  rm -rf "${WORK}/absl-host-src" "${WORK}/protobuf-host-src"
+  mkdir -p "${WORK}/absl-host-src" "${WORK}/protobuf-host-src"
+  tar -C "${WORK}/absl-host-src"     --strip-components=1 -xf "${DL}/absl.tar.gz"
+  tar -C "${WORK}/protobuf-host-src" --strip-components=1 -xf "${DL}/protobuf.tar.gz"
+
+  cmake -S "${WORK}/absl-host-src" -B "${WORK}/absl-host-build" -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DABSL_PROPAGATE_CXX_STD=ON -DABSL_ENABLE_INSTALL=ON \
+    -DCMAKE_INSTALL_PREFIX="${DEPS_HOST}"
+  cmake --build "${WORK}/absl-host-build" --target install -j "${JOBS}"
+
+  cmake -S "${WORK}/protobuf-host-src" -B "${WORK}/protobuf-host-build" -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_ABSL_PROVIDER=package \
+    -DCMAKE_PREFIX_PATH="${DEPS_HOST}" -DCMAKE_INSTALL_PREFIX="${DEPS_HOST}"
+  cmake --build "${WORK}/protobuf-host-build" --target install -j "${JOBS}"
+fi
+"${HOST_PROTOC}" --version
+
+# ---------------------------------------------------------------------------
+# 2. Target abseil + protobuf -- ONNX links these
+# ---------------------------------------------------------------------------
+if [[ ! -f "${DEPS_TARGET}/.done" ]]; then
+  echo "== [2/3] cross-building abseil ${ABSL_VER} + protobuf ${PROTOBUF_VER} for s390x =="
+  fetch "https://github.com/abseil/abseil-cpp/releases/download/${ABSL_VER}/abseil-cpp-${ABSL_VER}.tar.gz" "${DL}/absl.tar.gz"
+  fetch "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VER}/protobuf-${PROTOBUF_VER}.tar.gz" "${DL}/protobuf.tar.gz"
+
+  rm -rf "${WORK}/absl-tgt-src" "${WORK}/protobuf-tgt-src"
+  mkdir -p "${WORK}/absl-tgt-src" "${WORK}/protobuf-tgt-src"
+  tar -C "${WORK}/absl-tgt-src"     --strip-components=1 -xf "${DL}/absl.tar.gz"
+  tar -C "${WORK}/protobuf-tgt-src" --strip-components=1 -xf "${DL}/protobuf.tar.gz"
+
+  common_target_args=(
+    -G Ninja
+    "${TOOLCHAIN_ARGS[@]}"
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+    -DBUILD_SHARED_LIBS=OFF
+  )
+
+  cmake -S "${WORK}/absl-tgt-src" -B "${WORK}/absl-tgt-build" "${common_target_args[@]}" \
+    -DABSL_PROPAGATE_CXX_STD=ON -DABSL_ENABLE_INSTALL=ON \
+    -DCMAKE_INSTALL_PREFIX="${DEPS_TARGET}"
+  cmake --build "${WORK}/absl-tgt-build" --target install -j "${JOBS}"
+
+  cmake -S "${WORK}/protobuf-tgt-src" -B "${WORK}/protobuf-tgt-build" "${common_target_args[@]}" \
+    -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_ABSL_PROVIDER=package \
+    -Dprotobuf_BUILD_PROTOC_BINARIES=OFF \
+    -DCMAKE_PREFIX_PATH="${DEPS_TARGET}" -DCMAKE_INSTALL_PREFIX="${DEPS_TARGET}"
+  cmake --build "${WORK}/protobuf-tgt-build" --target install -j "${JOBS}"
+  touch "${DEPS_TARGET}/.done"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Cross-build the extension (and the dependency-free C++ unit tests)
+# ---------------------------------------------------------------------------
+echo "== [3/3] cross-building onnxsim for s390x =="
+
+NANOBIND_CMAKE_DIR="$(python3 -m nanobind --cmake_dir)"
+BUILD_DIR="${WORK}/onnxsim-build"
+# CMake's FindPython validates the interpreter against the target headers and
+# refuses a version mismatch, so the host interpreter must be the same X.Y as
+# the target CPython in the sysroot (it only runs ONNX's codegen scripts).
+HOSTPY="${HOSTPY:-$(command -v "python${PYVER}")}"
+[[ -x "${HOSTPY}" ]] || { echo "need a host python${PYVER} to match the target"; exit 1; }
+
+TGT_PY_INC="${SYSROOT}/usr/include/python${PYVER}"
+TGT_PY_LIB="${SYSROOT}/usr/lib/s390x-linux-gnu/libpython${PYVER}.so"
+TGT_PY_SABI="${SYSROOT}/usr/lib/s390x-linux-gnu/libpython3.so"
+
+# onnx splits the Python roles when cross-compiling (target dev libs land in the
+# Python3 namespace, the host interpreter in Python); onnxsim and onnx-optimizer
+# use the Python namespace for target dev libs. Provide hints for both, exactly
+# as the Windows cross-build does.
+python_args=(
+  -DPython_EXECUTABLE="${HOSTPY}"
+  -DPython_INCLUDE_DIR="${TGT_PY_INC}"
+  -DPython_LIBRARY="${TGT_PY_LIB}"
+  -DPython_SABI_LIBRARY="${TGT_PY_SABI}"
+  -DPython3_EXECUTABLE="${HOSTPY}"
+  -DPython3_INCLUDE_DIR="${TGT_PY_INC}"
+  -DPython3_LIBRARY="${TGT_PY_LIB}"
+  -DPython3_SABI_LIBRARY="${TGT_PY_SABI}"
+)
+
+cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -G Ninja -Wno-dev -Wdeprecated \
+  "${TOOLCHAIN_ARGS[@]}" \
+  -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="${REPO_ROOT}/scripts/cross/find_python_early.cmake" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DONNX_BUILD_PYTHON=ON \
+  -DONNX_INSTALL=OFF \
+  -DONNXSIM_PYTHON=ON \
+  -DONNXSIM_BUILTIN_ORT=OFF \
+  -DONNXSIM_TESTS=ON \
+  -DONNX_USE_LITE_PROTO=OFF \
+  -DONNX_USE_PROTOBUF_SHARED_LIBS=OFF \
+  -DONNX_CUSTOM_PROTOC_EXECUTABLE="${HOST_PROTOC}" \
+  -DCMAKE_PREFIX_PATH="${DEPS_TARGET};${NANOBIND_CMAKE_DIR}" \
+  -Dnanobind_DIR="${NANOBIND_CMAKE_DIR}" \
+  "${python_args[@]}"
+
+cmake --build "${BUILD_DIR}" --target onnxsim_cpp2py_export -j "${JOBS}"
+
+SO="$(find "${BUILD_DIR}" -name 'onnxsim_cpp2py_export*.so' -print -quit)"
+[[ -n "${SO}" ]] || { echo "no extension module produced"; exit 1; }
+echo "built: ${SO}"
+file "${SO}"

--- a/scripts/cross/linux-s390x.toolchain.cmake
+++ b/scripts/cross/linux-s390x.toolchain.cmake
@@ -1,0 +1,42 @@
+# CMake toolchain for cross-building onnxsim from an x86_64 Linux host to
+# s390x Linux (big endian).
+#
+# s390x is the only mainstream big-endian Linux target still shipped by a major
+# distro, so it is what onnxsim's endianness coverage is built and run against
+# (under qemu-user). The sysroot is an Ubuntu s390x rootfs produced by
+# `debootstrap --arch=s390x`; see scripts/cross/README.md.
+#
+# Point ONNXSIM_S390X_SYSROOT at that rootfs (default /rootfs-s390x).
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR s390x)
+
+if(NOT DEFINED ONNXSIM_S390X_SYSROOT)
+  set(ONNXSIM_S390X_SYSROOT "/rootfs-s390x")
+endif()
+
+set(CMAKE_C_COMPILER   s390x-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER s390x-linux-gnu-g++)
+
+set(CMAKE_SYSROOT "${ONNXSIM_S390X_SYSROOT}")
+set(CMAKE_FIND_ROOT_PATH "${ONNXSIM_S390X_SYSROOT}")
+
+# Programs (protoc, the host interpreter) must come from the host: an s390x
+# binary cannot run during the build. Everything else resolves in the sysroot.
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+# The rootfs' -dev symlinks (e.g. libpython3.12.so -> libpython3.12.so.1) are
+# relative, but its runtime linker paths are absolute; -rpath-link lets the
+# linker follow the transitive DT_NEEDED of sysroot shared objects.
+set(_s390x_libdirs
+  "${ONNXSIM_S390X_SYSROOT}/usr/lib/s390x-linux-gnu"
+  "${ONNXSIM_S390X_SYSROOT}/lib/s390x-linux-gnu")
+foreach(_dir IN LISTS _s390x_libdirs)
+  string(APPEND CMAKE_EXE_LINKER_FLAGS_INIT " -Wl,-rpath-link,${_dir}")
+  string(APPEND CMAKE_SHARED_LINKER_FLAGS_INIT " -Wl,-rpath-link,${_dir}")
+  string(APPEND CMAKE_MODULE_LINKER_FLAGS_INIT " -Wl,-rpath-link,${_dir}")
+endforeach()
+unset(_s390x_libdirs)

--- a/scripts/cross/run_s390x_tests.sh
+++ b/scripts/cross/run_s390x_tests.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Install the cross-built onnxsim into the s390x rootfs and run the test suite
+# there under qemu-user, i.e. big endian.
+#
+# Prerequisites:
+#   scripts/cross/bootstrap_s390x_rootfs.sh   # rootfs + binfmt
+#   scripts/cross/build_s390x_extension.sh    # the extension itself
+#
+# Set SYSROOT=/rootfs-amd64 and BUILD=.native-build-control/onnxsim-build to run
+# the identical stack little-endian as a control (see build_native_control.sh);
+# the two runs differ only in byte order, so any difference is an endianness bug.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SYSROOT="${SYSROOT:-/rootfs-s390x}"
+BUILD="${BUILD:-${REPO_ROOT}/.cross-build-s390x/onnxsim-build}"
+
+ONNX_SRC="${REPO_ROOT}/third_party/onnx-optimizer/third_party/onnx"
+ONNX_BUILD="${BUILD}/third_party/onnx-optimizer/third_party/onnx"
+DIST="${SYSROOT}/usr/lib/python3/dist-packages"
+PKG="${DIST}/onnxsim"
+LIBS="${SYSROOT}/work/pylibs"
+
+SO="$(find "${BUILD}" -maxdepth 1 -name 'onnxsim_cpp2py_export*.so' -print -quit)"
+[[ -n "${SO}" ]] || { echo "extension not built; run build_s390x_extension.sh first"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# onnxsim itself: the pure-Python package plus the built extension.
+# ---------------------------------------------------------------------------
+echo "== installing onnxsim into ${SYSROOT} =="
+rm -rf "${PKG}"; mkdir -p "${PKG}"
+find "${REPO_ROOT}/onnxsim" -maxdepth 1 -name '*.py' -exec cp {} "${PKG}/" \;
+# setup.py normally generates this; the cross-build never runs setup.py.
+cat > "${PKG}/version.py" <<EOF
+version = '$(cat "${REPO_ROOT}/VERSION")'
+git_version = None
+dev_count = None
+EOF
+cp "${SO}" "${PKG}/onnxsim_cpp2py_export.abi3.so"
+
+# ---------------------------------------------------------------------------
+# The vendored onnx, assembled from the same build. The distro's python3-onnx
+# is much older than what onnxsim's C++ is compiled against and fails a large
+# part of the suite for reasons unrelated to byte order, so put the matching
+# version ahead of it on PYTHONPATH. protobuf ships a pure-Python wheel, which
+# is architecture independent and so needs no s390x build.
+# ---------------------------------------------------------------------------
+echo "== installing vendored onnx $(cat "${ONNX_SRC}/VERSION_NUMBER") =="
+rm -rf "${LIBS}"; mkdir -p "${LIBS}"
+> "${LIBS}/.keep"
+python3 -m pip install --quiet --target="${LIBS}" --no-deps \
+  "$(grep -oE '"protobuf>=[0-9.]+"' "${ONNX_SRC}/pyproject.toml" | tr -d '"')" \
+  "$(grep -oE '"typing_extensions>=[0-9.]+"' "${ONNX_SRC}/pyproject.toml" | tr -d '"')"
+
+cp -r "${ONNX_SRC}/onnx" "${LIBS}/onnx"
+rm -rf "${LIBS}/onnx/test" "${LIBS}/onnx/backend/test/data"
+cp "${ONNX_BUILD}"/onnx/*_pb.py "${ONNX_BUILD}"/onnx/*_pb2.py "${LIBS}/onnx/"
+cp "${ONNX_BUILD}"/onnx_cpp2py_export*.so "${LIBS}/onnx/"
+# onnx.__init__ reads its version through importlib.metadata.
+ONNX_VER="$(cat "${ONNX_SRC}/VERSION_NUMBER")"
+mkdir -p "${LIBS}/onnx-${ONNX_VER}.dist-info"
+printf 'Metadata-Version: 2.1\nName: onnx\nVersion: %s\n' "${ONNX_VER}" \
+  > "${LIBS}/onnx-${ONNX_VER}.dist-info/METADATA"
+: > "${LIBS}/onnx-${ONNX_VER}.dist-info/RECORD"
+
+mkdir -p "${SYSROOT}/work"
+rm -rf "${SYSROOT}/work/tests"
+cp -r "${REPO_ROOT}/tests" "${SYSROOT}/work/tests"
+cp "${REPO_ROOT}/pyproject.toml" "${SYSROOT}/work/"
+
+echo "== environment =="
+chroot "${SYSROOT}" /bin/sh -c 'cd /work && PYTHONPATH=/work/pylibs python3 -c "
+import sys, numpy, onnx, onnxsim
+print(sys.byteorder, \"endian | python\", sys.version.split()[0],
+      \"| numpy\", numpy.__version__, \"| onnx\", onnx.__version__,
+      \"| onnxsim\", onnxsim.__version__)
+"'
+
+# torch, timm and onnxruntime have no s390x builds, so the test modules that
+# import them at module scope cannot be collected here. test_qnn_compat needs a
+# model fixture that is not vendored.
+echo "== pytest =="
+exec chroot "${SYSROOT}" /bin/sh -c "cd /work && PYTHONPATH=/work/pylibs python3 -m pytest tests -p no:cacheprovider \
+  --ignore=tests/test_mnn_llm_export.py --ignore=tests/test_python_api.py --ignore=tests/test_rfdetr.py \
+  --ignore=tests/test_simple.py --ignore=tests/test_timm.py --ignore=tests/test_yolo.py \
+  --ignore=tests/test_qnn_compat.py --ignore=tests/test_modelopt_integration.py ${PYTEST_ARGS:-}"


### PR DESCRIPTION
ONNX defines TensorProto.raw_data as little-endian on every host, so any
code that reinterprets those bytes in host order is a bug that x86/ARM's
byte order hides. Nothing here had ever been run big-endian.

Add tooling to do it, modelled on the existing Windows cross-build:

  bootstrap_s390x_rootfs.sh  Ubuntu s390x rootfs + binfmt_misc -> qemu
  linux-s390x.toolchain.cmake
  build_s390x_extension.sh   host protoc, target abseil/protobuf, onnxsim
  build_native_control.sh    same commit built for x86_64
  run_s390x_tests.sh         install into a rootfs and run pytest there

Everything compiles with the host toolchain (s390x-linux-gnu-g++), so the
build runs at native speed and only the binaries execute under qemu; an
emulated build of the onnx stack takes hours.

A big-endian run alone is hard to read, so the same commit is also built
for x86_64 and run in an amd64 rootfs with identical package versions.
Byte order is then the only variable and the failure sets can be diffed:

  little endian : 3 failed, 99 passed
  big endian    : 6 failed, 95 passed

The three shared failures need onnxruntime, which has no s390x build. The
three big-endian-only ones, plus one test that self-skips, all come from
the same place: dlpack_bridge.h refuses to run big-endian, RunOps catches
that per-op and warns, and simplify() then reports check_ok=True on a
model it never folded. Findings and reproduction are in docs/big-endian.md.

No behaviour is changed here -- this commit only measures.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QkRdiUuprge5DVv3yZVycC