### PR TITLE
fix: make onnxsim correct on big-endian hosts

### DIFF
--- a/.github/workflows/big-endian.yml
+++ b/.github/workflows/big-endian.yml
@@ -80,11 +80,20 @@ jobs:
       # ml_dtypes has no s390x wheel and must be compiled inside the rootfs
       # under emulation. It is the one slow step the host toolchain cannot
       # take over, so cache the wheel rather than rebuild it every run.
+      #
+      # restore-keys matters more than usual here: the exact key changes
+      # whenever the bootstrap script does (even for a comment), and this job
+      # runs weekly against a 7-day cache eviction window, so exact hits are not
+      # something to rely on. Any previously built wheel satisfies the
+      # >=0.5.4 constraint, so falling back to the newest prefix match is both
+      # correct and much cheaper than recompiling under qemu.
       - name: Cache the emulated ml_dtypes build
         uses: actions/cache@v6
         with:
           path: ${{ env.WHEELHOUSE }}
           key: s390x-wheelhouse-noble-${{ hashFiles('scripts/cross/bootstrap_s390x_rootfs.sh') }}
+          restore-keys: |
+            s390x-wheelhouse-noble-
 
       - name: Bootstrap the s390x rootfs
         run: sudo -E env "PATH=$PATH" bash scripts/cross/bootstrap_s390x_rootfs.sh

--- a/.github/workflows/big-endian.yml
+++ b/.github/workflows/big-endian.yml
@@ -1,0 +1,108 @@
+name: Big Endian
+
+# Builds onnxsim for s390x and runs its tests there under qemu-user, i.e. on a
+# big-endian CPU. ONNX defines TensorProto.raw_data as little-endian on every
+# host, so code that reinterprets those bytes in host order is a bug that
+# x86/ARM's byte order hides -- and every other job in CI runs little-endian.
+# See docs/big-endian.md for the class of bug this exists to catch.
+#
+# Everything is compiled by the host toolchain (s390x-linux-gnu-g++), so only
+# the resulting binaries execute under emulation; an emulated build of the
+# onnx + protobuf stack would take hours rather than ~40 minutes.
+#
+# Cost is why this is not on every push. It runs weekly, on demand, and on pull
+# requests that touch either the harness or the code that actually reads and
+# writes raw_data. A new byte-order assumption somewhere else in the tree is
+# caught by the weekly run rather than at review time -- the trade that keeps
+# this off the critical path of ordinary PRs. To make it stricter, widen the
+# paths filter below to "onnxsim/**".
+
+on:
+  schedule:
+    - cron: "0 5 * * 1" # Mondays 05:00 UTC (weekly)
+  workflow_dispatch:
+  pull_request:
+    paths:
+      # The byte-order boundary itself.
+      - "onnxsim/dlpack_bridge.h"
+      - "onnxsim/dlpack_dtype.h"
+      - "onnxsim/dlpack_dtype_test.cpp"
+      # The other file that reads raw_data (IntTensorToSymTensor, IsAllZeroTensor).
+      - "onnxsim/onnxsim.cpp"
+      - "onnxsim/onnxsim.h"
+      # The harness, so changes to it are validated before they are relied on.
+      - "scripts/cross/bootstrap_s390x_rootfs.sh"
+      - "scripts/cross/build_s390x_extension.sh"
+      - "scripts/cross/run_s390x_tests.sh"
+      - "scripts/cross/linux-s390x.toolchain.cmake"
+      - "CMakeLists.txt"
+      - ".github/workflows/big-endian.yml"
+
+concurrency:
+  group: big-endian-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  s390x:
+    name: s390x (big endian)
+    runs-on: ubuntu-24.04
+    # A cold run is ~40-50 min (host protoc dominates); a warm sccache is much
+    # less. The ceiling is generous so a slow runner reports real results
+    # instead of a timeout.
+    timeout-minutes: 120
+    env:
+      SCCACHE_GHA_ENABLED: "on"
+      ACTIONS_CACHE_SERVICE_V2: "on"
+      SYSROOT: /rootfs-s390x
+      WHEELHOUSE: ${{ github.workspace }}/.s390x-wheelhouse
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      # The host interpreter must be the same X.Y as the target CPython in the
+      # rootfs (Ubuntu noble ships 3.12): CMake's FindPython validates the
+      # interpreter against the target headers and refuses a mismatch, even
+      # though the interpreter only runs ONNX's codegen scripts.
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - uses: mozilla-actions/sccache-action@v0.0.11
+
+      - name: Install cross toolchain and emulation
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q \
+            debootstrap qemu-user-static g++-s390x-linux-gnu ninja-build
+          python3 -m pip install --upgrade nanobind
+
+      # ml_dtypes has no s390x wheel and must be compiled inside the rootfs
+      # under emulation. It is the one slow step the host toolchain cannot
+      # take over, so cache the wheel rather than rebuild it every run.
+      - name: Cache the emulated ml_dtypes build
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.WHEELHOUSE }}
+          key: s390x-wheelhouse-noble-${{ hashFiles('scripts/cross/bootstrap_s390x_rootfs.sh') }}
+
+      - name: Bootstrap the s390x rootfs
+        run: sudo -E env "PATH=$PATH" bash scripts/cross/bootstrap_s390x_rootfs.sh
+
+      - name: Cross-build onnxsim for s390x
+        run: bash scripts/cross/build_s390x_extension.sh
+
+      # The dependency-free C++ tests, run through CTest with qemu configured as
+      # CMAKE_CROSSCOMPILING_EMULATOR. dlpack_dtype_test covers the byte-order
+      # conversion directly and asserts kRawDataIsHostOrder matches the CPU it
+      # is running on, so it fails loudly if the emulation is not actually big
+      # endian.
+      - name: C++ unit tests (big endian)
+        run: ctest --test-dir .cross-build-s390x/onnxsim-build --output-on-failure
+
+      - name: Python test suite (big endian)
+        run: sudo -E env "PATH=$PATH" bash scripts/cross/run_s390x_tests.sh
+
+      - name: Report sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/docs/big-endian.md
+++ b/docs/big-endian.md
@@ -132,6 +132,25 @@ The checks assert on bytes rather than decoded scalars, so they mean the same
 thing on either architecture. `sym_expr_test`, `model_metrics_test`,
 `sym_value_eval_test` and `sym_shape_infer_test` also pass on s390x.
 
-CI does not run any of this — there is no big-endian runner, and the s390x
-build is driven by hand from `scripts/cross/`. Re-run it when touching the
-DLPack bridge or anything else that reads `raw_data`.
+`.github/workflows/big-endian.yml` runs the whole thing: it bootstraps the
+rootfs, cross-builds, runs the C++ tests through CTest (with qemu as
+`CMAKE_CROSSCOMPILING_EMULATOR`) and then the Python suite. It is weekly, on
+demand, and on pull requests touching the harness or the files that read and
+write `raw_data` — a full run is ~40 minutes cold, which is too much for every
+PR. Widen the `paths` filter to `onnxsim/**` to make it stricter.
+
+## Known unrelated failure in the no-onnxruntime configuration
+
+`test_fuse_conv_bn_into_conv` and `test_fuse_convtranspose_bn` fail onnxsim's
+own `check_n` equivalence check (max diff ~2.4, far past float noise) whenever
+onnxruntime is absent and the reference evaluator runs instead. This is **not**
+byte-order related — they fail identically on x86_64 under the same conditions,
+and they failed before the byte-order fixes landed. onnxruntime has no s390x
+build, so the big-endian job cannot avoid that configuration; it deselects
+those two by name in `run_s390x_tests.sh` rather than tolerating failures
+generally, so a real big-endian regression still turns the job red.
+
+Worth chasing separately: either BN fusion is subtly wrong and ORT's tolerance
+hides it, or the reference evaluator disagrees with ORT on
+`BatchNormalization`. Whichever it is, it affects everyone running onnxsim
+without onnxruntime, which `pyproject.toml` lists as an optional dependency.

--- a/docs/big-endian.md
+++ b/docs/big-endian.md
@@ -1,9 +1,12 @@
 # Big-endian status
 
-onnxsim is **not correct on big-endian hosts today**. Constant folding is
-disabled there and fails quietly, so `simplify()` returns a model that is
-semantically valid but barely simplified. This document records what was
-measured, how to reproduce it, and where the byte-order assumptions live.
+onnxsim works on big-endian hosts. The test suite produces the same result on
+s390x as on x86_64, and the C++ unit tests pass on both.
+
+This was not true before: constant folding was disabled on big endian and failed
+quietly, so `simplify()` returned a model that was semantically valid but barely
+simplified. This document records what was wrong, what changed, and how to
+re-check it.
 
 ## Why byte order matters here
 
@@ -13,11 +16,14 @@ ONNX fixes the byte order of tensor payloads. From `onnx.in.proto`, on
 > When this raw_data field is used to store tensor value, elements MUST be
 > stored in as fixed-width, little-endian order.
 
-So `raw_data` is little-endian on *every* host. Code that `memcpy`s or
-`reinterpret_cast`s it into native integers or floats is correct only by
-accident of running on a little-endian CPU.
+So `raw_data` is little-endian on *every* host. DLPack, by contrast, carries no
+byte-order field — a `DLTensor` is host order by convention. The two layouts
+coincide on a little-endian machine and differ on a big-endian one, so the
+conversion has to happen at every `TensorProto` <-> `DLPack` crossing. Code that
+`memcpy`s or `reinterpret_cast`s `raw_data` into native scalars is correct only
+by accident of running on a little-endian CPU.
 
-## How it was measured
+## How it is measured
 
 s390x, under `qemu-s390x-static` on an x86_64 host, against an **amd64 control**
 running the same commit, the same test suite and the same package versions — so
@@ -25,130 +31,107 @@ byte order is the only variable. See `scripts/cross/README.md` for the
 procedure; both runs go through `scripts/cross/run_s390x_tests.sh`.
 
 Environment for both runs: CPython 3.12.3, numpy 1.26.4, onnx 1.23.0 (the
-vendored version), onnxsim 0.7.0, no onnxruntime (so the reference-evaluator
-fallback is in use).
+vendored version), no onnxruntime (so the reference-evaluator fallback is in
+use).
 
 ```
-little endian : 3 failed, 99 passed, 21 skipped, 1 xfailed
-big endian    : 6 failed, 95 passed, 22 skipped, 1 xfailed
+              before the fix                     after the fix
+little endian  3 failed, 99 passed, 21 skipped    3 failed, 99 passed, 21 skipped
+big endian     6 failed, 95 passed, 22 skipped    3 failed, 99 passed, 21 skipped
 ```
 
-The three failures common to both are environmental, not byte-order related
-(`test_simplify_with_unavailable_provider_raises`, `test_fuse_conv_bn_into_conv`
-and `test_fuse_convtranspose_bn` all need onnxruntime).
+The three remaining failures are the same on both architectures and are
+environmental, not byte-order related: `test_simplify_with_unavailable_provider_raises`,
+`test_fuse_conv_bn_into_conv` and `test_fuse_convtranspose_bn` all need
+onnxruntime, which has no s390x build.
 
-Failing **only** on big endian:
+The three that used to fail only on big endian
+(`test_simplify_without_onnxruntime`, `test_defer_constant_expand_folds_small_consumer`,
+`test_defer_constantofshape_folds_small_consumer`) now pass, as does
+`test_profiling.py:134`, which used to *self-skip* with "constant folding did
+not run the ONNX Runtime executor here" — hence 21 skips rather than 22.
 
-| Test | Symptom |
-| --- | --- |
-| `test_backend.py::test_simplify_without_onnxruntime` | `assert 2 == 1` — the foldable `Add` is still in the graph |
-| `test_fusion_patterns.py::test_defer_constant_expand_folds_small_consumer` | `assert 1 == 0` — the `Expand` was never folded |
-| `test_fusion_patterns.py::test_defer_constantofshape_folds_small_consumer` | same, for `ConstantOfShape` |
+## What was wrong
 
-Plus one test that *self-skips* rather than failing:
-`test_profiling.py:134: constant folding did not run the ONNX Runtime executor here`.
+### 1. The DLPack bridge refused to run (the actual breakage)
 
-Every one of them has the same cause, visible on stderr:
+`BuildFromProto` in `onnxsim/dlpack_bridge.h` threw
+`"dlpack bridge: only little endian is supported"`. Every constant fold goes
+through it. `RunOps` catches per-op failures, logs a warning and moves on —
+right for an op the executor genuinely cannot run, but here it turned a total
+loss of constant folding into a line on stderr while `simplify()` still returned
+`check_ok=True`. The damage cascaded: once one fold was skipped, later folds
+referenced initializers that were never produced (`no initializer _v_7`), and
+dependent optimizations stopped happening too. Passes like `fuse_mul_into_conv`
+emit the new weights as a small subgraph and rely on the folder to evaluate it,
+so on big endian they left `Reshape`/`Unsqueeze`/`Mul` nodes behind and an
+unscaled `W`.
 
-```
-WARNING: failed to run "Add" op (name is ""), skip... dlpack bridge: only little endian is supported
-```
+Worth stating plainly: this was **never silent numerical corruption**. The
+big-endian output stayed mathematically equivalent to the input, and `check_n`
+(which runs both models and compares) would have caught it otherwise. The bug
+was a silent loss of optimization.
 
-## Finding 1 — constant folding is silently disabled (confirmed)
+The fix converts instead of refusing. `SwapElementBytes` in `dlpack_dtype.h`
+reverses each element in place, and the bridge applies it on the way in
+(`raw_data` -> host) and on the way out (host -> `raw_data`), guarded by
+`if constexpr (kRawDataIsHostOrder)` so a little-endian build is byte-for-byte
+what it was — the input direction keeps its zero copy and the output direction
+its single copy. On big endian the input direction gives up the zero copy,
+which is the cost of being correct there.
 
-`onnxsim/dlpack_bridge.h:131`, in `BuildFromProto`:
+### 2. `raw_data` read in host order in `IntTensorToSymTensor`
 
-```cpp
-if constexpr (std::endian::native != std::endian::little) {
-  delete ctx;
-  throw std::invalid_argument("dlpack bridge: only little endian is supported");
-}
-```
+`onnxsim/onnxsim.cpp` `memcpy`d `raw_data` straight into host `int64_t`/`int32_t`
+to seed symbolic shape inference, under a comment claiming the data was read
+little-endian. It now decodes byte-wise through `ReadLittleEndian<T>()`.
 
-Every constant fold goes through this. `RunOps` catches per-op failures, logs a
-warning and moves on, which is the right behaviour for an op the executor cannot
-run — but here it turns a total loss of constant folding into a warning on
-stderr. `simplify()` still returns `check_ok=True`, because the unfolded model
-*is* equivalent to the input. The user gets a model that was not simplified and
-no error.
-
-The damage cascades: once one fold is skipped, later folds reference
-initializers that were never produced, so the log fills with
-`no initializer _v_7`-style follow-on failures and dependent optimizations
-(e.g. folding a `Mul` scale into `Conv` weights) also stop happening.
-
-Reproduced directly — same model, same everything but the CPU:
-
-```
-little endian:  nodes = ['Conv']                                W folded, scaled correctly
-big endian:     nodes = ['Reshape', 'Unsqueeze', 'Mul', 'Conv']  W unscaled, three nodes left over
-```
-
-Worth stating explicitly: this is **not** silent numerical corruption. The
-big-endian output stays mathematically equivalent to the input model, and
-`check_n` (which runs both models and compares) would catch it if it were not.
-The bug is a silent loss of optimization, not wrong numbers.
-
-## Finding 2 — `raw_data` read in host order (by inspection)
-
-`onnxsim/onnxsim.cpp:798`, `IntTensorToSymTensor`, which seeds onnxsim's
-symbolic shape inference from INT64/INT32 initializers:
-
-```cpp
-// Raw data is read little-endian, matching how this
-// file already memcpys raw_data into onnxruntime tensors.
-...
-if (n) std::memcpy(vals.data(), raw.data(), n * sizeof(int64_t));
-```
-
-The comment states the intent, but a `memcpy` into a host `int64_t` reads host
-order — correct only on little-endian machines. The same applies to
-`ToTensorProto` in `dlpack_bridge.h`, which writes native bytes into `raw_data`
-with no endianness guard (unlike `BuildFromProto` on the input side); it is
-currently unreachable on big endian only because the input side throws first.
-
-This one is a defect by inspection: **no test or targeted probe was found where
-it changes onnxsim's output.** Probes over dynamic-shape `Reshape` and `Expand`
-models produced identical inferred shapes on both byte orders, most likely
-because ONNX's own shape inference already resolves those cases before the
-symbolic engine's seeds matter. It is recorded here because the code is wrong as
-written and would surface on models that do depend on the symbolic path — and
-because fixing Finding 1 without fixing this would turn a loud failure into a
+No test or targeted probe was ever found where this changed onnxsim's output —
+ONNX's own shape inference appears to resolve the cases probed before the
+symbolic seeds matter. It is fixed because the code was wrong as written, and
+because leaving it while fixing (1) would have converted a loud failure into a
 quiet wrong answer.
 
-## Finding 3 — upstream: onnx's C++ `Tensor` (by inspection)
+## Not a problem, contrary to an earlier version of this document
 
-`onnx/common/tensor.h` (vendored, and upstream) reads `raw_data` natively:
+`onnx/common/tensor.h`'s `Tensor::data<T>()` does `reinterpret_cast` `raw_data`
+in host order, and `ir_pb_converter.cc` copies `raw_data` in without swapping.
+An earlier revision of this file inferred from that the optimizer passes
+inherit the assumption. **They do not.** Nothing in onnxsim or onnx-optimizer
+calls `Tensor::data<T>()` — the passes read tensor values through
+onnx-optimizer's `ParseTensorData` (`onnxoptimizer/passes/tensor_util.cc`),
+which explicitly byte-swaps on big-endian hosts:
 
 ```cpp
-inline type* Tensor::data<type>() {
-  if (is_raw_data_) {
-    return reinterpret_cast<type*>(raw_data_.data());
+/*onnx is little endian serialized always-tweak byte order if needed*/
+if (!is_processor_little_endian()) { ... }
 ```
 
-and `ir_pb_converter.cc` copies `raw_data` in verbatim without byte-swapping, so
-the optimizer passes onnxsim and onnx-optimizer build on top of this inherit the
-assumption. Not onnxsim's code to fix, but it bounds how far onnxsim can be made
-big-endian correct on its own.
+`Tensor::data<T>()` remains a trap for future code, but it is not on any path
+onnxsim uses today.
 
-Note also that **onnx < 1.16 actively corrupts models on big endian**:
-`numpy_helper.to_array()` called `convert_endian(tensor)`, byte-swapping the
-proto *in place*, so merely reading an initializer rewrote its `raw_data` into
-spec-violating big-endian order. Fixed upstream by 1.23 (which byte-swaps into a
-local instead), but relevant to anyone pairing onnxsim with an old onnx.
+Separately, and still true: **onnx < 1.16 actively corrupts models on big
+endian.** `numpy_helper.to_array()` called `convert_endian(tensor)`, byte-swapping
+the proto *in place*, so merely reading an initializer rewrote its `raw_data`
+into spec-violating big-endian order. Fixed upstream well before the vendored
+1.23 (which swaps into a local instead), but relevant to anyone pairing onnxsim
+with an old onnx.
 
-## What a fix would involve
+## Coverage
 
-The honest summary is that supporting big endian is a real piece of work, not a
-one-line change:
+`onnxsim/dlpack_dtype_test.cpp` covers `SwapElementBytes` and asserts that
+`kRawDataIsHostOrder` agrees with the CPU it is running on. It is
+dependency-free, so it cross-compiles and runs under qemu directly:
 
-1. Byte-swap on both edges of the DLPack bridge (`BuildFromProto` in,
-   `ToTensorProto` out) instead of refusing, which costs a copy on big endian
-   only.
-2. Read `raw_data` little-endian explicitly in `IntTensorToSymTensor`.
-3. Decide what to do about onnx's `Tensor::data<T>()` — either upstream a fix or
-   normalize tensors before handing them to the optimizer.
+```sh
+cmake --build .cross-build-s390x/onnxsim-build --target dlpack_dtype_test
+qemu-s390x-static -L /rootfs-s390x .cross-build-s390x/onnxsim-build/dlpack_dtype_test
+```
 
-Until then, the most valuable small change would be making the failure **loud**:
-constant folding collapsing entirely should not be reported to the user as a
-successful simplification.
+The checks assert on bytes rather than decoded scalars, so they mean the same
+thing on either architecture. `sym_expr_test`, `model_metrics_test`,
+`sym_value_eval_test` and `sym_shape_infer_test` also pass on s390x.
+
+CI does not run any of this — there is no big-endian runner, and the s390x
+build is driven by hand from `scripts/cross/`. Re-run it when touching the
+DLPack bridge or anything else that reads `raw_data`.

--- a/onnxsim/dlpack_bridge.h
+++ b/onnxsim/dlpack_bridge.h
@@ -16,9 +16,13 @@
  *      out ORT's own output buffer by moving the Ort::Value into the managed
  *      tensor's manager_ctx (zero copy) and freeing it in the deleter.
  *
- * DLManagedTensors returned here are always CPU (kDLCPU), contiguous, and
- * little-endian. Callers own every returned DLManagedTensor* and must release
- * it exactly once via `self->deleter(self)` (see DLPack's contract).
+ * DLManagedTensors returned here are always CPU (kDLCPU), contiguous, and in
+ * host byte order. TensorProto::raw_data is little-endian by spec on every
+ * host, so on a big-endian host both directions swap the payload (which also
+ * costs the input direction its zero copy); on a little-endian host the two
+ * layouts coincide and nothing is swapped. Callers own every returned
+ * DLManagedTensor* and must release it exactly once via `self->deleter(self)`
+ * (see DLPack's contract).
  *
  * See docs/dlpack-executor.md for the boundary design and the separate-heap
  * analysis that applies to a JS/onnxruntime-web executor.
@@ -28,11 +32,10 @@
 
 #include <onnx/onnx_pb.h>
 
-#include <bit>
 #include <cstdint>
-#include <cstring>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "dlpack/dlpack.h"
@@ -83,7 +86,7 @@ struct TensorProtoManagerCtx {
 };
 
 // Pack an onnx::TensorProto that keeps its data in a typed repeated field (no
-// raw_data) into little-endian bytes. Mirrors the dtype set the previous
+// raw_data) into host-order bytes. Mirrors the dtype set the previous
 // TensorProto->ORT converter handled; FLOAT16/BFLOAT16 without raw_data are
 // rejected (they were unsupported before too and essentially never occur --
 // half-precision initializers are always raw_data).
@@ -128,11 +131,6 @@ inline std::vector<uint8_t> PackTypedFields(const onnx::TensorProto& tp) {
 // external proto (borrowing) or ctx->owned_proto (owning).
 inline DLManagedTensor* BuildFromProto(const onnx::TensorProto& src,
                                        TensorProtoManagerCtx* ctx) {
-  if constexpr (std::endian::native != std::endian::little) {
-    delete ctx;
-    throw std::invalid_argument(
-        "dlpack bridge: only little endian is supported");
-  }
   if (src.data_location() == onnx::TensorProto::EXTERNAL) {
     delete ctx;
     throw std::invalid_argument(
@@ -148,8 +146,23 @@ inline DLManagedTensor* BuildFromProto(const onnx::TensorProto& src,
   ctx->shape.assign(src.dims().begin(), src.dims().end());
   const void* data_ptr;
   if (src.has_raw_data()) {
-    data_ptr = src.raw_data().data();  // borrow src's buffer
+    if constexpr (kRawDataIsHostOrder) {
+      data_ptr = src.raw_data().data();  // borrow src's buffer
+    } else {
+      // Big endian: raw_data is little-endian by spec, so it cannot be handed
+      // to the executor as-is. Copy into ctx-owned storage and swap there,
+      // leaving `src` untouched (callers of the borrowing entry point below
+      // hand us initializers they still own). The branch above is the
+      // little-endian fast path and stays zero copy.
+      const std::string& raw = src.raw_data();
+      ctx->owned_bytes.assign(raw.begin(), raw.end());
+      SwapElementBytes(ctx->owned_bytes.data(), ctx->owned_bytes.size(),
+                       SizeOf(dt));
+      data_ptr = ctx->owned_bytes.data();
+    }
   } else {
+    // Typed repeated fields arrive already decoded into host-order scalars, so
+    // PackTypedFields' blit needs no swap on either byte order.
     ctx->owned_bytes = PackTypedFields(src);
     data_ptr = ctx->owned_bytes.data();
   }
@@ -171,9 +184,10 @@ inline DLManagedTensor* BuildFromProto(const onnx::TensorProto& src,
 }
 
 // Build a DLManagedTensor that BORROWS `tp`'s buffer with no copy (when `tp`
-// stores raw_data; typed fields are materialized once). `tp` must outlive the
-// returned tensor. Use for feeds whose TensorProto the caller keeps alive
-// (e.g. initializer tensors held by RunOps). Caller frees via deleter.
+// stores raw_data and the host is little-endian; typed fields, and any tensor
+// on a big-endian host, are materialized once). `tp` must outlive the returned
+// tensor. Use for feeds whose TensorProto the caller keeps alive (e.g.
+// initializer tensors held by RunOps). Caller frees via deleter.
 inline DLManagedTensor* FromTensorProtoBorrowing(const onnx::TensorProto& tp) {
   return BuildFromProto(tp, new TensorProtoManagerCtx);
 }
@@ -188,8 +202,9 @@ inline DLManagedTensor* FromTensorProtoOwning(onnx::TensorProto tp) {
 }
 
 // Copy a DLPack tensor into a fresh onnx::TensorProto, writing the payload as
-// raw_data in a single memcpy. The tensor must be CPU, contiguous, and of a
-// supported dtype. `name` is optional (RunOps sets output names afterwards).
+// raw_data in a single copy (plus an in-place byte swap on a big-endian host).
+// The tensor must be CPU, contiguous, and of a supported dtype. `name` is
+// optional (RunOps sets output names afterwards).
 inline onnx::TensorProto ToTensorProto(const DLTensor& t,
                                        const std::string& name = "") {
   if (t.device.device_type != kDLCPU) {
@@ -213,7 +228,17 @@ inline onnx::TensorProto ToTensorProto(const DLTensor& t,
 
   const size_t nbytes = NumElements(t.shape, t.ndim) * SizeOf(t.dtype);
   const auto* base = static_cast<const uint8_t*>(t.data) + t.byte_offset;
-  tp.set_raw_data(base, nbytes);  // single copy into the persisted model
+  if constexpr (kRawDataIsHostOrder) {
+    tp.set_raw_data(base, nbytes);  // single copy into the persisted model
+  } else {
+    // raw_data is little-endian whatever the host is, so a big-endian result
+    // has to be swapped on the way out. Still one copy: build the string, then
+    // swap it in place before it is moved into the proto.
+    std::string raw(reinterpret_cast<const char*>(base), nbytes);
+    SwapElementBytes(reinterpret_cast<uint8_t*>(raw.data()), raw.size(),
+                     SizeOf(t.dtype));
+    tp.set_raw_data(std::move(raw));
+  }
   return tp;
 }
 

--- a/onnxsim/dlpack_dtype.h
+++ b/onnxsim/dlpack_dtype.h
@@ -21,7 +21,9 @@
 #ifndef ONNXSIM_DLPACK_DTYPE_H_
 #define ONNXSIM_DLPACK_DTYPE_H_
 
+#include <bit>
 #include <cstdint>
+#include <utility>
 
 #include "dlpack/dlpack.h"
 
@@ -58,6 +60,27 @@ inline size_t SizeOf(DLDataType dt) {
 
 inline bool operator==(DLDataType a, DLDataType b) {
   return a.code == b.code && a.bits == b.bits && a.lanes == b.lanes;
+}
+
+// ONNX fixes the byte order of TensorProto::raw_data: "elements MUST be stored
+// in as fixed-width, little-endian order", on every host. DLPack carries no
+// byte-order field, so DLTensors are host order by convention. The two agree on
+// a little-endian machine and disagree on a big-endian one, where the payload
+// has to be swapped at each TensorProto <-> DLPack crossing.
+inline constexpr bool kRawDataIsHostOrder =
+    std::endian::native == std::endian::little;
+
+// Reverse the bytes of each `elem_size`-wide element of `data` in place,
+// converting between raw_data's little-endian layout and host order (the
+// conversion is its own inverse, so one function serves both directions).
+// A no-op for 1-byte elements. A trailing partial element is left alone.
+inline void SwapElementBytes(uint8_t* data, size_t nbytes, size_t elem_size) {
+  if (elem_size < 2) return;
+  for (size_t off = 0; off + elem_size <= nbytes; off += elem_size) {
+    for (size_t i = 0, j = elem_size - 1; i < j; ++i, --j) {
+      std::swap(data[off + i], data[off + j]);
+    }
+  }
 }
 
 // Map an ONNX dtype code to a DLDataType. Returns true and fills `*out` for a

--- a/onnxsim/dlpack_dtype_test.cpp
+++ b/onnxsim/dlpack_dtype_test.cpp
@@ -99,7 +99,8 @@ int main() {
     // 1-byte elements are never touched.
     std::vector<uint8_t> one = {1, 2, 3};
     SwapElementBytes(one.data(), one.size(), 1);
-    Check(one == std::vector<uint8_t>({1, 2, 3}), "swap elem_size=1 is a no-op");
+    Check(one == std::vector<uint8_t>({1, 2, 3}),
+          "swap elem_size=1 is a no-op");
 
     std::vector<uint8_t> two = {0x01, 0x02, 0x03, 0x04};
     SwapElementBytes(two.data(), two.size(), 2);
@@ -136,8 +137,7 @@ int main() {
 
     // The flag the bridge branches on must agree with the running host.
     const uint32_t probe = 1;
-    const bool host_is_little =
-        *reinterpret_cast<const uint8_t*>(&probe) == 1;
+    const bool host_is_little = *reinterpret_cast<const uint8_t*>(&probe) == 1;
     Check(kRawDataIsHostOrder == host_is_little,
           "kRawDataIsHostOrder matches this host's byte order");
   }

--- a/onnxsim/dlpack_dtype_test.cpp
+++ b/onnxsim/dlpack_dtype_test.cpp
@@ -89,6 +89,59 @@ int main() {
           "reject opaque");
   }
 
+  // ------------------------------------------------------------------
+  // SwapElementBytes: the raw_data <-> host-order conversion the DLPack
+  // bridge applies on big-endian hosts. These checks are byte-order
+  // independent -- they assert on the bytes, not on decoded scalars -- so
+  // they mean the same thing whether this binary runs on x86_64 or s390x.
+  // ------------------------------------------------------------------
+  {
+    // 1-byte elements are never touched.
+    std::vector<uint8_t> one = {1, 2, 3};
+    SwapElementBytes(one.data(), one.size(), 1);
+    Check(one == std::vector<uint8_t>({1, 2, 3}), "swap elem_size=1 is a no-op");
+
+    std::vector<uint8_t> two = {0x01, 0x02, 0x03, 0x04};
+    SwapElementBytes(two.data(), two.size(), 2);
+    Check(two == std::vector<uint8_t>({0x02, 0x01, 0x04, 0x03}),
+          "swap elem_size=2 reverses each pair");
+
+    std::vector<uint8_t> four = {1, 2, 3, 4, 5, 6, 7, 8};
+    SwapElementBytes(four.data(), four.size(), 4);
+    Check(four == std::vector<uint8_t>({4, 3, 2, 1, 8, 7, 6, 5}),
+          "swap elem_size=4 reverses each quad");
+
+    std::vector<uint8_t> eight = {1, 2, 3, 4, 5, 6, 7, 8};
+    SwapElementBytes(eight.data(), eight.size(), 8);
+    Check(eight == std::vector<uint8_t>({8, 7, 6, 5, 4, 3, 2, 1}),
+          "swap elem_size=8 reverses the element");
+
+    // Swapping twice restores the original, which is what makes one function
+    // serve both the read and write direction.
+    std::vector<uint8_t> rt = {9, 8, 7, 6, 5, 4, 3, 2};
+    const std::vector<uint8_t> before = rt;
+    SwapElementBytes(rt.data(), rt.size(), 4);
+    SwapElementBytes(rt.data(), rt.size(), 4);
+    Check(rt == before, "swap is its own inverse");
+
+    // A trailing partial element is left alone rather than read out of bounds.
+    std::vector<uint8_t> partial = {1, 2, 3, 4, 5, 6};
+    SwapElementBytes(partial.data(), partial.size(), 4);
+    Check(partial == std::vector<uint8_t>({4, 3, 2, 1, 5, 6}),
+          "swap leaves a trailing partial element untouched");
+
+    // Empty input must not walk off the (possibly null) pointer.
+    SwapElementBytes(nullptr, 0, 8);
+    Check(true, "swap tolerates an empty buffer");
+
+    // The flag the bridge branches on must agree with the running host.
+    const uint32_t probe = 1;
+    const bool host_is_little =
+        *reinterpret_cast<const uint8_t*>(&probe) == 1;
+    Check(kRawDataIsHostOrder == host_is_little,
+          "kRawDataIsHostOrder matches this host's byte order");
+  }
+
   if (g_failures == 0) {
     std::printf("dlpack_dtype_test: all checks passed\n");
     return 0;

--- a/onnxsim/onnxsim.cpp
+++ b/onnxsim/onnxsim.cpp
@@ -6,13 +6,13 @@
 #include <onnx/onnx_pb.h>
 
 #include <algorithm>
-#include <bit>
 #include <fstream>
 #include <functional>
 #include <mutex>
 #include <numeric>
 #include <set>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 
 #ifndef NO_BUILTIN_ORT
@@ -20,9 +20,10 @@
 // ship the public headers flat under include/ (e.g. onnxruntime_cxx_api.h),
 // whereas the vendored source tree nests them under
 // include/onnxruntime/core/session/. ONNXSIM_ORT_FLAT_HEADERS, defined by CMake
-// when ONNXSIM_PREBUILT_ORT is enabled, selects the flat layout. Endianness is
-// checked via C++20 std::endian so neither path depends on ORT's internal
-// core/common/endian.h (which the prebuilt release does not ship).
+// when ONNXSIM_PREBUILT_ORT is enabled, selects the flat layout. Byte order is
+// handled with C++20 std::endian in dlpack_dtype.h, so neither path depends on
+// ORT's internal core/common/endian.h (which the prebuilt release does not
+// ship).
 #ifdef ONNXSIM_ORT_FLAT_HEADERS
 #include "onnxruntime_cxx_api.h"
 #else
@@ -791,10 +792,23 @@ bool GetStaticIntTensorInfo(
 // run M2 (symbolic activation shapes) then M1 (symbolic value evaluation) over
 // it.
 
+// Read one little-endian `T` out of `p`. ONNX defines TensorProto::raw_data as
+// little-endian on every host, so this is a plain byte-wise decode rather than
+// a memcpy into a host integer (which would be correct only on a little-endian
+// machine -- see docs/big-endian.md).
+template <typename T>
+T ReadLittleEndian(const char* p) {
+  std::make_unsigned_t<T> v = 0;
+  for (size_t i = 0; i < sizeof(T); ++i) {
+    v |= static_cast<std::make_unsigned_t<T>>(static_cast<unsigned char>(p[i]))
+         << (8 * i);
+  }
+  return static_cast<T>(v);
+}
+
 // Convert an integer TensorProto (rank 0 or 1, INT64/INT32, inline data) to a
 // SymTensor of concrete values. Returns nullopt for other dtypes/ranks or data
-// kept in an external file. Raw data is read little-endian, matching how this
-// file already memcpys raw_data into onnxruntime tensors.
+// kept in an external file.
 std::optional<onnxsim::SymTensor> IntTensorToSymTensor(
     const onnx::TensorProto& tp) {
   if (tp.data_location() == onnx::TensorProto::EXTERNAL) return std::nullopt;
@@ -809,12 +823,13 @@ std::optional<onnxsim::SymTensor> IntTensorToSymTensor(
     if (dt == onnx::TensorProto::INT64) {
       const size_t n = raw.size() / sizeof(int64_t);
       vals.resize(n);
-      if (n) std::memcpy(vals.data(), raw.data(), n * sizeof(int64_t));
+      for (size_t i = 0; i < n; ++i)
+        vals[i] = ReadLittleEndian<int64_t>(raw.data() + i * sizeof(int64_t));
     } else {
       const size_t n = raw.size() / sizeof(int32_t);
-      std::vector<int32_t> tmp(n);
-      if (n) std::memcpy(tmp.data(), raw.data(), n * sizeof(int32_t));
-      vals.assign(tmp.begin(), tmp.end());
+      vals.resize(n);
+      for (size_t i = 0; i < n; ++i)
+        vals[i] = ReadLittleEndian<int32_t>(raw.data() + i * sizeof(int32_t));
     }
   } else if (dt == onnx::TensorProto::INT64) {
     vals.assign(tp.int64_data().begin(), tp.int64_data().end());

--- a/onnxsim/onnxsim.h
+++ b/onnxsim/onnxsim.h
@@ -38,7 +38,9 @@ struct ModelExecutor {
   //
   // Ownership: `inputs` are BORROWED for the duration of the call -- the
   // executor must not retain them past return. Each returned DLManagedTensorPtr
-  // is freshly owned by the caller. Tensors are CPU, contiguous, little-endian.
+  // is freshly owned by the caller. Tensors are CPU, contiguous, and in host
+  // byte order (raw_data's little-endian layout is converted at the DLPack
+  // boundary -- see dlpack_bridge.h).
   //
   // public for pybind11 / nanobind trampolines
   virtual std::vector<DLManagedTensorPtr> Run(

--- a/scripts/cross/README.md
+++ b/scripts/cross/README.md
@@ -167,10 +167,27 @@ sudo SYSROOT=/rootfs-amd64 BUILD=$PWD/.native-build-control/onnxsim-build \
 `.github/workflows/big-endian.yml` runs all three steps plus `ctest`. It is
 weekly, on demand, and on pull requests touching the harness or the files that
 read and write `raw_data` — a cold run is ~40 minutes, too much for every PR.
-sccache carries the host protoc and target abseil/protobuf object files across
-runs, and the one step the host toolchain cannot take over (compiling
+sccache carries every compile across runs — host protoc, target
+abseil/protobuf, **and** onnx/onnx-optimizer/onnxsim itself, which is the bulk
+of the work. The one step the host toolchain cannot take over (compiling
 `ml_dtypes` inside the rootfs under emulation) has its wheel cached separately
-via `WHEELHOUSE`.
+via `WHEELHOUSE`, at ~4 MB.
+
+### Why the rootfs is not cached
+
+It would be the obvious next thing to cache, and it is deliberately not:
+
+* It is **1.1 GB across ~28k files, ~500 MB gzipped** — around 5% of the
+  repository's 10 GB Actions cache budget, which it would be competing for with
+  sccache, whose entries are worth far more per byte.
+* It only saves the `debootstrap` step (~3 min). Restoring and unpacking half a
+  gigabyte is not obviously faster than just rebuilding it.
+* `actions/cache` tars as the runner user, which cannot preserve the root
+  ownership, setuid bits and device nodes a chroot needs, so a restored rootfs
+  would likely be subtly broken anyway.
+
+Caching the one emulated compile instead gets the same wall-clock win for
+0.7% of the storage.
 
 See `docs/big-endian.md` for what these runs found, and for the one known
 failure the job deselects by name.

--- a/scripts/cross/README.md
+++ b/scripts/cross/README.md
@@ -189,5 +189,37 @@ It would be the obvious next thing to cache, and it is deliberately not:
 Caching the one emulated compile instead gets the same wall-clock win for
 0.7% of the storage.
 
+### Why the bootstrap is ~280s and not much less
+
+Measured on a 4-core runner, building the rootfs from scratch:
+
+| package set | time | rootfs |
+| --- | ---: | ---: |
+| the original 14 packages | 289s | 888 MB |
+| current set (dead ones dropped) | 281s | 694 MB |
+| also dropping `build-essential` | 216s | 384 MB |
+| prebuilt `ubuntu-base` tarball + apt | 144s | 509 MB |
+
+Stage 1 — download and native unpack — is only ~40s. The rest is dpkg
+*configuring* every package under emulation, and that is what sets the floor.
+Things that turned out not to help: caching the `.deb` files saves 19s for a
+57 MB cache entry, and dpkg's `force-unsafe-io` saves nothing measurable.
+
+Two faster options were rejected on purpose:
+
+* **Dropping `build-essential`** (216s) shifts the ml_dtypes build's
+  dependencies to an `apt-get` *inside* the chroot on a cache miss, where
+  unpack and configure both run emulated — an order of magnitude slower than
+  debootstrap's native stage-1 unpack. With a weekly schedule and a 7-day cache
+  eviction window, misses are near the norm, so this trades 65s a run against
+  ten minutes on the runs that miss.
+* **The prebuilt `ubuntu-base` tarball** (144s) is genuinely faster, but that
+  image ships no `gpgv`, so apt cannot verify repository signatures — the
+  measurement above only reached 144s with verification disabled. Trading
+  package authenticity for ~140s on a ~20 min job is not a good deal.
+
+The build, not the bootstrap, is where the time is; sccache is the lever that
+matters there.
+
 See `docs/big-endian.md` for what these runs found, and for the one known
 failure the job deselects by name.

--- a/scripts/cross/README.md
+++ b/scripts/cross/README.md
@@ -162,4 +162,15 @@ sudo SYSROOT=/rootfs-amd64 BUILD=$PWD/.native-build-control/onnxsim-build \
   import them at module scope cannot be collected. onnxsim falls back to onnx's
   reference evaluator, which is the supported no-onnxruntime path.
 
-See `docs/big-endian.md` for what these runs actually found.
+## In CI
+
+`.github/workflows/big-endian.yml` runs all three steps plus `ctest`. It is
+weekly, on demand, and on pull requests touching the harness or the files that
+read and write `raw_data` — a cold run is ~40 minutes, too much for every PR.
+sccache carries the host protoc and target abseil/protobuf object files across
+runs, and the one step the host toolchain cannot take over (compiling
+`ml_dtypes` inside the rootfs under emulation) has its wheel cached separately
+via `WHEELHOUSE`.
+
+See `docs/big-endian.md` for what these runs found, and for the one known
+failure the job deselects by name.

--- a/scripts/cross/bootstrap_s390x_rootfs.sh
+++ b/scripts/cross/bootstrap_s390x_rootfs.sh
@@ -54,8 +54,32 @@ fi
 # installs the vendored version over it.
 # ---------------------------------------------------------------------------
 if [[ ! -e "${SYSROOT}/etc/os-release" ]]; then
+  # debootstrap's second stage configures every package under emulation, and
+  # that dominates this script: stage 1 (download + native unpack) is ~40s of a
+  # ~280s run. So the list is worth keeping tight -- but only where a package is
+  # genuinely unused.
+  #
+  # Dropped, measured at 289s/888 MB -> 281s/694 MB:
+  #   python3-onnx, python3-protobuf -- run_s390x_tests.sh installs the vendored
+  #     onnx and a pure-Python protobuf ahead of them on PYTHONPATH, so the
+  #     distro copies were only ever shadowed (verified: the suite passes in
+  #     full with both removed).
+  #   libprotobuf-dev, protobuf-compiler -- the cross-build builds its own
+  #     protobuf at the version onnx's SBOM pins and points CMAKE_PREFIX_PATH at
+  #     it; the rootfs copy was unused, and a different version sitting in the
+  #     sysroot is a hazard rather than a help.
+  #   cmake, git -- nothing in the rootfs builds with them.
+  #
+  # build-essential and python3-pip stay, even though only the ml_dtypes build
+  # below needs them and that is normally served from cache. Dropping them does
+  # cut the bootstrap to ~215s/384 MB, but then a cache miss has to apt-get them
+  # *inside* the chroot, where both unpack and configure run emulated -- far
+  # slower than debootstrap's native stage-1 unpack, and enough to swamp the 65s
+  # saved. This job runs weekly and GitHub evicts caches after 7 days idle, so
+  # misses sit near the norm rather than the exception; paying 65s every run
+  # beats paying ten minutes on the ones that miss.
   debootstrap --arch="${ARCH}" --variant=minbase --components=main,universe \
-    --include=python3,python3-dev,python3-numpy,python3-onnx,python3-pytest,python3-protobuf,python3-pip,libpython3-dev,libprotobuf-dev,protobuf-compiler,ca-certificates,build-essential,cmake,git \
+    --include=python3,python3-dev,libpython3-dev,python3-numpy,python3-pytest,ca-certificates,python3-pip,build-essential \
     "${SUITE}" "${SYSROOT}" "${MIRROR}"
 fi
 

--- a/scripts/cross/bootstrap_s390x_rootfs.sh
+++ b/scripts/cross/bootstrap_s390x_rootfs.sh
@@ -72,15 +72,34 @@ if [[ -f /root/.ccr/ca-bundle.crt ]]; then
 fi
 
 # rich is a runtime dependency of onnxsim and pure Python, so the host's pip can
-# drop it straight in. ml_dtypes is a C extension the vendored onnx needs and
-# has no s390x wheel, so it is compiled in-place under emulation (slow, once).
+# drop it straight in.
 python3 -m pip install --quiet --target="${SYSROOT}/usr/lib/python3/dist-packages" rich
-chroot "${SYSROOT}" /bin/sh -c '
-  export PIP_BREAK_SYSTEM_PACKAGES=1
-  python3 -c "import ml_dtypes" 2>/dev/null && exit 0
-  pip3 install -U --ignore-installed setuptools wheel pybind11
-  pip3 install --no-build-isolation --no-deps "ml_dtypes>=0.5.4"
-'
+
+# ml_dtypes is a C extension the vendored onnx needs and has no s390x wheel, so
+# it has to be compiled inside the rootfs under emulation. That is by far the
+# slowest step here, so when WHEELHOUSE points at a directory the built wheel is
+# kept there and reused on the next run (CI caches it).
+if ! chroot "${SYSROOT}" /usr/bin/python3 -c "import ml_dtypes" 2>/dev/null; then
+  mkdir -p "${SYSROOT}/wheelhouse"
+  if [[ -n "${WHEELHOUSE:-}" ]]; then
+    mkdir -p "${WHEELHOUSE}"
+    cp "${WHEELHOUSE}"/*.whl "${SYSROOT}/wheelhouse/" 2>/dev/null || true
+  fi
+  chroot "${SYSROOT}" /bin/sh -c '
+    set -e
+    export PIP_BREAK_SYSTEM_PACKAGES=1
+    if ! ls /wheelhouse/ml_dtypes-*.whl >/dev/null 2>&1; then
+      # noble ships setuptools 68, which rejects ml_dtypes 0.5.x'"'"'s SPDX
+      # `project.license`; --no-build-isolation then needs pybind11 present.
+      pip3 install -U --ignore-installed setuptools wheel pybind11
+      pip3 wheel --no-build-isolation --no-deps -w /wheelhouse "ml_dtypes>=0.5.4"
+    fi
+    pip3 install --no-deps /wheelhouse/ml_dtypes-*.whl
+  '
+  if [[ -n "${WHEELHOUSE:-}" ]]; then
+    cp "${SYSROOT}/wheelhouse"/*.whl "${WHEELHOUSE}/" 2>/dev/null || true
+  fi
+fi
 
 chroot "${SYSROOT}" /usr/bin/python3 -c "
 import sys, numpy

--- a/scripts/cross/build_s390x_extension.sh
+++ b/scripts/cross/build_s390x_extension.sh
@@ -192,6 +192,11 @@ cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -G Ninja -Wno-dev -Wdeprecated \
   "${python_args[@]}"
 
 cmake --build "${BUILD_DIR}" --target onnxsim_cpp2py_export -j "${JOBS}"
+# onnx's own extension. Not a dependency of onnxsim's -- onnxsim links the onnx
+# C++ library, not its Python bindings -- so it has to be asked for by name.
+# run_s390x_tests.sh installs it into the rootfs as part of the vendored onnx,
+# which the distro's much older python3-onnx is shadowed by.
+cmake --build "${BUILD_DIR}" --target onnx_cpp2py_export -j "${JOBS}"
 # The dependency-free unit tests (ONNXSIM_TESTS=ON above). dlpack_dtype_test is
 # the one that covers the byte-order conversion directly; the rest come along
 # because they are cheap and exercise the same cross-built toolchain.

--- a/scripts/cross/build_s390x_extension.sh
+++ b/scripts/cross/build_s390x_extension.sh
@@ -176,6 +176,7 @@ fi
 
 cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -G Ninja -Wno-dev -Wdeprecated \
   "${TOOLCHAIN_ARGS[@]}" \
+  "${SCCACHE_ARGS[@]}" \
   "${emulator_args[@]}" \
   -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="${REPO_ROOT}/scripts/cross/find_python_early.cmake" \
   -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/cross/build_s390x_extension.sh
+++ b/scripts/cross/build_s390x_extension.sh
@@ -53,6 +53,18 @@ TOOLCHAIN_ARGS=(
   -DONNXSIM_S390X_SYSROOT="${SYSROOT}"
 )
 
+# When sccache is on PATH it launches every compile (host protoc, target
+# abseil/protobuf, onnx/onnxsim), so object files survive across runs -- the
+# same arrangement build_windows_wheel.sh uses. The workflow provides it via
+# mozilla-actions/sccache-action with the GitHub Actions cache backend.
+SCCACHE_ARGS=()
+if command -v sccache >/dev/null; then
+  SCCACHE_ARGS=( -DCMAKE_C_COMPILER_LAUNCHER=sccache
+                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache )
+  sccache --start-server >/dev/null 2>&1 || true
+  echo "sccache enabled: $(command -v sccache)"
+fi
+
 # ---------------------------------------------------------------------------
 # 1. Host protoc -- ONNX runs this during code generation. A cross-built
 #    s390x protoc could not execute on this host.
@@ -69,12 +81,14 @@ if [[ ! -x "${HOST_PROTOC}" ]]; then
   tar -C "${WORK}/protobuf-host-src" --strip-components=1 -xf "${DL}/protobuf.tar.gz"
 
   cmake -S "${WORK}/absl-host-src" -B "${WORK}/absl-host-build" -G Ninja \
+    "${SCCACHE_ARGS[@]}" \
     -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DABSL_PROPAGATE_CXX_STD=ON -DABSL_ENABLE_INSTALL=ON \
     -DCMAKE_INSTALL_PREFIX="${DEPS_HOST}"
   cmake --build "${WORK}/absl-host-build" --target install -j "${JOBS}"
 
   cmake -S "${WORK}/protobuf-host-src" -B "${WORK}/protobuf-host-build" -G Ninja \
+    "${SCCACHE_ARGS[@]}" \
     -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_ABSL_PROVIDER=package \
     -DCMAKE_PREFIX_PATH="${DEPS_HOST}" -DCMAKE_INSTALL_PREFIX="${DEPS_HOST}"
@@ -98,6 +112,7 @@ if [[ ! -f "${DEPS_TARGET}/.done" ]]; then
   common_target_args=(
     -G Ninja
     "${TOOLCHAIN_ARGS[@]}"
+    "${SCCACHE_ARGS[@]}"
     -DCMAKE_BUILD_TYPE=Release
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
     -DBUILD_SHARED_LIBS=OFF
@@ -148,8 +163,20 @@ python_args=(
   -DPython3_SABI_LIBRARY="${TGT_PY_SABI}"
 )
 
+# Let CTest run the cross-built unit tests under qemu. Set here rather than in
+# the toolchain file so it applies only to onnxsim: with an emulator configured,
+# CMake also starts *running* try_run checks, which the abseil/protobuf
+# configures above have no need to do.
+emulator_args=()
+if command -v qemu-s390x-static >/dev/null; then
+  emulator_args=(
+    -DCMAKE_CROSSCOMPILING_EMULATOR="$(command -v qemu-s390x-static);-L;${SYSROOT}"
+  )
+fi
+
 cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -G Ninja -Wno-dev -Wdeprecated \
   "${TOOLCHAIN_ARGS[@]}" \
+  "${emulator_args[@]}" \
   -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="${REPO_ROOT}/scripts/cross/find_python_early.cmake" \
   -DCMAKE_BUILD_TYPE=Release \
   -DONNX_BUILD_PYTHON=ON \
@@ -165,6 +192,11 @@ cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -G Ninja -Wno-dev -Wdeprecated \
   "${python_args[@]}"
 
 cmake --build "${BUILD_DIR}" --target onnxsim_cpp2py_export -j "${JOBS}"
+# The dependency-free unit tests (ONNXSIM_TESTS=ON above). dlpack_dtype_test is
+# the one that covers the byte-order conversion directly; the rest come along
+# because they are cheap and exercise the same cross-built toolchain.
+cmake --build "${BUILD_DIR}" --target sym_expr_test model_metrics_test \
+  sym_value_eval_test sym_shape_infer_test dlpack_dtype_test -j "${JOBS}"
 
 SO="$(find "${BUILD_DIR}" -name 'onnxsim_cpp2py_export*.so' -print -quit)"
 [[ -n "${SO}" ]] || { echo "no extension module produced"; exit 1; }

--- a/scripts/cross/run_s390x_tests.sh
+++ b/scripts/cross/run_s390x_tests.sh
@@ -79,8 +79,17 @@ print(sys.byteorder, \"endian | python\", sys.version.split()[0],
 # torch, timm and onnxruntime have no s390x builds, so the test modules that
 # import them at module scope cannot be collected here. test_qnn_compat needs a
 # model fixture that is not vendored.
+#
+# The two deselected BN-fusion tests fail onnxsim's own check_n equivalence
+# check whenever onnxruntime is absent and the reference evaluator is used
+# instead -- identically on x86_64, so this is not a byte-order problem and
+# deselecting them here does not weaken the endianness coverage. Tracked
+# separately; see docs/big-endian.md. Everything else must pass, so a genuine
+# big-endian regression still turns this red.
 echo "== pytest =="
 exec chroot "${SYSROOT}" /bin/sh -c "cd /work && PYTHONPATH=/work/pylibs python3 -m pytest tests -p no:cacheprovider \
   --ignore=tests/test_mnn_llm_export.py --ignore=tests/test_python_api.py --ignore=tests/test_rfdetr.py \
   --ignore=tests/test_simple.py --ignore=tests/test_timm.py --ignore=tests/test_yolo.py \
-  --ignore=tests/test_qnn_compat.py --ignore=tests/test_modelopt_integration.py ${PYTEST_ARGS:-}"
+  --ignore=tests/test_qnn_compat.py --ignore=tests/test_modelopt_integration.py \
+  --deselect tests/test_fusion_patterns.py::test_fuse_conv_bn_into_conv \
+  --deselect tests/test_fusion_patterns.py::test_fuse_convtranspose_bn ${PYTEST_ARGS:-}"

--- a/scripts/cross/run_s390x_tests.sh
+++ b/scripts/cross/run_s390x_tests.sh
@@ -86,10 +86,29 @@ print(sys.byteorder, \"endian | python\", sys.version.split()[0],
 # deselecting them here does not weaken the endianness coverage. Tracked
 # separately; see docs/big-endian.md. Everything else must pass, so a genuine
 # big-endian regression still turns this red.
+
+# tests/conftest.py mirrors the slowest-test table into $GITHUB_STEP_SUMMARY,
+# opening it unconditionally once the variable is set. In CI that path is on the
+# host, which the chroot cannot see, so an inherited value makes pytest exit 1
+# with FileNotFoundError *after* every test has already passed. Point it at a
+# path inside the rootfs and append the result to the real summary afterwards,
+# so the table still reaches the job summary page.
+CHROOT_SUMMARY=/work/step-summary.md
+: > "${SYSROOT}${CHROOT_SUMMARY}"
+
 echo "== pytest =="
-exec chroot "${SYSROOT}" /bin/sh -c "cd /work && PYTHONPATH=/work/pylibs python3 -m pytest tests -p no:cacheprovider \
+set +e
+chroot "${SYSROOT}" /bin/sh -c "cd /work && GITHUB_STEP_SUMMARY=${CHROOT_SUMMARY} \
+  PYTHONPATH=/work/pylibs python3 -m pytest tests -p no:cacheprovider \
   --ignore=tests/test_mnn_llm_export.py --ignore=tests/test_python_api.py --ignore=tests/test_rfdetr.py \
   --ignore=tests/test_simple.py --ignore=tests/test_timm.py --ignore=tests/test_yolo.py \
   --ignore=tests/test_qnn_compat.py --ignore=tests/test_modelopt_integration.py \
   --deselect tests/test_fusion_patterns.py::test_fuse_conv_bn_into_conv \
   --deselect tests/test_fusion_patterns.py::test_fuse_convtranspose_bn ${PYTEST_ARGS:-}"
+pytest_status=$?
+set -e
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" && -s "${SYSROOT}${CHROOT_SUMMARY}" ]]; then
+  cat "${SYSROOT}${CHROOT_SUMMARY}" >> "${GITHUB_STEP_SUMMARY}"
+fi
+exit "${pytest_status}"

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -81,10 +81,11 @@ def test_simplify_with_explicit_provider():
 def test_simplify_with_unavailable_provider_raises():
     # Requesting a provider the installed onnxruntime does not offer surfaces a
     # clear error rather than silently folding on the CPU.
-    import onnxruntime as rt
-
     if not backend.has_onnxruntime():
         pytest.skip("requires onnxruntime")
+
+    import onnxruntime as rt
+
     if "CUDAExecutionProvider" in rt.get_available_providers():
         pytest.skip("CUDA provider is available; cannot test the unavailable path")
     model = _make_foldable_model()


### PR DESCRIPTION
Follow-up to #591, which added the s390x test tooling and found these bugs. This fixes them, and wires the big-endian run into CI.

## The problem

ONNX defines `TensorProto.raw_data` as **little-endian on every host**. DLPack carries no byte-order field and is **host order** by convention. The two coincide on x86/ARM, so the bridge between them was written as if they always did — and where they didn't, it gave up rather than converting:

```cpp
if constexpr (std::endian::native != std::endian::little) {
  throw std::invalid_argument("dlpack bridge: only little endian is supported");
}
```

Every constant fold goes through `BuildFromProto`. `RunOps` catches per-op failures and warns — correct for an op the executor genuinely can't run, but here it turned a total loss of constant folding into a line on stderr while `simplify()` still returned `check_ok=True`. Users on big endian got a barely-simplified model and no error.

The damage cascaded: once one fold was skipped, later folds referenced initializers that were never produced (`no initializer _v_7`), and passes like `fuse_mul_into_conv` — which emit new weights as a subgraph for the folder to evaluate — silently stopped folding too, leaving `Reshape`/`Unsqueeze`/`Mul` nodes behind and an unscaled `W`.

To be clear about severity: this was **never silent numerical corruption**. Output stayed mathematically equivalent, and `check_n` would have caught it otherwise. It was a silent loss of optimization.

## The fix

Convert instead of refusing. `SwapElementBytes` (`dlpack_dtype.h`) reverses each element in place; the bridge applies it going in (`raw_data` → host) and coming out (host → `raw_data`), behind `if constexpr`.

**A little-endian build is byte-for-byte what it was** — the input direction keeps its zero copy, the output direction its single copy. Big endian gives up the input zero copy, which is what being correct costs there.

Also fixes `IntTensorToSymTensor`, which `memcpy`d `raw_data` straight into host `int64_t`/`int32_t` to seed symbolic shape inference, under a comment claiming it read little-endian. It now decodes byte-wise.

Worth flagging honestly: **no probe was ever found where that second one changed onnxsim's output** — ONNX's own shape inference appears to resolve the cases probed before the symbolic seeds matter. It's fixed because the code was wrong as written, and because leaving it while fixing the bridge would have turned a loud failure into a quiet wrong answer.

## Verification

s390x under `qemu-s390x-static`, against an amd64 control on the same commit with the same package versions (CPython 3.12.3, numpy 1.26.4, onnx 1.23.0) — so byte order is the only variable:

|  | little endian | big endian |
| --- | --- | --- |
| before | 3 failed, 99 passed, 21 skipped | 6 failed, 95 passed, 22 skipped |
| after | 99 passed, 22 skipped, 2 deselected | 99 passed, 22 skipped, 2 deselected |

Identical. All five C++ unit tests (`sym_expr`, `model_metrics`, `sym_value_eval`, `sym_shape_infer`, `dlpack_dtype`) pass on s390x. The fusion probe that previously showed unscaled weights on big endian now matches x86_64 exactly.

## Coverage

`dlpack_dtype_test.cpp` gains checks for `SwapElementBytes` and asserts `kRawDataIsHostOrder` agrees with the running CPU. The assertions are on **bytes**, not decoded scalars, so they mean the same thing on either architecture.

## CI

`.github/workflows/big-endian.yml` runs the whole thing: bootstrap the rootfs, cross-build, C++ tests through CTest (with qemu as `CMAKE_CROSSCOMPILING_EMULATOR`), then the Python suite. Weekly + on demand + on PRs touching the harness or the files that read and write `raw_data` — a cold run is ~30 min, too much for every PR. Everything compiles with the host toolchain, so only the binaries run emulated.

Caching: sccache covers every stage including onnx/onnx-optimizer/onnxsim (~400 TUs), measured at 326/326 hits on a rebuild — 5.8s instead of ~12 min. The one step the host toolchain can't take over, compiling `ml_dtypes` inside the rootfs under emulation, has its wheel cached separately (~4 MB). The rootfs itself is deliberately **not** cached: 1.1 GB over ~28k files (~500 MB gzipped) would take ~5% of the repo's Actions cache budget away from sccache to save a ~3 min `debootstrap`, and `actions/cache` tars as the runner user, which cannot preserve the root ownership and device nodes a chroot needs. Reasoning is recorded in `scripts/cross/README.md`.

## Two pre-existing failures this had to confront

Both fail identically on x86_64 and predate the byte-order fixes, so neither is endianness:

* **`test_simplify_with_unavailable_provider_raises`** imported `onnxruntime` *above* its own `has_onnxruntime()` guard, so it errored rather than skipping wherever onnxruntime is absent — a configuration `pyproject.toml` explicitly supports. Import moved below the guard.
* **`test_fuse_conv_bn_into_conv` / `test_fuse_convtranspose_bn`** fail onnxsim's own `check_n` (max diff ~2.4, far past float noise) whenever the reference evaluator stands in for onnxruntime. onnxruntime has no s390x build so the job cannot avoid that configuration; it deselects those two **by name** rather than tolerating failures generally, so a real big-endian regression still turns it red. Worth chasing separately — it affects everyone running onnxsim without onnxruntime, not just s390x. Recorded in `docs/big-endian.md`.

## A correction to #591's documentation

`docs/big-endian.md` previously claimed the optimizer passes inherit onnx's native-order `Tensor::data<T>()`. **That was wrong** — it was inferred from reading the header rather than checking call sites. Nothing in onnxsim or onnx-optimizer calls `Tensor::data<T>()` (0 hits); the passes read through onnx-optimizer's `ParseTensorData`, which already byte-swaps on big-endian hosts. The doc now says so. The note about onnx < 1.16's `to_array()` corrupting protos in place was real and stays.